### PR TITLE
FCBH-656 Set true/false instead of 0/1 on playlists response

### DIFF
--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -35,7 +35,7 @@ class Plan extends Model
   protected $connection = 'dbp_users';
   public $table         = 'plans';
   protected $fillable   = ['user_id', 'name', 'suggested_start_date'];
-  protected $hidden     = ['featured', 'user_id', 'deleted_at', 'plan_id'];
+  protected $hidden     = ['user_id', 'deleted_at', 'plan_id'];
   protected $dates      = ['deleted_at'];
 
   /**
@@ -103,6 +103,11 @@ class Plan extends Model
    */
   protected $created_at;
   protected $deleted_at;
+
+  public function getFeaturedAttribute($featured)
+  {
+    return (bool) $featured;
+  }
 
   public function user()
   {

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -37,7 +37,7 @@ class Playlist extends Model
     protected $connection = 'dbp_users';
     public $table         = 'user_playlists';
     protected $fillable   = ['user_id', 'name', 'external_content'];
-    protected $hidden     = ['featured', 'user_id', 'deleted_at'];
+    protected $hidden     = ['user_id', 'deleted_at'];
     protected $dates      = ['deleted_at'];
 
     /**
@@ -115,6 +115,17 @@ class Playlist extends Model
        */
       protected $created_at;
       protected $deleted_at;
+      
+      public function getFeaturedAttribute($featured)
+      {
+        return (bool) $featured;
+      }
+
+      public function getFollowingAttribute($following)
+      {
+        return (bool) $following;
+      }
+
       public function user()
       {
         return $this->belongsTo(User::class)->select('id', 'name');


### PR DESCRIPTION
# Description
- Changed Plan and Playlist models in order to return booleans instead of 1/0


## Issue Link
Original Story: [FCBH-656](https://fullstacklabs.atlassian.net/browse/FCBH-656) 
Review Story: [FCBH-724](https://fullstacklabs.atlassian.net/browse/FCBH-724) 

## How Do I QA This
- Test `/plans` GET endpoint and check that now you get booleans instead of numbers
- Test `/playlists` GET endpoint and check that now you get booleans instead of numbers

## Screenshots
Plans reponse: 
![image](https://user-images.githubusercontent.com/41348080/63553524-4502e400-c500-11e9-97d6-e710a95b1bfb.png)
Playlist response: 
![image](https://user-images.githubusercontent.com/41348080/63553544-52b86980-c500-11e9-9010-8518f1b6abb4.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
