### PR TITLE
FCBH-659 Calculate the number of verses on an Item and the total playlists

### DIFF
--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -128,9 +128,18 @@ class Playlist extends Model
         return (bool) $following;
       }
 
+      /**
+       *
+       * @OA\Property(
+       *   title="verses",
+       *   type="integer",
+       *   description="The playlist verses count"
+       * )
+       *
+       */
       public function getVersesAttribute()
       {
-        return $this['items']->sum('verses');
+        return PlaylistItems::where('playlist_id', $this['id'])->get()->sum('verses');
       }
 
       public function user()

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -116,6 +116,8 @@ class Playlist extends Model
       protected $created_at;
       protected $deleted_at;
       
+      protected $appends = array('verses');
+
       public function getFeaturedAttribute($featured)
       {
         return (bool) $featured;
@@ -124,6 +126,11 @@ class Playlist extends Model
       public function getFollowingAttribute($following)
       {
         return (bool) $following;
+      }
+
+      public function getVersesAttribute()
+      {
+        return $this['items']->sum('verses');
       }
 
       public function user()


### PR DESCRIPTION
# Description
- Added `getVersesAttribute` function to Playlist Model
- Added `getVersesAttribute` function to PlaylistItems Model
- Updated documentation

## Issue Link
Original Story: [FCBH-659](https://fullstacklabs.atlassian.net/browse/FCBH-659) 
Review Story: [FCBH-735](https://fullstacklabs.atlassian.net/browse/FCBH-735) 

## How Do I QA This
- On your local environment run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test `/playlists` GET  endpoint and check that now the total number of verses appears
- Test `/playlists/{playlist_id}`  GET  endpoint and check that now the number of verses per item appears

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

