### PR TITLE
FCBH-657/658 Full playlist object on create/edit a Playlist/Plan

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -165,6 +165,7 @@ class PlansController extends APIController
             'plan_id'               => $plan->id
         ]);
 
+        $plan = $this->getPlan($plan->id, $user);
         return $this->reply($plan);
     }
 


### PR DESCRIPTION
# Description
- Added full object response on create plan endpoint
- Added full object response on create/edit/follow playlist endpoints

## Issue Link
Original Story: [FCBH-657](https://fullstacklabs.atlassian.net/browse/FCBH-657) 
Original Story: [FCBH-658](https://fullstacklabs.atlassian.net/browse/FCBH-658) 

Review Story: [FCBH-725](https://fullstacklabs.atlassian.net/browse/FCBH-725)
Review Story: [FCBH-726](https://fullstacklabs.atlassian.net/browse/FCBH-726) 

## How Do I QA This
- Test `/plans` POST endpoint and check that now you get a full object response
- Test `/playlists` POST endpoint and check that now you get a full object response
- Test `/playlists/{playlist_id}` PUT endpoint and check that now you get a full object response
- Test `/playlists/{playlist_id}/follow` POST endpoint and check that now you get a full object response




## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

