### PR TITLE
FCBH-297/298 v2 Artwork Routes

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -214,14 +214,10 @@ class BibleFileset extends Model
     {
         return $query->when($id, function ($query) use ($id) {
             $query->where(function ($query) use ($id) {
-                if($this->v === 2) {
                     $query->where('bible_filesets.id', $id)
                           ->orWhere('bible_filesets.id', substr($id, 0, -4))
                           ->orWhere('bible_filesets.id', 'like',  substr($id, 0, 6))
                           ->orWhere('bible_filesets.id', 'like', substr($id, 0, -2).'%');
-                } else {
-                    $query->where('bible_filesets.id', $id);
-                }
             });
         })
         ->when($asset_id, function ($query) use ($asset_id) {

--- a/app/Transformers/FileSetTransformer.php
+++ b/app/Transformers/FileSetTransformer.php
@@ -54,7 +54,7 @@ class FileSetTransformer extends BaseTransformer
                 $meta['channel']['title'] = $fileset->translations->where('iso', $bible->language->iso)->first()->name.' - '.$bible->language->name ?? $bible->where('iso', 'eng')->first()->name.' - '.$bible->language->name;
                 $meta['channel']['link'] = config('app.url_podcast');
                 $meta['channel']['atom:link']['_attributes'] = ['href'  => 'http://www.faithcomesbyhearing.com/feeds/audio-bibles/'.$bible->id.'.xml','rel'   => 'self','type'  => 'application/rss+xml'];
-                $meta['channel']['description'] = $bible->translations->where('iso', $bible->language->iso)->first()->description ?? $bible->where('iso', 'eng')->first()->description;
+                $meta['channel']['description'] = $bible->translations->where('iso', $bible->language->iso)->first()->description ?? $bible->language->where('iso', 'eng')->first()->description;
                 $meta['channel']['language'] = $bible->language->iso;
                 $meta['channel']['managingEditor'] = 'adhooker@fcbhmail.org';
                 $meta['channel']['webMaster'] = 'charles@faithcomesbyhearing.com';
@@ -69,7 +69,7 @@ class FileSetTransformer extends BaseTransformer
                 $meta['channel']['itunes:explicit'] = 'no';
                 $meta['channel']['itunes:owner']['itunes:name'] = 'Faith Comes By Hearing';
                 $meta['channel']['itunes:owner']['itunes:email'] = config('app.contact');
-                $meta['channel']['itunes:image'] = ['href' => 'http://bible.is/ImageSize300X300.jpg'];
+                $meta['channel']['itunes:image'] = ['href' =>  $fileset->artwork_url];
                 $meta['channel']['itunes:category'] = [
                     '_attributes' => ['text' => 'Religion & Spirituality']
                 ];


### PR DESCRIPTION
## Description
- Updated /library/volume documentation
- Fixed wrong query column names (updated_at)
- Reverted `f9b9cce0c3a115becae9b228ab54251469079a64 ` commit
- Added artwork_url to podcast endpoint
## Motivation and Context
- v2 Artwork Routes: Android & iOS are not available
- podcast endpoint is not retrieving the new artwork URL 
- text access is unavailable

## Issue Link

[FCBH-297](https://fullstacklabs.atlassian.net/browse/FCBH-297) 
[FCBH-298](https://fullstacklabs.atlassian.net/browse/FCBH-298) 

## How Do I Test This?

_To run the test suite refer to the Readme.md_
 - On your local environment access to `https://api.dbp.test/library/volume?delivery=mobile&rich=1&key=809db3bd83c66f3bc41be0cbd6bd1e3f&v=3&language_code=ENG&updated=2018-09-06` and verify that the endpoint retrieves  the `artwork_url `
- On your local environmental  access to `https://api.dbp.test/bibles/filesets/ACAWBTP2DA/podcast?key=53355c32fca5f3cac4d7a670d2df2e09&v=4` and verify that the endpoint retrieves the `itunes:image` variable with the correct image url
## Checklist:
- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.