### PR TITLE
FCBH-404/405 Backend: Playlists Support

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace App\Http\Controllers\Playlist;
+
+use App\Traits\AccessControlAPI;
+use App\Http\Controllers\APIController;
+use App\Models\User\User;
+use App\Models\Playlist\Playlist;
+use App\Traits\CheckProjectMembership;
+
+class PlaylistsController extends APIController
+{
+    use AccessControlAPI;
+    use CheckProjectMembership;
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @OA\Get(
+     *     path="/playlists/{user_id}",
+     *     tags={"Playlists"},
+     *     summary="List a user's playlists",
+     *     description="",
+     *     operationId="v4_playlists.index",
+     *     @OA\Parameter(
+     *          name="user_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/User/properties/id"),
+     *          description="The user who created the playlists"
+     *     ),
+     *     @OA\Parameter(
+     *          name="featured",
+     *          in="query",
+     *          @OA\Schema(ref="#/components/schemas/Playlist/properties/featured"),
+     *          description="Return featured playlists"
+     *     ),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/v4_playlist_index"))
+     *     )
+     * )
+     *
+     * @param $user_id
+     *
+     * @return mixed
+     * 
+     * 
+     * @OA\Schema (
+     *   type="array",
+     *   schema="v4_playlist_index",
+     *   description="The v4 playlist index response.",
+     *   title="User playlist",
+     *   @OA\Xml(name="v4_playlist_index"),
+     *   @OA\Items(ref="#/components/schemas/Playlist")
+     * )
+     */
+    public function index($user_id)
+    {
+
+        // Validate Project / User Connection
+        $user = User::where('id', $user_id)->select('id')->first();
+
+        if (!$user) {
+            return $this->setStatusCode(404)->replyWithError(trans('api.users_errors_404'));
+        }
+
+        $user_is_member = $this->compareProjects($user_id, $this->key);
+
+        if (!$user_is_member) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $featured = checkParam('featured');
+        $featured = $featured && $featured != 'false';
+
+        $playlists = Playlist::with('items')->when($featured, function ($q) {
+                $q->where('user_playlists.featured', '1');
+            })->unless($featured, function ($q) use ($user_id) {
+                $q->where('user_playlists.user_id', $user_id);
+            })->orderBy('updated_at', 'desc')->get();
+
+        return $this->reply($playlists);
+    }
+
+    /**
+     * Store a newly created playlist in storage.
+     *
+     * @OA\Post(
+     *     path="/playlists/{user_id}",
+     *     tags={"Playlists"},
+     *     summary="Crete a playlist",
+     *     description="",
+     *     operationId="v4_playlists.store",
+     *     @OA\Parameter(
+     *          name="user_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/User/properties/id"),
+     *          description="The user who is creating the playlist"
+     *     ),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\RequestBody(required=true, description="Fields for User Playlist Creation", @OA\MediaType(mediaType="application/json",
+     *          @OA\Schema(
+     *              @OA\Property(property="name",                  ref="#/components/schemas/Playlist/properties/name"),
+     *          )
+     *     )),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v4_playlist_index")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/v4_playlist_index"))
+     *     )
+     * )
+     *
+     * @return \Illuminate\Http\Response|array
+     */
+    public function store($user_id)
+    {
+
+        // Validate Project / User Connection
+        $user = User::where('id', $user_id)->select('id')->first();
+
+        if (!$user) {
+            return $this->setStatusCode(404)->replyWithError(trans('api.users_errors_404'));
+        }
+
+        $user_is_member = $this->compareProjects($user_id, $this->key);
+
+        if (!$user_is_member) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $name = checkParam('name', true);
+
+        $playlist = Playlist::create([
+            'user_id'           => $user_id,
+            'name'              => request()->name,
+            'featured'          => false
+        ]);
+
+        return $this->reply($playlist);
+    }
+
+    /**
+     * Remove the specified playlist.
+     *
+     * @OA\Delete(
+     *     path="/playlists/{user_id}/{playlist_id}",
+     *     tags={"Playlists"},
+     *     summary="Delete a playlist",
+     *     description="",
+     *     operationId="v4_playlists.destroy",
+     *     @OA\Parameter(name="user_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/User/properties/id")),
+     *     @OA\Parameter(name="playlist_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Playlist/properties/id")),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(type="string")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(type="string")),
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(type="string")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(type="string"))
+     *     )
+     * )
+     *
+     * @param  int $user_id
+     * @param  int $playlist_id
+     *
+     * @return array|\Illuminate\Http\Response
+     */
+    public function destroy($user_id, $playlist_id)
+    {
+        // Validate Project / User Connection
+        $user = User::where('id', $user_id)->select('id')->first();
+
+        if (!$user) {
+            return $this->setStatusCode(404)->replyWithError(trans('api.users_errors_404'));
+        }
+
+        $user_is_member = $this->compareProjects($user_id, $this->key);
+
+        if (!$user_is_member) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $playlist = Playlist::where('user_id', $user_id)->where('id', $playlist_id)->first();
+
+        if (!$playlist) {
+            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+        }
+
+        $playlist->items()->delete();
+        $playlist->delete();
+
+        return $this->reply('Playlist Deleted');
+    }
+
+    private function validatePlaylist()
+    {
+        $validator = Validator::make(request()->all(), [
+            'user_id'           => 'required|exists:dbp_users.users,id',
+            'name'              => 'required|string'
+        ]);
+        if ($validator->fails()) {
+            return ['errors' => $validator->errors()];
+        }
+        return true;
+    }
+
+}

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Models\Playlist;
+
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Carbon\Carbon;
+
+
+/**
+ * App\Models\Playlist
+ * @mixin \Eloquent
+ * 
+ * @property int $id
+ * @property string $name
+ * @property string $user_id
+ * @property bool $featured
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ * @property Carbon $deleted_at
+ *
+ *
+ * @OA\Schema (
+ *     type="object",
+ *     description="The User created Playlist",
+ *     title="Playlist",
+ *     @OA\Xml(name="Playlist")
+ * )
+ *
+ */
+class Playlist extends Model
+{
+    use SoftDeletes;
+    
+    protected $connection = 'dbp_users';
+    public $table         = 'user_playlists';
+    protected $fillable   = ['user_id','name'];
+    protected $hidden     = ['featured', 'user_id'];
+    protected $dates      = ['deleted_at'];
+
+    /**
+      *
+      * @OA\Property(
+      *   title="id",
+      *   type="integer",
+      *   description="The playlist id",
+      *   minimum=0
+      * )
+      *
+      */
+    protected $id;
+      /**
+       *
+       * @OA\Property(
+       *   title="name",
+       *   type="string",
+       *   description="The name of the playlist"
+       * )
+       *
+       */
+     protected $name;
+       /**
+       *
+       * @OA\Property(
+       *   title="user_id",
+       *   type="string",
+       *   description="The user that created the playlist"
+       * )
+       *
+       */
+      protected $user_id;
+       /**
+       *
+       * @OA\Property(
+       *   title="featured",
+       *   type="boolean",
+       *   description="If the playlist is featured"
+       * )
+       *
+       */
+      protected $featured;
+      /** @OA\Property(
+       *   title="updated_at",
+       *   type="string",
+       *   description="The timestamp the playlist was last updated at",
+       *   nullable=true
+       * )
+       *
+       * @method static Note whereUpdatedAt($value)
+       * @public Carbon|null $updated_at
+       */
+      protected $updated_at;
+      /**
+       *
+       * @OA\Property(
+       *   title="created_at",
+       *   type="string",
+       *   description="The timestamp the playlist was created at"
+       * )
+       *
+       * @method static Note whereCreatedAt($value)
+       * @public Carbon $created_at
+       */
+      protected $created_at;
+      protected $deleted_at;
+
+}

