### PR TITLE
FCBH-669 Add log out endpoint that eliminates token access

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -576,7 +576,7 @@ class PlansController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
-        $plan = Plan::where('user_id', $user->id)->where('id', $plan_id)->first();
+        $plan = Plan::where('id', $plan_id)->first();
 
         if (!$plan) {
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -583,7 +583,7 @@ class PlansController extends APIController
         }
 
 
-        $user_plan = UserPlan::where('plan_id', $plan_id)->where('user_id', $user->id)->first();
+        $user_plan = UserPlan::where('plan_id', $plan->id)->where('user_id', $user->id)->first();
 
         if (!$user_plan) {
             return $this->setStatusCode(404)->replyWithError('User Plan Not Found');
@@ -592,7 +592,7 @@ class PlansController extends APIController
         $start_date = checkParam('start_date');
 
         $user_plan->reset($start_date)->save();
-        $plan = $this->getPlan($plan_id, $user);
+        $plan = $this->getPlan($plan->id, $user);
         return $this->reply($plan);
     }
 

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -91,7 +91,7 @@ class UserPlan extends Model
                 $completed = $plan_day->verifyDayCompleted();
                 return $completed;
             });;
-        $this->percentage_completed = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
+        $this->attributes['percentage_completed'] = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
         return $this;
     }
 
@@ -101,8 +101,8 @@ class UserPlan extends Model
             ->map(function ($plan_day) {
                 $plan_day->unComplete();
             });;
-        $this->percentage_completed = 0;
-        $this->start_date = $start_date;
+        $this->attributes['percentage_completed'] = 0;
+        $this->attributes['start_date'] = $start_date;
         return $this;
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,8 @@ Route::name('v4_user.oAuth')->get('/login/{driver}',                            
 Route::name('v4_user.oAuthCallback')->get('/login/{driver}/callback',              'User\SocialController@callback');
 Route::name('v4_user.password_reset')->post('users/password/reset/{token?}',       'User\PasswordsController@validatePasswordReset');
 Route::name('v4_user.password_email')->post('users/password/email',                'User\PasswordsController@triggerPasswordResetEmail');
+Route::name('v4_user.logout')
+    ->middleware('APIToken:check')->post('/logout',                                'User\UsersController@logout');
 
 // VERSION 4 | Accounts
 Route::name('v4_user_accounts.index')->get('accounts',                             'User\AccountsController@index');


### PR DESCRIPTION
# Description
- Added `logout` endpoint in order to revoke the access of the api_token if the user logs out.
- Added documentation to endpoint
- Fixed bugs on reset plan endpoint

## Issue Link
Original Story: [FCBH-669](https://fullstacklabs.atlassian.net/browse/FCBH-669) 
Review Story: [FCBH-761](https://fullstacklabs.atlassian.net/browse/FCBH-761) 

## How Do I QA This
- Run `http://dbp.test/open-api-v4.json` to get the new documentation
- `login` with a valid user to get an `api_token`
- Call `/logout` and verify that the `api_token` now don't have access
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

