### PR TITLE
 FCBH-377 Add user_token to login endpoint

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -43,6 +43,14 @@ class APIController extends Controller
      *     description="Development server",
      *     @OA\ServerVariable( serverVariable="schema", enum={"https"}, default="https")
      * )
+     * 
+     * @OA\SecurityScheme(
+     *   securityScheme="api_token",
+     *   name="api_token",
+     *   in="query",
+     *   type="apiKey",
+     *   description="The key granted to the user upon sign up or login"
+     * )
      *
      * @OA\Parameter(parameter="version_number",name="v",in="query",description="The Version Number",required=true,@OA\Schema(type="integer",enum={2,4},example=4))
      * @OA\Parameter(parameter="key",name="key",in="query",description="The Key granted to the api user upon sign up",required=true,@OA\Schema(type="string",example="ar45g3h4ae644"))
@@ -110,7 +118,7 @@ class APIController extends Controller
             $this->v   = (int) checkParam('v', true, $this->preset_v);
             $this->key = checkParam('key', true);
 
-            $cache_string = 'keys:'.$this->key;
+            $cache_string = 'keys:' . $this->key;
             $keyExists = \Cache::remember($cache_string, now()->addDay(), function () {
                 return Key::with('user')->where('key', $this->key)->first();
             });
@@ -123,9 +131,9 @@ class APIController extends Controller
             // i18n
             $i18n = checkParam('i18n') ?? 'eng';
 
