### PR TITLE
FCBH-294 API Completeness: Languages

### DIFF
--- a/app/Http/Controllers/Wiki/AlphabetsController.php
+++ b/app/Http/Controllers/Wiki/AlphabetsController.php
@@ -47,6 +47,10 @@ class AlphabetsController extends APIController
      *         @OA\MediaType(
      *             mediaType="text/x-yaml",
      *             @OA\Schema(ref="#/components/schemas/v4_alphabets_all_response"
+     *         )),
+     *         @OA\MediaType(
+     *             mediaType="text/csv",
+     *             @OA\Schema(ref="#/components/schemas/v4_alphabets_all_response"
      *         ))
      *     )
      * )
@@ -106,6 +110,10 @@ class AlphabetsController extends APIController
      *         ),
      *         @OA\MediaType(
      *             mediaType="text/x-yaml",
+     *             @OA\Schema(ref="#/components/schemas/v4_alphabets_one_response"
+     *         )),
+     *         @OA\MediaType(
+     *             mediaType="text/csv",
      *             @OA\Schema(ref="#/components/schemas/v4_alphabets_one_response"
      *         ))
      *     )

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -18,7 +18,7 @@ class LanguagesController extends APIController
      * Fetches the records from the database > passes them through fractal for transforming.
      *
      * @OA\Get(
-     *     path="/languages/",
+     *     path="/languages",
      *     tags={"Languages"},
      *     summary="Returns Languages",
      *     description="Returns the List of Languages",
@@ -38,27 +38,8 @@ class LanguagesController extends APIController
      *     @OA\Parameter(
      *          name="language_name",
      *          in="query",
-     *          @OA\Schema(type="object"),
+     *          @OA\Schema(type="string"),
      *          description="The language_name field will filter results by a specific language name"
-     *     ),
-     *     @OA\Parameter(
-     *          name="sort_by",
-     *          in="query",
-     *          @OA\Schema(type="object"),
-     *          description="The sort_by field will order results by a specific field"
-     *     ),
-     *     @OA\Parameter(
-     *          name="has_bibles",
-     *          in="query",
-     *          @OA\Schema(type="object"),
-     *          description="When set to true will filter language results depending whether or not they have bibles."
-     *     ),
-     *     @OA\Parameter(
-     *          name="has_filesets",
-     *          in="query",
-     *          @OA\Schema(type="object",default=null,example=true),
-     *          description="When set to true will filter language results depending whether or not they have filesets.
-     *              Will add new filesets_count field to the return."
      *     ),
      *     @OA\Parameter(
      *          name="asset_id",
@@ -77,10 +58,15 @@ class LanguagesController extends APIController
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
      *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_by"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_dir"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/Language"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/Language"))
      *     )
      * )
      * @link https://api.dbp.test/languages?key=1234&v=4&pretty
@@ -100,7 +86,7 @@ class LanguagesController extends APIController
         $include_alt_names     = checkParam('include_alt_names');
         $show_restricted       = checkParam('show_restricted');
         $asset_id              = checkParam('bucket_id|asset_id');
-        $name                  = checkParam('name');
+        $name                  = checkParam('name|language_name');
 
         $access_control = $this->accessControl($this->key);
 
@@ -142,17 +128,21 @@ class LanguagesController extends APIController
      *     @OA\Parameter(
      *          name="id",
      *          in="path",
-     *          description="The languages ID",
+     *          description="The language ID",
      *          required=true,
      *          @OA\Schema(ref="#/components/schemas/Language/properties/id")
      *     ),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(
-     *            mediaType="application/json",
-     *            @OA\Schema(ref="#/components/schemas/Language")
-     *         )
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/Language")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/Language"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Wiki/NumbersController.php
+++ b/app/Http/Controllers/Wiki/NumbersController.php
@@ -49,7 +49,8 @@ class NumbersController extends APIController
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_numbers_range")),
      *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_numbers_range")),
-     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v4_numbers_range"))
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v4_numbers_range")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/v4_numbers_range"))
      *     )
      * )
      *
