### PR TITLE
FCBH-660 Calculate playlist item length

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -488,7 +488,7 @@ class PlaylistsController extends APIController
         $created_playlist_items = [];
 
         foreach ($playlist_items as $playlist_item) {
-            $created_playlist_items[] = PlaylistItems::create([
+            $created_playlist_item = PlaylistItems::create([
                 'playlist_id'       => $playlist->id,
                 'fileset_id'        => $playlist_item->fileset_id,
                 'book_id'           => $playlist_item->book_id,
@@ -497,6 +497,8 @@ class PlaylistsController extends APIController
                 'verse_start'       => $playlist_item->verse_start,
                 'verse_end'         => $playlist_item->verse_end
             ]);
+            $created_playlist_item->calculateDuration()->save();
+            $created_playlist_items[] = $created_playlist_item;
         }
 
         return $this->reply($single_item ? $created_playlist_items[0] : $created_playlist_items);


### PR DESCRIPTION
# Description
- Added `calculateDuration` function to `PlaylistItem` model in order to calculate the duration of a PlayListItem based on the `bible_file_timestamps` table
- If `bible_file_timestamps` doesn't have timestamps information for the query the duration value will be 0


## Issue Link
Original Story: [FCBH-660](https://fullstacklabs.atlassian.net/browse/FCBH-660) 
Review Story: [FCBH-754](https://fullstacklabs.atlassian.net/browse/FCBH-754) 

## How Do I QA This
- On your local environment call `/playlists/{playlist_id}/item` and verify that now the duration is calculated and saved (Not all the filesets have timestamps)

**Body request example:** 
```javascript
[
  {
    "fileset_id": "ENGESVO2DA",
    "book_id": "GEN",
    "chapter_start": 1,
    "chapter_end": 3,
    "verse_start": 10,
    "verse_end": 1
  },
  {
    "fileset_id": "ENGESVO2DA",
    "book_id": "GEN",
    "chapter_start": 4,
    "chapter_end": 7,
    "verse_start": 1,
    "verse_end": 5
  }
]
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