-            $cache_string = 'selected_api_language:'.strtolower($i18n);
+            $cache_string = 'selected_api_language:' . strtolower($i18n);
             $current_language = \Cache::remember($cache_string, now()->addDay(), function () use ($i18n) {
-                $language = Language::where('iso', $i18n)->select(['iso','id'])->first();
+                $language = Language::where('iso', $i18n)->select(['iso', 'id'])->first();
                 return [
                     'i18n_iso' => $language->iso,
                     'i18n_id'  => $language->id
@@ -174,7 +182,7 @@ class APIController extends Controller
         if (is_a($object, JsonResponse::class)) {
             return $object;
         }
-        
+
         // Status Code, Headers, Params, Body, Time
         try {
             apiLogs(request(), $this->statusCode, $s3_transaction_id, request()->ip());
@@ -230,35 +238,35 @@ class APIController extends Controller
         switch ($format) {
             case 'jsonp':
                 return response()->json($object, $this->statusCode)
-                                 ->header('Content-Type', 'application/javascript; charset=utf-8')
-                                 ->setCallback(request()->input('callback'));
+                    ->header('Content-Type', 'application/javascript; charset=utf-8')
+                    ->setCallback(request()->input('callback'));
             case 'xml':
                 $formatter = ArrayToXml::convert($object, [
                     'rootElementName' => $meta['rootElementName'] ?? 'root',
                     '_attributes'     => $meta['rootAttributes'] ?? []
                 ], true, 'utf-8');
                 return response()->make($formatter, $this->statusCode)
-                                 ->header('Content-Type', 'application/xml; charset=utf-8');
+                    ->header('Content-Type', 'application/xml; charset=utf-8');
             case 'yaml':
                 $formatter = Yaml::dump($object);
                 return response()->make($formatter, $this->statusCode)
-                                 ->header('Content-Type', 'text/yaml; charset=utf-8');
+                    ->header('Content-Type', 'text/yaml; charset=utf-8');
             case 'toml':
                 $tomlBuilder = new TomlBuilder();
                 $formatter   = $tomlBuilder->addValue('multiple', $object)->getTomlString();
                 return response()->make($formatter, $this->statusCode)
-                                 ->header('Content-Type', 'text/yaml; charset=utf-8');
+                    ->header('Content-Type', 'text/yaml; charset=utf-8');
             case 'csv':
                 $formatter = Formatter::make($object, Formatter::ARR);
                 return response()->make($formatter->toCsv(), $this->statusCode)
-                                 ->header('Content-Type', 'text/csv; charset=utf-8');
+                    ->header('Content-Type', 'text/csv; charset=utf-8');
             default:
                 if (isset($_GET['pretty'])) {
                     return response()->json($object, $this->statusCode, [], JSON_UNESCAPED_UNICODE)
                         ->header('Content-Type', 'application/json; charset=utf-8')->setCallback($input);
                 }
                 return response()->json($object, $this->statusCode, [], JSON_UNESCAPED_UNICODE)
-                        ->header('Content-Type', 'application/json; charset=utf-8')->setCallback($input);
+                    ->header('Content-Type', 'application/json; charset=utf-8')->setCallback($input);
         }
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -78,6 +78,7 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'APIToken' => \App\Http\Middleware\APIToken::class,
     ];
 
     /**

--- a/app/Http/Middleware/APIToken.php
+++ b/app/Http/Middleware/APIToken.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Auth\AuthenticationException;
+
+use Closure;
+
+class APIToken
+{
+    /**
+     * The authentication factory instance.
+     *
+     * @var \Illuminate\Contracts\Auth\Factory
+     */
+    protected $auth;
+
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(Auth $auth)
+    {
+        $this->auth = $auth;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $method
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next, $type = "")
+    {
+        $guard = "api";
+
+        if ($type === "check") {
+            if (!$this->auth->guard($guard)->check()) {
+                throw new AuthenticationException(trans('auth.failed'));
+            }
+        }
+
+        $this->auth->shouldUse($guard);
+        return $next($request);
+    }
+}

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -6,7 +6,7 @@ namespace App\Models\Playlist;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Carbon\Carbon;
-
+use App\Models\User\User;
 
 /**
  * App\Models\Playlist
@@ -36,7 +36,7 @@ class Playlist extends Model
     protected $connection = 'dbp_users';
     public $table         = 'user_playlists';
     protected $fillable   = ['user_id','name'];
-    protected $hidden     = ['featured', 'user_id'];
+    protected $hidden     = ['featured', 'user_id', 'deleted_at'];
     protected $dates      = ['deleted_at'];
 
     /**
@@ -105,4 +105,8 @@ class Playlist extends Model
       protected $created_at;
       protected $deleted_at;
 
+      public function user()
+      {
+        return $this->belongsTo(User::class)->select('id', 'name');
+      }
 }

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -56,7 +56,8 @@ class UserTransformer extends BaseTransformer
                     'profile'   => $user->profile,
                     'organizations' => $user->organizations,
                     'accounts'  => $user->accounts,
-                    'keys'      => $user->keys
+                    'keys'      => $user->keys,
+                    'api_token' => $user->api_token,
                 ];
 
             /**

--- a/config/auth.php
+++ b/config/auth.php
@@ -44,6 +44,7 @@ return [
         'api' => [
             'driver' => 'token',
             'provider' => 'users',
+            'hash' => true,
         ],
     ],
 

--- a/database/migrations/2019_07_14_154139_add_user_api_token.php
+++ b/database/migrations/2019_07_14_154139_add_user_api_token.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUserApiToken extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('users', function (Blueprint $table) {
+            $table->string('api_token', 80)->after('password')
+                ->unique()
+                ->nullable()
+                ->default(null);
+        });
+    }
+
+    /** 
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('users', function (Blueprint $table) {
+            $table->dropColumn('api_token');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,7 @@ Route::name('v2_library_chapter')->get('library/chapter',                       
 // VERSION 2 | Languages
 Route::name('v2_library_language')->get('library/language',                        'Wiki\LanguageControllerV2@languageListing');
 Route::name('v2_library_volumeLanguage')->get('library/volumelanguage',            'Wiki\LanguageControllerV2@volumeLanguage');
-Route::name('v2_library_volumeLanguageFamily')->get('library/volumelanguagefamily','Wiki\LanguageControllerV2@volumeLanguageFamily');
+Route::name('v2_library_volumeLanguageFamily')->get('library/volumelanguagefamily', 'Wiki\LanguageControllerV2@volumeLanguageFamily');
 Route::name('v2_country_lang')->get('country/countrylang',                         'Wiki\LanguageControllerV2@countryLang');
 
 // VERSION 2 | Library
@@ -49,9 +49,9 @@ Route::name('v2_api_jesusFilm_stream')->get('video/jesusfilm/{id}.m3u8',        
 
 // VERSION 2 | Users
 Route::name('v2_users_banners_banner')->get('/banners/banner',                     'User\UsersControllerV2@banner');
-Route::name('v2_users_user')->match(['get','post','options'], '/users/user',       'User\UsersControllerV2@user');
+Route::name('v2_users_user')->match(['get', 'post', 'options'], '/users/user',       'User\UsersControllerV2@user');
 Route::name('v2_users_profile')->post('/users/profile',                            'User\UsersControllerV2@profile');
-Route::name('v2_user_login')->match(['put','post','options'], '/users/login',      'User\UsersControllerV2@login');
+Route::name('v2_user_login')->match(['put', 'post', 'options'], '/users/login',      'User\UsersControllerV2@login');
 Route::name('v2_annotations')->get('/annotations/list',                            'User\UsersControllerV2@annotationList');
 Route::name('v2_bookmarks')->get('/annotations/bookmark',                          'User\UsersControllerV2@bookmark');
 Route::name('v2_bookmarks_alter')->post('/annotations/bookmark',                   'User\UsersControllerV2@bookmarkAlter');
@@ -92,7 +92,7 @@ Route::name('v4_bible.all')->get('bibles',                                      
 Route::name('v4_filesets.types')->get('bibles/filesets/media/types',               'Bible\BibleFileSetsController@mediaTypes');
 Route::name('v4_filesets.podcast')->get('bibles/filesets/{fileset_id}/podcast',    'Bible\BibleFilesetsPodcastController@index');
 Route::name('v4_filesets.download')->get('bibles/filesets/{fileset_id}/download',  'Bible\BibleFileSetsController@download');
-Route::name('v4_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright','Bible\BibleFileSetsController@copyright');
+Route::name('v4_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright', 'Bible\BibleFileSetsController@copyright');
 Route::name('v4_filesets.show')->get('bibles/filesets/{fileset_id?}',              'Bible\BibleFileSetsController@show');
 Route::name('v4_filesets.update')->put('bibles/filesets/{fileset_id}',             'User\Dashboard\BibleFilesetsManagementController@update');
 Route::name('v4_filesets.store')->post('bibles/filesets',             'User\Dashboard\BibleFilesetsManagementController@store');
@@ -138,7 +138,7 @@ Route::name('v4_user.index')->get('users',                                      
 Route::name('v4_user.store')->post('users',                                        'User\UsersController@store');
 Route::name('v4_user.show')->get('users/{user_id}',                                'User\UsersController@show');
 Route::name('v4_user.update')->put('users/{user_id}',                              'User\UsersController@update');
-Route::name('v4_user.destroy')->delete('users/{user_id}',                          'User\UsersController@destroy');
+Route::name('v4_user.destroy')->middleware('APIToken:check')->delete('users',      'User\UsersController@destroy');
 Route::name('v4_user.login')->post('/login',                                       'User\UsersController@login');
 Route::name('v4_user.oAuth')->get('/login/{driver}',                               'User\SocialController@redirect');
 Route::name('v4_user.oAuthCallback')->get('/login/{driver}/callback',              'User\SocialController@callback');
@@ -210,6 +210,9 @@ Route::name('v4_api.changes')->get('/api/changelog',                            
 Route::name('v4_api.generator')->get('/api/gen/bibles',                            'Connections\GeneratorController@bibles');
 
 // VERSION 4 | Playlists
-Route::name('v4_playlists.index')->get('playlists/{user_id}',                     'Playlist\PlaylistsController@index');
-Route::name('v4_playlists.store')->post('playlists/{user_id}',                    'Playlist\PlaylistsController@store');
-Route::name('v4_playlists.destroy')->delete('playlists/{user_id}/{playlist_id}',  'Playlist\PlaylistsController@destroy');
+Route::name('v4_playlists.index')
+    ->middleware('APIToken')->get('playlists',                                      'Playlist\PlaylistsController@index');
+Route::name('v4_playlists.store')
+    ->middleware('APIToken:check')->post('playlists',                               'Playlist\PlaylistsController@store');
+Route::name('v4_playlists.destroy')
+    ->middleware('APIToken:check')->delete('playlists/{playlist_id}',               'Playlist\PlaylistsController@destroy');


### PR DESCRIPTION
# Description
- Added `api_token` column to the users table
- When the user register/ login an `api_token` will be retrieved, this token will be stored hashed `hash('sha256', $token)`
- Added `api_token` to documentation as a SecurityScheme
- Updated Playlist CRUD endpoints to use api_token instead of `user_id`
- Created APIToken middleware in order to handle the `api_token` on the requests
   - `middleware('APIToken:check')` will force to have a valid token
   - `middleware('APIToken')` will allow an authenticated user to access data (for the logged-out experience)

## Issue Link
[FCBH-377](https://fullstacklabs.atlassian.net/browse/FCBH-377) 

## How Do I QA This

- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Test that now you receive an `api_token` on login and registration
- This PR is based on `FCBH-443`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

