### PR TITLE
FCBH-296 v2 No Getting Audio Properly

### DIFF
--- a/app/Http/Controllers/Bible/AudioController.php
+++ b/app/Http/Controllers/Bible/AudioController.php
@@ -71,6 +71,9 @@ class AudioController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path"))
      *     )
      * )
@@ -87,7 +90,7 @@ class AudioController extends APIController
         $chapter_id = checkParam('chapter_id');
         $asset_id   = checkParam('bucket|bucket_id|asset_id') ?? config('filesystems.disks.s3_fcbh.bucket');
 
-        $cache_string = strtolower("audio_index:".$asset_id.':'.$fileset_id.':'.$book_id.':'.$chapter_id);
+        $cache_string = strtolower('audio_index:'.$asset_id.':'.$fileset_id.':'.$book_id.':'.$chapter_id);
 
         $audioChapters = \Cache::remember($cache_string, now()->addDay(), function () use ($fileset_id, $book_id, $chapter_id, $asset_id) {
             // Account for various book ids
@@ -326,7 +329,7 @@ class AudioController extends APIController
      *     description="This route offers information about the media distribution servers and the
                protocols they support. It is currently depreciated and only remains to account for
                the possibility that someone might still be using this old method of uri generation",
-     *     operationId="v2_audio_timestamps",
+     *     operationId="v2_audio_location",
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),

--- a/app/Http/Controllers/Bible/AudioController.php
+++ b/app/Http/Controllers/Bible/AudioController.php
@@ -72,9 +72,9 @@ class AudioController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_path"))
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_audio_path")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_audio_path"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -167,7 +167,7 @@ class BibleFileSetsController extends APIController
      *     @OA\Parameter(name="asset_id", in="query", required=true, description="The fileset ID",
      *          @OA\Schema(ref="#/components/schemas/Asset/properties/id")
      *     ),
-     *     @OA\Parameter(name="fileset_type", in="query", description="The type of fileset being queried"
+     *     @OA\Parameter(name="fileset_type", in="query", description="The type of fileset being queried",
      *         @OA\Schema(ref="#/components/schemas/BibleFileset/properties/set_type_code")
      *     ),
      *     @OA\Parameter(name="book_ids", in="query", required=true,

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -186,7 +186,7 @@ class LibraryController extends APIController
      *     summary="Volume History List",
      *     description="This call gets the event history for volume changes to status, expiry, basic info, delivery, and organization association. The event reflects the previous state of the volume. In other words, it reflects the state up to the moment of the time of the event.",
      *     operationId="v2_volume_history",
-     *     @OA\Parameter(name="limit",  in="query", description="The Number of records to return"),
+     *     @OA\Parameter(name="limit",  in="query", description="The Number of records to return", @OA\Schema(type="integer",default=500)),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),

--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -189,7 +189,7 @@ class LanguageControllerV2 extends APIController
      *     summary="Returns the list of languages",
      *     description="This method retrieves the list of languages for available volumes and the related volume data in
                the system according to the filter specified.",
-     *     operationId="v2_library_volumeLanguageFamily",
+     *     operationId="v2_library_volumeLanguage",
      *     @OA\Parameter(
      *         name="language_code",
      *         in="query",


### PR DESCRIPTION
## Description

- This was fixed on https://github.com/faithcomesbyhearing/dbp/commit/bf16c426f4be081a3dfa3ef8fecae9af7ee03c48
   - Previous book query was:
      `$book_id = optional(Book::selectByID('id', $book_id)->select('id')->first())->id;`
      instead of:
      `$book_id = optional(Book::where('id_osis', $book_id)->first())->id;`
- Added important fixes to v2 documentation
   - Added a missed comma on v4_bible_filesets.download
   - Fixed operationId name on:
     - v2_audio_location
     - v2_library_volumeLanguage
   - Added schema to limit parameter on v2_volume_history


## Motivation and Context
- v2 `audio/path` endpoint wasn't filtering by the book id parameter

## Issue Link

[FCBH-296](https://fullstacklabs.atlassian.net/browse/FCBH-296) 

## How Do I Test This?

_To run the test suite refer to the Readme.md_

- Navigate in your local environment to `https://api.dbp.test/open-api-v2.json` and verify that the documentation has no errors 
- You can import the json to `https://editor.swagger.io/` also to verify this.

## Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.