### PR TITLE
FCBH-290 API Completeness: StudyBible

### DIFF
--- a/app/Http/Controllers/Bible/Study/CommentaryController.php
+++ b/app/Http/Controllers/Bible/Study/CommentaryController.php
@@ -20,11 +20,14 @@ class CommentaryController extends APIController
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
      *     @OA\Response(
      *         response=200,
      *         description="The fileset types",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/Commentary")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/Commentary"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/Commentary")),
+     *         @OA\MediaType(mediaType="text/x-yaml",  @OA\Schema(ref="#/components/schemas/Commentary")),
+     *         @OA\MediaType(mediaType="text/csv",  @OA\Schema(ref="#/components/schemas/Commentary"))
      *     )
      * )
      *
@@ -46,18 +49,27 @@ class CommentaryController extends APIController
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
      *     @OA\Parameter(
      *          name="commentary_id",
      *          in="path",
      *          required=true,
      *          @OA\Schema(ref="#/components/schemas/Commentary/properties/id"),
-     *          description="The commentary id of the commentary"
+     *          description="The id of the commentary"
+     *     ),
+     *     @OA\Parameter(name="book_id", in="query", description="Will filter the results by the given book",
+     *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
+     *     ),
+     *     @OA\Parameter(name="chapter", in="query", description="Will filter the results by the given chapter",
+     *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")
      *     ),
      *     @OA\Response(
      *         response=200,
      *         description="The fileset types",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_commentaries_chapter_response")),
-     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v4_commentaries_chapter_response"))
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v4_commentaries_chapter_response")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v4_commentaries_chapter_response")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v4_commentaries_chapter_response"))
      *     )
      * )
      *
@@ -108,14 +120,15 @@ class CommentaryController extends APIController
     /**
      *
      * @OA\GET(
-     *     path="/commentaries/{commentary_id}/sections",
+     *     path="/commentaries/{commentary_id}/{book_id}/{chapter}",
      *     tags={"StudyBible"},
      *     summary="Commentary Sections",
      *     description="A list of all the chapter navigation for a specific commentary",
-     *     operationId="v4_commentary_chapter",
+     *     operationId="v4_commentary_section",
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
      *     @OA\Parameter(
      *          name="commentary_id",
      *          in="path",
@@ -123,16 +136,24 @@ class CommentaryController extends APIController
      *          @OA\Schema(ref="#/components/schemas/Commentary/properties/id"),
      *          description="The commentary id of the commentary"
      *     ),
+     *     @OA\Parameter(name="book_id", in="path", required=true, description="Will filter the results by the given book",
+     *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
+     *     ),
+     *     @OA\Parameter(name="chapter", in="path", required=true, description="Will filter the results by the given chapter",
+     *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="The fileset types",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_commentaries_section_response")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_commentaries_section_response"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_commentaries_section_response")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v4_commentaries_section_response")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v4_commentaries_section_response"))
      *     )
      * )
      *
      * @OA\Schema(
-     *     type="object",
+     *     type="array",
      *     title="The commentary section response",
      *     description="",
      *     schema="v4_commentaries_section_response",

--- a/app/Http/Controllers/Bible/Study/LexiconController.php
+++ b/app/Http/Controllers/Bible/Study/LexiconController.php
@@ -14,7 +14,7 @@ class LexiconController extends APIController
      *
      *
      * @OA\Get(
-     *     path="/lexicons/",
+     *     path="/lexicons",
      *     tags={"StudyBible"},
      *     summary="",
      *     description="",
@@ -38,6 +38,7 @@ class LexiconController extends APIController
      *         @OA\Schema(type="boolean"),
      *         description="Enables"
      *     ),
+     *     @OA\Parameter(name="limit",  in="query", description="The Number of records to return", @OA\Schema(type="integer")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -46,10 +47,10 @@ class LexiconController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
-     *         @OA\MediaType(mediaType="application/yaml", @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
-     *         @OA\MediaType(mediaType="application/toml", @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
      *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
-     *         @OA\MediaType(mediaType="application/csv",  @OA\Schema(ref="#/components/schemas/v4_lexicon_index"))
+     *         @OA\MediaType(mediaType="application/toml", @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v4_lexicon_index")),
+     *         @OA\MediaType(mediaType="text/csv",  @OA\Schema(ref="#/components/schemas/v4_lexicon_index"))
      *     )
      * )
      *


### PR DESCRIPTION
## Description
- Updated API documentation on StudyBible endpoints
   - /commentaries
   - /commentaries/{commentary_id}/chapters
     - Added book_id, chapter query parameters
   - /commentaries/{commentary_id}/{book_id}/{chapter}
     - Fixed query path
     - Fixed query operationId
     - Added book_id, chapter path parameters
   - /lexicons
     - Added limit parameter 
- Added default MediaTypes responses (xml, json, csv and yaml)
- Added default parameters (version_number, key, format and pretty)
- Updated `SwaggerDocsController.php ` in order to add the missed components to the open-api documentation that are being used on v2 and v4.

## Motivation and Context
- As a user, I’d like the API documentation and interactive Swagger to function with all options available to the StudyBible endpoints.

## Issue Link

[FCBH-290](https://fullstacklabs.atlassian.net/browse/FCBH-290) 

## How Do I Test This?

_To run the test suite refer to the Readme.md_

- Navigate in your local environment to `http://dbp.test/docs/swagger/v4` or in the `swagger-editor` import `https://api.dbp.test/open-api-v4.json`
- Verify that the endpoints of `StudyBible` are working correctly with all options available.

## Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
