### PR TITLE
FCBH-662 Add Multiple Playlist items

### DIFF
--- a/app/Http/Controllers/User/SwaggerDocsController.php
+++ b/app/Http/Controllers/User/SwaggerDocsController.php
@@ -28,8 +28,8 @@ class SwaggerDocsController extends Controller
     public function swaggerDocsGen($version)
     {
 
-        define("API_URL_DOCS", 'https://'.config('app.api_url'));
-        $swagger = \Cache::remember('OAS_'.$version, now()->addDay(), function () use ($version) {
+        define("API_URL_DOCS", config('app.api_url'));
+        $swagger = \Cache::remember('OAS_' . $version, now()->addDay(), function () use ($version) {
             $swagger = \OpenApi\scan(app_path());
             $swagger->tags  = $this->swaggerVersionTags($swagger->tags, $version);
             $swagger->paths = $this->swaggerVersionPaths($swagger->paths, $version);
@@ -83,5 +83,4 @@ class SwaggerDocsController extends Controller
 
         return $paths;
     }
-
 }


### PR DESCRIPTION
# Description
- Added the ability to handle an array of items on `/playlists/{playlist_id}/item` POST endpoint
- Removed `https` from the API_URL_DOCS

## Issue Link
Original Story: [FCBH-662](https://fullstacklabs.atlassian.net/browse/FCBH-662) 
Review Story: [FCBH-705](https://fullstacklabs.atlassian.net/browse/FCBH-705) 

## How Do I QA This
- On your `.env` file add to the `API_URL` var the scheme in order to be a complete url (`eg: https://api.dbp.test`)
- On your local environment run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test `/playlists/{playlist_id}/item` POST endpoint and check that now you can send a request with an array of playlist items

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
