### PR TITLE
FCBH-374 API Completeness: v2 endpoints

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -33,7 +33,7 @@ class APIController extends Controller
      * )
      *
      * @OA\Server(
-     *     url="https://api.dbp4.org",
+     *     url=API_URL_DOCS,
      *     description="Live Server",
      *     @OA\ServerVariable( serverVariable="schema", enum={"https"}, default="https")
      * )
@@ -50,7 +50,7 @@ class APIController extends Controller
      * @OA\Parameter(parameter="format",name="format",in="query",description="Setting this param to true will add format the return as a specific file type. The currently supported return types are `xml`, `csv`, `json`, and `yaml`",@OA\Schema(type="string",enum={"xml","csv","json","yaml"}))
      * @OA\Parameter(name="sort_by", in="query", description="The field to sort by", @OA\Schema(type="string"))
      * @OA\Parameter(name="sort_dir", in="query", description="The direction to sort by", @OA\Schema(type="string",enum={"asc","desc"}))
-     * @OA\Parameter(name="l10n", in="query", description="When set to a valid three letter language iso, the returning results will be localized in the language matching that iso. (If an applicable translation exists).", @OA\Schema(ref="#/components/schemas/Language/properties/iso")),
+     * @OA\Parameter(name="l10n", in="query", description="When set to a valid three letter language iso, the returning results will be localized in the language matching that iso. (If an applicable translation exists). For a complete list see the `iso` field in the `/languages` route", @OA\Schema(ref="#/components/schemas/Language/properties/iso")),
      *
      */
 

--- a/app/Http/Controllers/ApiMetadataController.php
+++ b/app/Http/Controllers/ApiMetadataController.php
@@ -125,6 +125,8 @@ class ApiMetadataController extends APIController
      *     description="This call returns the file path information. This information can be used with the response of the locations calls to create a URI to retrieve files.",
      *     operationId="v2_library_asset",
      *     @OA\Parameter(name="dam_id", in="query", description="The DAM ID for which to retrieve file path info.", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")),
+     *     @OA\Parameter(name="asset_id", in="query", description="Will filter the results by the given Asset", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/asset_id")),
+     *     @OA\Parameter(name="asset_type", in="query", description="The asset type to filter result by.", @OA\Schema(ref="#/components/schemas/Asset/properties/asset_type")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -133,7 +135,9 @@ class ApiMetadataController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
-     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_asset"))
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_asset"))
      *     )
      * )
      *
@@ -201,7 +205,9 @@ class ApiMetadataController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_api_versionLatest")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_api_versionLatest"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_api_versionLatest")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_api_versionLatest")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_api_versionLatest"))
      *     )
      * )
      *
@@ -244,7 +250,9 @@ class ApiMetadataController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_api_apiReply")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_api_apiReply"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_api_apiReply")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_api_apiReply")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_api_apiReply"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Bible/AudioController.php
+++ b/app/Http/Controllers/Bible/AudioController.php
@@ -196,12 +196,14 @@ class AudioController extends APIController
      *     @OA\Parameter(name="fileset_id", in="query", description="The specific fileset to return references for", required=true, @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")),
      *     @OA\Parameter(name="book", in="query", description="The Book ID for which to return timestamps. For a complete list see the `book_id` field in the `/bibles/books` route.", @OA\Schema(ref="#/components/schemas/Book/properties/id")),
      *     @OA\Parameter(name="chapter", in="query", description="The chapter for which to return timestamps", @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")),
+     *     @OA\Parameter(name="asset_id", in="query", description="The asset id for which to return timestamps.", @OA\Schema(ref="#/components/schemas/Asset/properties/id")),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_audio_timestamps")),
      *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_audio_timestamps")),
-     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v2_audio_timestamps"))
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v2_audio_timestamps")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/v2_audio_timestamps"))
      *     )
      * )
      *