--- a/database/migrations/2019_03_18_144021_create_changelog_table.php
+++ b/database/migrations/2019_03_18_144021_create_changelog_table.php
@@ -13,14 +13,16 @@ class CreateChangelogTable extends Migration
      */
     public function up()
     {
-        Schema::connection('dbp_users')->create('changelog', function (Blueprint $table) {
-            $table->increments('id');
-            $table->string('subheading');
-            $table->string('title');
-            $table->text('description');
-            $table->timestamp('released_at')->nullable();
-            $table->timestamps();
-        });
+        if (!Schema::connection('dbp_users')->hasTable('changelog')) {
+            Schema::connection('dbp_users')->create('changelog', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('subheading');
+                $table->string('title');
+                $table->text('description');
+                $table->timestamp('released_at')->nullable();
+                $table->timestamps();
+            });
+        }
     }
 
     /**

--- a/database/migrations/2019_07_02_050029_create_playlists_table.php
+++ b/database/migrations/2019_07_02_050029_create_playlists_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePlaylistsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::connection('dbp_users')->hasTable('user_playlists')) {
+            Schema::connection('dbp_users')->create('user_playlists', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->string('name');
+                $table->boolean('featured')->default(false);
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id', 'FK_user_playlists')->references('id')->on(config('database.connections.dbp_users.database').'.users')->onDelete('cascade')->onUpdate('cascade');
+                $table->softDeletes();
+                $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+                $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->dropIfExists('user_playlists');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -215,3 +215,8 @@ Route::name('v4_api.changes')->get('/api/changelog',                            
 
 // VERSION 4 | GENERATOR
 Route::name('v4_api.generator')->get('/api/gen/bibles',                            'Connections\GeneratorController@bibles');
+
+// VERSION 4 | Playlists
+Route::name('v4_playlists.index')->get('playlists/{user_id}',                     'Playlist\PlaylistsController@index');
+Route::name('v4_playlists.store')->post('playlists/{user_id}',                    'Playlist\PlaylistsController@store');
+Route::name('v4_playlists.destroy')->delete('playlists/{user_id}/{playlist_id}',  'Playlist\PlaylistsController@destroy');


### PR DESCRIPTION
## Description
- Added CRUD Endpoints for playlists
- Added Playlist Database Migration
- Added Playlist Model
- Updated documentation

## Motivation and Context
- As a user, I’d like the ability to create, update, delete, and get playlists of bible audio and/or video.

## Issue Link
[FCBH-404](https://fullstacklabs.atlassian.net/browse/FCBH-404) 
[FCBH-405](https://fullstacklabs.atlassian.net/browse/FCBH-405) 

## How Do I Test This?
- On your local environment run `php artisan migrate --database="dbp_users"` to generate the database table
- On your local environment run `http://dbp.test/open-api-v4.json` and verify that now create, read and update endpoints are documented
- Test that now you can create, read and update a playlist
- Playlist items will be addressed on FCBH-454

## Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.