### PR TITLE
FCBH-666 Add completed to plans/playlists

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -601,7 +601,7 @@ class PlansController extends APIController
      *     operationId="v4_plans.reset",
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
-     *     @OA\RequestBody(required=true, @OA\MediaType(mediaType="application/json",
+     *     @OA\RequestBody(@OA\MediaType(mediaType="application/json",
      *          @OA\Schema(
      *              @OA\Property(property="start_date", type="string")
      *          )

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -4,10 +4,11 @@ namespace App\Http\Controllers\Playlist;
 
 use App\Traits\AccessControlAPI;
 use App\Http\Controllers\APIController;
-use App\Models\User\User;
+use App\Models\Plan\UserPlan;
 use App\Models\Playlist\Playlist;
 use App\Models\Playlist\PlaylistFollower;
 use App\Models\Playlist\PlaylistItems;
+use App\Models\Playlist\PlaylistItemsComplete;
 use App\Traits\CheckProjectMembership;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -400,7 +401,7 @@ class PlaylistsController extends APIController
         $playlist = Playlist::where('id', $playlist_id)->first();
 
         if (!$playlist) {
-            return $this->setStatusCode(404)->replyWithError('Plan Not Found');
+            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
         }
 
         $follow = checkParam('follow');
@@ -509,6 +510,82 @@ class PlaylistsController extends APIController
         }
 
         return $this->reply($single_item ? $created_playlist_items[0] : $created_playlist_items);
+    }
+
+    /**
+     * Complete a playlist item.
+     *
+     * @OA\Post(
+     *     path="/playlists/item/{item_id}/complete",
+     *     tags={"Playlists"},
+     *     summary="Complete a playlist item",
+     *     description="",
+     *     operationId="v4_playlists_items.complete",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(name="item_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/PlaylistItems/properties/id")),
+     *     @OA\Parameter(name="complete", in="query", @OA\Schema(type="boolean")),
+     *     @OA\Parameter(ref="#/components/parameters/version_number"),
+     *     @OA\Parameter(ref="#/components/parameters/key"),
+     *     @OA\Parameter(ref="#/components/parameters/pretty"),
+     *     @OA\Parameter(ref="#/components/parameters/format"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/PlaylistItems")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/PlaylistItems")),
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/PlaylistItems")),
+     *         @OA\MediaType(mediaType="text/csv",      @OA\Schema(ref="#/components/schemas/PlaylistItems"))
+     *     )
+     * )
+     * 
+     *
+     * @return mixed
+     */
+    public function completeItem(Request $request, $item_id)
+    {
+        // Validate Project / User Connection
+        $user = $request->user();
+        $user_is_member = $this->compareProjects($user->id, $this->key);
+
+        if (!$user_is_member) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $playlist_item = PlaylistItems::where('id', $item_id)->first();
+
+        if (!$playlist_item) {
+            return $this->setStatusCode(404)->replyWithError('Playlist Item Not Found');
+        }
+
+        $user_plan = UserPlan::join('plans', function ($join) use ($user) {
+            $join->on('user_plans.plan_id', '=', 'plans.id')->where('user_plans.user_id', $user->id);
+        })
+        ->join('plan_days', function ($join) use ($playlist_item) {
+            $join->on('plan_days.plan_id', '=', 'plans.id')->where('plan_days.playlist_id', $playlist_item->playlist_id);
+        })
+        ->select('user_plans.*')
+        ->first();
+
+        if (!$user_plan) {
+            return $this->setStatusCode(404)->replyWithError('User Plan Not Found');
+        }
+
+        $complete = checkParam('complete') ?? true;
+        $complete = $complete && $complete !== 'false';
+
+        if ($complete) {
+            $playlist_item->complete();
+        } else {
+            $playlist_item->unComplete();
+        }
+
+        $result = $complete ? 'completed' : 'not completed';
+        $user_plan->calculatePercentageCompleted()->save();
+
+        return $this->reply([
+            'percentage_completed' => $user_plan->percentage_completed,
+            'message' => 'Playlist Item ' . $result
+        ]);
     }
 
     private function validatePlaylist()

--- a/app/Models/Plan/PlanDay.php
+++ b/app/Models/Plan/PlanDay.php
@@ -3,7 +3,10 @@
 namespace App\Models\Plan;
 
 use App\Models\Playlist\Playlist;
+use App\Models\Playlist\PlaylistItems;
+use Illuminate\Auth\TokenGuard;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 
@@ -44,6 +47,72 @@ class PlanDay extends Model implements Sortable
      * @OA\Property(ref="#/components/schemas/Playlist/properties/id")
      */
     protected $playlist_id;
+
+    protected $appends = array('completed');
+
+    /**
+     * @OA\Property(
+     *   title="completed",
+     *   type="boolean",
+     *   description="If the plan day is completed"
+     * )
+     */
+    public function getCompletedAttribute()
+    {
+        $user = Auth::user();
+        if (empty($user)) {
+            return false;
+        }
+
+        $complete = PlanDayComplete::where('plan_day_id', $this->attributes['id'])
+            ->where('user_id', $user->id)->first();
+
+        return !empty($complete);
+    }
+
+    public function verifyDayCompleted()
+    {
+        $user = Auth::user();
+        $playlist_items_count = PlaylistItems::where('playlist_items.playlist_id', $this['playlist_id'])->count();
+        $playlist_items_completed_count =
+            PlaylistItems::where('playlist_items.playlist_id', $this['playlist_id'])
+            ->join('playlist_items_completed', function ($join) use ($user) {
+                $join->on('playlist_items_completed.playlist_item_id', '=', 'playlist_items.id')
+                    ->where('playlist_items_completed.user_id',  $user->id);
+            })
+            ->count();
+        if ($playlist_items_count && $playlist_items_completed_count === $playlist_items_count) {
+            $this->complete();
+        }
+        return  [
+            'total_items' => $playlist_items_count,
+            'total_items_completed' => $playlist_items_completed_count
+        ];
+    }
+
+    public function complete()
+    {
+        $user = Auth::user();
+        $completed_item = PlanDayComplete::firstOrNew([
+            'user_id'               => $user->id,
+            'plan_day_id'           => $this['id']
+        ]);
+        $completed_item->save();
+        PlaylistItems::where('playlist_id', $this['playlist_id'])->each(function ($playlist_item) { 
+            $playlist_item->complete();
+        });
+    }
+
+    public function unComplete()
+    {
+        $user = Auth::user();
+        $completed_item = PlanDayComplete::where('plan_day_id', $this['id'])
+            ->where('user_id', $user->id);
+        $completed_item->delete();
+        PlaylistItems::where('playlist_id', $this['playlist_id'])->each(function ($playlist_item) { 
+            $playlist_item->unComplete();
+        });
+    }
 
     public function playlist()
     {

--- a/app/Models/Plan/PlanDayComplete.php
+++ b/app/Models/Plan/PlanDayComplete.php
@@ -5,15 +5,15 @@ namespace App\Models\Plan;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
-class UserPlan extends Model
+class PlanDayComplete extends Model
 {
 
     protected $connection = 'dbp_users';
-    protected $primaryKey = ['user_id', 'plan_id'];
-    public $incrementing = false;
-    public $table         = 'user_plans';
-    protected $fillable   = ['plan_id', 'user_id', 'start_date', 'suggested_start_date', 'percentage_completed'];
-    protected $hidden     = ['plan_id', 'created_at', 'updated_at'];
+    public $table         = 'plan_days_completed';
+    protected $primaryKey = ['user_id', 'plan_day_id'];
+    protected $fillable   = ['user_id', 'plan_day_id'];
+    public $incrementing  = false;
+    public $timestamps = false;
 
     /**
      * Set the keys for a save update query.
@@ -52,16 +52,5 @@ class UserPlan extends Model
         }
 
         return $this->getAttribute($keyName);
-    }
-
-    public function calculatePercentageCompleted()
-    {
-        $completed_per_day = PlanDay::where('plan_id', $this->plan_id)->get()
-            ->map(function ($plan_day) {
-                $completed = $plan_day->verifyDayCompleted();
-                return $completed;
-            });;
-        $this->percentage_completed = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
-        return $this;
     }
 }

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -65,14 +65,14 @@ class UserPlan extends Model
         return $this;
     }
 
-    public function reset()
+    public function reset($start_date = null)
     {
         PlanDay::where('plan_id', $this->plan_id)->get()
             ->map(function ($plan_day) {
                 $plan_day->unComplete();
             });;
         $this->percentage_completed = 0;
-        $this->start_date = 0;
+        $this->start_date = $start_date;
         return $this;
     }
 }

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -64,4 +64,15 @@ class UserPlan extends Model
         $this->percentage_completed = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
         return $this;
     }
+
+    public function reset()
+    {
+        PlanDay::where('plan_id', $this->plan_id)->get()
+            ->map(function ($plan_day) {
+                $plan_day->unComplete();
+            });;
+        $this->percentage_completed = 0;
+        $this->start_date = 0;
+        return $this;
+    }
 }

--- a/app/Models/Playlist/PlaylistItemsComplete.php
+++ b/app/Models/Playlist/PlaylistItemsComplete.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace App\Models\Plan;
+namespace App\Models\Playlist;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 
-class UserPlan extends Model
+class PlaylistItemsComplete extends Model
 {
 
     protected $connection = 'dbp_users';
-    protected $primaryKey = ['user_id', 'plan_id'];
-    public $incrementing = false;
-    public $table         = 'user_plans';
-    protected $fillable   = ['plan_id', 'user_id', 'start_date', 'suggested_start_date', 'percentage_completed'];
-    protected $hidden     = ['plan_id', 'created_at', 'updated_at'];
+    public $table         = 'playlist_items_completed';
+    protected $primaryKey = ['user_id', 'playlist_item_id'];
+    protected $fillable   = ['user_id', 'playlist_item_id'];
+    public $incrementing  = false;
+    public $timestamps = false;
 
     /**
      * Set the keys for a save update query.
@@ -52,16 +52,5 @@ class UserPlan extends Model
         }
 
         return $this->getAttribute($keyName);
-    }
-
-    public function calculatePercentageCompleted()
-    {
-        $completed_per_day = PlanDay::where('plan_id', $this->plan_id)->get()
-            ->map(function ($plan_day) {
-                $completed = $plan_day->verifyDayCompleted();
-                return $completed;
-            });;
-        $this->percentage_completed = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
-        return $this;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,6 +241,8 @@ Route::name('v4_plans.destroy')
     ->middleware('APIToken:check')->delete('plans/{plan_id}',                       'Plan\PlansController@destroy');
 Route::name('v4_plans.start')
     ->middleware('APIToken:check')->post('plans/{plan_id}/start',                   'Plan\PlansController@start');
+Route::name('v4_plans.reset')
+    ->middleware('APIToken:check')->post('plans/{plan_id}/reset',                   'Plan\PlansController@reset');
 Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
 Route::name('v4_plans_days.complete')

--- a/routes/api.php
+++ b/routes/api.php
@@ -224,6 +224,8 @@ Route::name('v4_playlists.follow')
     ->middleware('APIToken:check')->post('playlists/{playlist_id}/follow',          'Playlist\PlaylistsController@follow');
 Route::name('v4_playlists_items.store')
     ->middleware('APIToken:check')->post('playlists/{playlist_id}/item',            'Playlist\PlaylistsController@storeItem');
+Route::name('v4_playlists_items.complete')
+    ->middleware('APIToken:check')->post('playlists/item/{item_id}/complete',       'Playlist\PlaylistsController@completeItem');
 
 
 // VERSION 4 | Plans
@@ -241,3 +243,5 @@ Route::name('v4_plans.start')
     ->middleware('APIToken:check')->post('plans/{plan_id}/start',                   'Plan\PlansController@start');
 Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
+Route::name('v4_plans_days.complete')
+    ->middleware('APIToken:check')->post('plans/day/{day_id}/complete',             'Plan\PlansController@completeDay');


### PR DESCRIPTION
# Description
- Added `complete` POST endpoint to plan days and playlist items controllers
- Added `completed` attribute to `PlanDay` and `PlaylistItems` models
- Added `complete` and `unComplete` methods  to `PlanDay` and `PlaylistItems` models
- Added `verifyCompleted` method to `PlanDay` model
- Created `PlanDayComplete` and `PlaylistItemsComplete` models
- Added `calculatePercentageComplete` to `UserPlan` model
- Updated documentation

## Issue Link
Original Story: [FCBH-666](https://fullstacklabs.atlassian.net/browse/FCBH-666) 
Review Story: [FCBH-734](https://fullstacklabs.atlassian.net/browse/FCBH-734) 

## How Do I QA This
- On your local environment run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test `/playlists/item/{item_id}/complete` POST endpoint and check that now you can complete an item, also check that the response has the `percetage_complete`value of the plan  
- Test `/plans/day/{day_id}/complete` POST endpoint and check that now you can complete a day, also check that the response has the `percetage_complete`value of the plan  

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