@@ -212,7 +214,7 @@ class AudioController extends APIController
     {
         // Check Params
         $id       = checkParam('fileset_id|dam_id');
-        $asset_id = checkParam('asset_id');
+        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh.bucket');;
         $book     = checkParam('book|osis_code');
         $chapter  = checkParam('chapter_id|chapter_number');
 

--- a/app/Http/Controllers/Bible/BooksControllerV2.php
+++ b/app/Http/Controllers/Bible/BooksControllerV2.php
@@ -19,16 +19,15 @@ class BooksControllerV2 extends APIController
      *
      * @version 2
      * @category v2_library_book
-     * @category v2_library_bookOrder
-     * @link http://dbt.io/library/bookorder - V2 Access
+     * @link http://dbt.io/library/book - V2 Access
      * @link http://api.dbp.test/library/bookorder?key=1234&v=2&dam_id=AMKWBT&pretty - V2 Test
      * @link https://dbp.test/eng/docs/swagger/v2#/Library/v2_library_book - V2 Test Docs
      *
      * @OA\Get(
      *     path="/library/book/",
      *     tags={"Library Catalog"},
-     *     summary="Returns books order",
-     *     description="Gets the book order and code listing for a volume.",
+     *     summary="Returns books",
+     *     description="Gets the book and code listing for a volume.",
      *     operationId="v2_library_book",
      *     @OA\Parameter(name="dam_id",in="query",required=true, @OA\Schema(ref="#/components/schemas/Bible/properties/id")),
      *     @OA\Parameter(name="asset_id",in="query", @OA\Schema(ref="#/components/schemas/Asset/properties/id")),
@@ -39,7 +38,10 @@ class BooksControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_book"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_book")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_book")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_book")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_book"))
      *     )
      * )
      *
@@ -97,6 +99,41 @@ class BooksControllerV2 extends APIController
         return $this->reply($libraryBook);
     }
 
+     /**
+     * Gets the book order and code listing for a volume.
+     *
+     * @version 2
+     * @category v2_library_bookOrder
+     * @link http://dbt.io/library/bookorder - V2 Access
+     * @link http://api.dbp.test/library/bookorder?key=1234&v=2&dam_id=AMKWBT&pretty - V2 Test
+     * @link https://dbp.test/eng/docs/swagger/v2#/Library/v2_library_book - V2 Test Docs
+     *
+     * @OA\Get(
+     *     path="/library/bookorder/",
+     *     tags={"Library Catalog"},
+     *     summary="Returns books order",
+     *     description="Gets the book order and code listing for a volume.",
+     *     operationId="v2_library_bookOrder",
+     *     @OA\Parameter(name="dam_id",in="query",required=true, @OA\Schema(ref="#/components/schemas/Bible/properties/id")),
+     *     @OA\Parameter(name="asset_id",in="query", @OA\Schema(ref="#/components/schemas/Asset/properties/id")),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_bookOrder")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_bookOrder")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_bookOrder")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_bookOrder"))
+     *     )
+     * )
+     *
+     * @param dam_id - the volume internal bible_id.
+     *
+     * @return Book string - A JSON string that contains the status code and error messages if applicable.
+     */
     public function bookOrder()
     {
         $id        = checkParam('dam_id', true);
@@ -158,7 +195,10 @@ class BooksControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_bookName"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_bookName")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_bookName")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_bookName")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_bookName"))
      *     )
      * )
      *
@@ -325,7 +365,10 @@ class BooksControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(type="object",example={"GEN"="Genesis","EXO"="Exodus"}))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(type="object",example={"GEN"="Genesis","EXO"="Exodus"})),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(type="object",example={"GEN"="Genesis","EXO"="Exodus"})),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(type="object",example={"GEN"="Genesis","EXO"="Exodus"})),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(type="object",example={"GEN"="Genesis","EXO"="Exodus"}))
      *     )
      * )
      *

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -31,6 +31,8 @@ class LibraryController extends APIController
      *     summary="This returns copyright and associated organizations info.",
      *     description="",
      *     operationId="v2_library_metadata",
+     *     @OA\Parameter(name="dam_id", in="query", description="The DAM ID for which to retrieve library metadata.", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")),
+     *     @OA\Parameter(name="asset_id", in="query", description="Will filter the results by the given Asset", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/asset_id")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -107,7 +109,10 @@ class LibraryController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_version"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_version")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_version")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_version")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_version"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -43,6 +43,7 @@ class TextController extends APIController
      *     @OA\Parameter(name="verse_end", in="query", description="Will filter the results by the given end verse",
      *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/verse_end")
      *     ),
+     *     @OA\Parameter(name="asset_id", in="query", description="Will filter the results by the given Asset", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/asset_id")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -160,12 +161,6 @@ class TextController extends APIController
      *          description="Search for a specific font by name",
      *          @OA\Schema(type="string")
      *     ),
-     *     @OA\Parameter(
-     *          name="platform",
-     *          in="query",
-     *          description="Only return fonts that have been authorized for the specified platform. Available values are: `android`, `ios`, `web`, or `all`. All the current fonts are available cross-platform",
-     *          @OA\Schema(type="string",enum={"android","ios","web","all"},default="all")
-     *     ),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -175,7 +170,8 @@ class TextController extends APIController
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/font_response")),
      *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/font_response")),
-     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/font_response"))
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/font_response")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/font_response"))
      *     )
      * )
      *
