### PR TITLE
FCBH-511 Backwards Compatibility (iOS) - New User Accessing Highlights Crashes App

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -215,7 +215,7 @@ class BibleFileset extends Model
         $version = (int)request()->v;
         return $query->when($id, function ($query) use ($id, $version) {
             $query->where(function ($query) use ($id, $version) {
-                if($version  === 2) {
+                if($version  <= 2) {
                     $query->where('bible_filesets.id', $id)
                           ->orWhere('bible_filesets.id', substr($id, 0, -4))
                           ->orWhere('bible_filesets.id', 'like',  substr($id, 0, 6))


### PR DESCRIPTION
# Description
- Production app is calling the highlights with `v=1` parameter
```javascript
GET http://api.bible.is/annotations/highlight?dbt_data=1&dbt_version=2&hash={GENERATED_HASH}&key={API_KEY}&limit=1000&offset=0&reply=json&u
                        ser_id=1149374&v=1
```
- Added `v1` support to scopeUniqueFileset function on BibleFileset model


## Issue Link
Original Story: [FCBH-511](https://fullstacklabs.atlassian.net/browse/FCBH-511) 
Review Story: [FCBH-767](https://fullstacklabs.atlassian.net/browse/FCBH-767) 

## How Do I QA This
- Run `http://api.dbp.local/annotations/highlight?dbt_data=1&dbt_version=2&hash={GENERATED_HASH}&key={API_KEY}&limit=1000&offset=0&reply=json&u
                        ser_id=1149374&v=1` and verify that you get highlights results
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

