### PR TITLE
FCBH-717/744 Incorrect fileset paths / Bible text retrieving wrong results

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -424,7 +424,7 @@ class PlansController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
-        $plan = Plan::where('user_id', $user->id)->where('id', $plan_id)->first();
+        $plan = Plan::where('id', $plan_id)->first();
 
         if (!$plan) {
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -212,12 +212,17 @@ class BibleFileset extends Model
 
     public function scopeUniqueFileset($query, $id = null, $asset_id = null, $fileset_type = null, $ambigious_fileset_type = false, $testament_filter = null)
     {
-        return $query->when($id, function ($query) use ($id) {
-            $query->where(function ($query) use ($id) {
+        $version = (int)request()->v;
+        return $query->when($id, function ($query) use ($id, $version) {
+            $query->where(function ($query) use ($id, $version) {
+                if($version  === 2) {
                     $query->where('bible_filesets.id', $id)
                           ->orWhere('bible_filesets.id', substr($id, 0, -4))
                           ->orWhere('bible_filesets.id', 'like',  substr($id, 0, 6))
                           ->orWhere('bible_filesets.id', 'like', substr($id, 0, -2).'%');
+                } else {
+                    $query->where('bible_filesets.id', $id);
+                }
             });
         })
         ->when($asset_id, function ($query) use ($asset_id) {


### PR DESCRIPTION
# Description
- Fixed BibleFileset Scope filter by changing the query when the version of the api is `2`
- Tested by mitmproxy the backwards compatibility
## Issue Link
Original Story: [FCBH-717](https://fullstacklabs.atlassian.net/browse/FCBH-717) 
Original Story: [FCBH-744](https://fullstacklabs.atlassian.net/browse/FCBH-744) 
Review Story: [FCBH-745](https://fullstacklabs.atlassian.net/browse/FCBH-745) 
Review Story: [FCBH-752](https://fullstacklabs.atlassian.net/browse/FCBH-752) 

## How Do I QA This
**FCBH-744** 
- On your local environment run `http://api.dbp.test/bibles/filesets/ENGNIV/GEN/1?v=4&key={API_KEY}` and verify that the endpoint retrieves the verses
- Run `http://api.dbp.test/text/verse?dam_id=SPNBDAO2ET&book_id=Gen&chapter_id=2&key={API_KEY}&v=2` and that the endpoint retrieves the verses (backwards compatibility)

**FCBH-717**
- Run `http://api.dbp.test/bibles/filesets/CUKNVSN2DA16?v=4&key={API_KEY}&format=json&book_id=MAT&chapter_id=1&type=audio_drama` and verify that the result is the same than `http://api.dbp4.org/bibles/filesets/CUKNVSN2DA16?v=4&key={API_KEY}&format=json&book_id=MAT&chapter_id=1&type=audio_drama`


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