@@ -258,7 +254,7 @@ class TextController extends APIController
         $fileset_id = checkParam('fileset_id|dam_id', true);
         $limit      = checkParam('limit') ?? 15;
         $book_id    = checkParam('book|book_id|books');
-        $asset_id   = checkParam('asset_id') ?? 'dbp-prod';
+        $asset_id   = checkParam('asset_id') ?? config('filesystems.disks.s3.bucket');
         $relevance_order   = checkParam('relevance_order');
 
         $fileset = BibleFileset::with('bible')->uniqueFileset($fileset_id, $asset_id, 'text_plain')->first();
@@ -316,6 +312,7 @@ class TextController extends APIController
      *          required=true,
      *          @OA\Schema(type="string")
      *     ),
+     *     @OA\Parameter(name="asset_id", in="query", description="Will filter the results by the given Asset", @OA\Schema(ref="#/components/schemas/BibleFileset/properties/asset_id")),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
      *     @OA\Parameter(ref="#/components/parameters/key"),
      *     @OA\Parameter(ref="#/components/parameters/pretty"),
@@ -325,7 +322,8 @@ class TextController extends APIController
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_text_search_group")),
      *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_text_search_group")),
-     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v2_text_search_group"))
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v2_text_search_group")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/v2_text_search_group"))
      *     )
      * )
      *
@@ -408,10 +406,16 @@ class TextController extends APIController
      *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")
      *     ),
      *     @OA\Parameter(
+     *          name="asset_id",
+     *          in="query",
+     *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/asset_id"),
+     *          description="If specified returns verse text ONLY for the specified fileset"
+     *     ),
+     *     @OA\Parameter(
      *          name="chapter",
      *          in="path",
      *          required=true,
-     *          description=" If specified returns verse text ONLY for the specified chapter",
+     *          description="If specified returns verse text ONLY for the specified chapter",
      *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")
      *     ),
      *     @OA\Parameter(
@@ -432,7 +436,9 @@ class TextController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
-     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_asset"))
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_asset")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_asset"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Organization/FilmsController.php
+++ b/app/Http/Controllers/Organization/FilmsController.php
@@ -30,7 +30,9 @@ class FilmsController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_video_location")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_video_location"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_video_location")),
+     *         @OA\MediaType(mediaType="text/csv",  @OA\Schema(ref="#/components/schemas/v2_video_location")),
+     *         @OA\MediaType(mediaType="text/x-yaml",  @OA\Schema(ref="#/components/schemas/v2_video_location"))
      *     )
      * )
      *
@@ -99,13 +101,15 @@ class FilmsController extends APIController
      *         response=200,
      *         description="successful operation",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_video_path")),
-     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_video_path"))
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_video_path")),
+     *         @OA\MediaType(mediaType="text/csv",  @OA\Schema(ref="#/components/schemas/v2_video_path")),
+     *         @OA\MediaType(mediaType="text/x-yaml",  @OA\Schema(ref="#/components/schemas/v2_video_path"))
      *     )
      * )
      *
      * @return mixed
      */
-    public function videopath()
+    public function videoPath()
     {
         if (!$this->api) {
             return view('docs.v2.video_videoPath');

--- a/app/Http/Controllers/Organization/OrganizationsController.php
+++ b/app/Http/Controllers/Organization/OrganizationsController.php
@@ -61,7 +61,10 @@ class OrganizationsController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_volume_organization_list"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_volume_organization_list")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_volume_organization_list")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_volume_organization_list")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_volume_organization_list"))
      *     )
      * )
      *

--- a/app/Http/Controllers/Organization/ResourcesController.php
+++ b/app/Http/Controllers/Organization/ResourcesController.php
@@ -88,23 +88,42 @@ class ResourcesController extends APIController
         return null;
     }
 