@@ -71,7 +72,7 @@ class NumbersController extends APIController
     public function customRange()
     {
         $script = checkParam('script|script_id', true);
-        $start  = checkParam('start');
+        $start  = checkParam('start') ?? 0;
         $end    = checkParam('end');
         if (($end - $start) > 200) {
             return $this->replyWithError(trans('api.numerals_range_error', ['num' => $end]));
@@ -90,7 +91,7 @@ class NumbersController extends APIController
      * @OA\Get(
      *     path="/numbers",
      *     tags={"Languages"},
-     *     summary="Return a all Alphabets that have a custom number sets",
+     *     summary="Return all Alphabets that have a custom number sets",
      *     description="Returns a range of numbers",
      *     operationId="v4_numbers.index",
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
@@ -105,6 +106,8 @@ class NumbersController extends APIController
      *         @OA\MediaType(mediaType="application/xml",
      *         @OA\Schema(ref="#/components/schemas/v4_alphabets_all_response")),
      *         @OA\MediaType(mediaType="text/x-yaml",
+     *         @OA\Schema(ref="#/components/schemas/v4_alphabets_all_response")),
+     *         @OA\MediaType(mediaType="text/csv",
      *         @OA\Schema(ref="#/components/schemas/v4_alphabets_all_response"))
      *     )
      * )
@@ -133,8 +136,8 @@ class NumbersController extends APIController
      *     summary="Return a single custom number set",
      *     description="Returns a range of numbers",
      *     operationId="v4_numbers.show",
-     *     @OA\Parameter(name="id", in="path", required=true, description="The Alphabet id",
-     *          @OA\Schema(ref="#/components/schemas/Alphabet/properties/script")),
+     *     @OA\Parameter(name="id", in="path", required=true, description="The NumeralSystem id",
+     *          @OA\Schema(ref="#/components/schemas/NumeralSystem/properties/id")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -147,6 +150,8 @@ class NumbersController extends APIController
      *         @OA\MediaType(mediaType="application/xml",
      *              @OA\Schema(ref="#/components/schemas/v4_alphabets_one_response")),
      *         @OA\MediaType(mediaType="text/x-yaml",
+     *              @OA\Schema(ref="#/components/schemas/v4_alphabets_one_response")),
+     *         @OA\MediaType(mediaType="text/csv",
      *              @OA\Schema(ref="#/components/schemas/v4_alphabets_one_response"))
      *     )
      * )

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,6 +131,7 @@ Route::name('v4_alphabets.one')->get('alphabets/{alphabet_id}',                 
 Route::name('v4_alphabets.store')->post('alphabets',                               'Wiki\AlphabetsController@store');
 Route::name('v4_alphabets.update')->put('alphabets/{alphabet_id}',                 'Wiki\AlphabetsController@update');
 Route::name('v4_numbers.all')->get('numbers/',                                     'Wiki\NumbersController@index');
+Route::name('v4_numbers.range')->get('numbers/range',                              'Wiki\NumbersController@customRange');
 Route::name('v4_numbers.one')->get('numbers/{number_id}',                          'Wiki\NumbersController@show');
 
 // VERSION 4 | Users


### PR DESCRIPTION
## Description

- Updated API documentation on Languages endpoints
  - /alphabets
  - /alphabets​/{id}
  - /languages​
    - Changed language_name type to string
    - Remove unused parameters has_bibles, has_filesets
  - /languages​/{id}
  - /numbers​/range
    - Added API route
    - Changed start default value to `0`
  - /numbers
  - /numbers​/{id}
    -  Changed id type to NumeralSystem
- Added default MediaTypes responses (xml, json, csv and yaml)
- Added default parameters (version_number, key, format and pretty)
- Updated SwaggerDocsController.php in order to add the missed components to the open-api documentation that are being used on v2 and v4.

## Motivation and Context
- As a user, I’d like the API documentation and interactive Swagger to function with all options available to the Languages endpoints.

## Issue Link

[FCBH-294](https://fullstacklabs.atlassian.net/browse/FCBH-294) 

## How Do I Test This?

_To run the test suite refer to the Readme.md_

- Navigate in your local environment to `http://dbp.test/docs/swagger/v4` or in the `swagger-editor` import `https://api.dbp.test/open-api-v4.json`
- Verify that the endpoints of `Languages` are working correctly with all options available.

## Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.