### PR TITLE
FCBH-667 Plan/Playlist order

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -38,6 +38,8 @@ class PlansController extends APIController
      *     @OA\Parameter(ref="#/components/parameters/format"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_by"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_dir"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -73,6 +75,8 @@ class PlansController extends APIController
         $featured = checkParam('featured');
         $featured = $featured && $featured != 'false' || empty($user);
         $limit        = (int) (checkParam('limit') ?? 25);
+        $sort_by    = checkParam('sort_by') ?? 'name';
+        $sort_dir   = checkParam('sort_dir') ?? 'asc';
 
         $plans = Plan::with('days')
             ->with('user')
@@ -82,7 +86,8 @@ class PlansController extends APIController
                 $q->join('user_plans', function ($join) use ($user) {
                     $join->on('user_plans.plan_id', '=', 'plans.id')->where('user_plans.user_id', $user->id);
                 });
-            })->orderBy('plans.updated_at', 'desc')->paginate($limit);
+            })
+            ->orderBy($sort_by, $sort_dir)->paginate($limit);
 
         foreach ($plans as $plan) {
             $plan->total_days = sizeof($plan->days);

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -39,6 +39,8 @@ class PlaylistsController extends APIController
      *     @OA\Parameter(ref="#/components/parameters/format"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_by"),
+     *     @OA\Parameter(ref="#/components/parameters/sort_dir"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -72,6 +74,9 @@ class PlaylistsController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
+        $sort_by    = checkParam('sort_by') ?? 'name';
+        $sort_dir   = checkParam('sort_dir') ?? 'asc';
+
         $featured = checkParam('featured');
         $featured = $featured && $featured != 'false' || empty($user);
         $limit    = (int) (checkParam('limit') ?? 25);
@@ -93,7 +98,7 @@ class PlaylistsController extends APIController
                     ->orWhere('playlists_followers.user_id', $user->id);
             })
             ->select($select)
-            ->orderBy('name', 'asc')->paginate($limit);
+            ->orderBy($sort_by, $sort_dir)->paginate($limit);
 
         return $this->reply($playlists);
     }


### PR DESCRIPTION
- Added sort_by and sort_dir parameters to `/playlist` and  `/plans` GET endpoints
- sort_by default value is now `name`
- sort_dir default value is now `asc`
- Added new parameters to the documentation

# Description
- Added full object response on create plan endpoint
- Added full object response on create/edit/follow playlist endpoints

## Issue Link
Original Story: [FCBH-667](https://fullstacklabs.atlassian.net/browse/FCBH-667) 
Review Story: [FCBH-727](https://fullstacklabs.atlassian.net/browse/FCBH-727) 

## How Do I QA This
- On your local environment run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test `/plans` GET endpoint and check that now are ordered by name 
- Test `/playlists` GET endpoint and check that now are ordered by name 
- Change `sort_dir` parameter to `desc` and verify that the order changed
- Change `sort_by` parameter to `updated_at` and verify that the list is orderer by updated_at

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