-    /**
+     /**
      *
-     * dam_id: DAM ID for the Jesus Film volume desired.
-     * encoding: [mp4|m3u8] The video encoding format desired.
-     * book_id (optional): OSIS book code to filter segments by references to book desired.
-     * chapter_id (optional): Chapter id to filter segments by references based on book and chapter.
-     * verse_id (optional): Verse id to filter segments by references based on book, chapter and verse.
+     * Returns an array of version return types
      *
+     * @category v2_api_jesusFilms
+     * @link http://api.dbp4.org/api/reply - V4 Access
+     * @link https://api.dbp.test/api/reply?key=1234&v=4&pretty - V4 Test Access
+     * @link https://dbp.test/eng/docs/swagger/gen#/Version_2/v2_api_apiReply - V4 Test Docs
+     *
+     * @OA\Get(
+     *     path="/library/jesusfilm",
+     *     tags={"Library Video"},
+     *     summary="",
+     *     description="",
+     *     operationId="v2_api_jesusFilms",
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Parameter(name="dam_id", in="query", description="DAM ID for the Jesus Film volume desired.", @OA\Schema(type="string",title="encoding")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_video_path")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_video_path")),
+     *         @OA\MediaType(mediaType="text/csv",  @OA\Schema(ref="#/components/schemas/v2_video_path")),
+     *         @OA\MediaType(mediaType="text/x-yaml",  @OA\Schema(ref="#/components/schemas/v2_video_path"))
+     *     )
+     * )
+     *
+     * @return mixed
      */
     public function jesusFilmListing()
     {
 
         $id         = checkParam('dam_id');
-        $encoding   = checkParam('encoding');
-        $book_id    = checkParam('book_id');
-        $chapter_id = checkParam('chapter_id');
-        $verse_id   = checkParam('verse_id');
 
         $organization = Organization::where('slug', 'the-jesus-film-project')->first();
         $iso          = strtolower(substr($id, 0, 3));

--- a/app/Http/Controllers/User/SwaggerDocsController.php
+++ b/app/Http/Controllers/User/SwaggerDocsController.php
@@ -27,6 +27,8 @@ class SwaggerDocsController extends Controller
 
     public function swaggerDocsGen($version)
     {
+
+        define("API_URL_DOCS", 'https://'.config('app.api_url'));
         $swagger = \Cache::remember('OAS_'.$version, now()->addDay(), function () use ($version) {
             $swagger = \OpenApi\scan(app_path());
             $swagger->tags  = $this->swaggerVersionTags($swagger->tags, $version);

--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -34,7 +34,10 @@ class LanguageControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_language"))
      *     )
      * )
      *
@@ -125,7 +128,10 @@ class LanguageControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_country_lang"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_country_lang")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_country_lang")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_country_lang")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_country_lang"))
      *     )
      * )
      *
@@ -241,7 +247,10 @@ class LanguageControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_language"))
      *     )
      * )
      *
@@ -328,29 +337,10 @@ class LanguageControllerV2 extends APIController
      *         description=""
      *     ),
      *     @OA\Parameter(
-     *         name="delivery",
+     *         name="organization_id",
      *         in="query",
-     *         deprecated=true,
-     *         @OA\Schema(type="string"),
-     *         description=""
-     *     ),
-     *     @OA\Parameter(
-     *         name="full_word",
-     *         in="query",
-     *         @OA\Schema(type="string"),
-     *         description=""
-     *     ),
-     *     @OA\Parameter(
-     *         name="status",
-     *         in="query",
-     *         @OA\Schema(type="string"),
-     *         description=""
-     *     ),
-     *     @OA\Parameter(
-     *         name="resolution",
-     *         in="query",
-     *         @OA\Schema(type="string"),
-     *         description=""
+     *         description="The organization id to filter equivalents by",
+     *         @OA\Schema(ref="#/components/schemas/Organization/properties/id")
      *     ),
      *     @OA\Parameter(ref="#/components/parameters/l10n"),
      *     @OA\Parameter(ref="#/components/parameters/version_number"),
@@ -360,7 +350,10 @@ class LanguageControllerV2 extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language"))
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="application/xml", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/csv", @OA\Schema(ref="#/components/schemas/v2_library_language")),
+     *         @OA\MediaType(mediaType="text/x-yaml", @OA\Schema(ref="#/components/schemas/v2_library_language"))
      *     )
      * )
      *


### PR DESCRIPTION
## Description

- Updated API documentation on Languages endpoints
  - /library/asset
    - Added asset_id, asset_type parameters
  - /audio/versestart
    - Added asset_id parameters
  - /library/bookorder/
    - Added documentation
  - /library/metadata
    - Added dam_id, asset_id
  - /bibles/filesets/{id}/{book}/{chapter}
    - Added asset_id
  - /text/font
    - Removed unused platform parameter
  - /text/searchgroup
    - Added asset_id
  - /library/verseinfo
    - Added asset_id
  - /library/jesusfilm
    - Added documentation
  - /library/volumelanguagefamily/
    - Added organization_id
    - Removed  delivery, full_word, status, resolution unused parameters
- Added default MediaTypes responses (xml, json, csv and yaml)
- Added default parameters (version_number, key, format and pretty)


## Motivation and Context
- As a user, I’d like the v2 API documentation and interactive Swagger to function with all options available to the v2 endpoints.

## Issue Link

[FCBH-374](https://fullstacklabs.atlassian.net/browse/FCBH-374) 

## How Do I Test This?

_To run the test suite refer to the Readme.md_

- Navigate in your local environment to `http://dbp.test/docs/swagger/v2` or in the `swagger-editor` import `https://api.dbp.test/open-api-v2.json`

## Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.