### PR TITLE
FCBH-684 Add INSTALL.md to the frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ API_URL=api.dbp.test
 APP_URL_PODCAST=https://bible.build
 APP_SITE_CONTACT=info@fcbhmail.net
 APP_SERVER_NAME=Travis
-GETTING_STARTED_URL=
+GET_STARTED_URL=
 
 NODE_PATH=/usr/local
 LOG_CHANNEL=stack

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ API_URL=api.dbp.test
 APP_URL_PODCAST=https://bible.build
 APP_SITE_CONTACT=info@fcbhmail.net
 APP_SERVER_NAME=Travis
+GETTING_STARTED_URL=
 
 NODE_PATH=/usr/local
 LOG_CHANNEL=stack

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,7 @@ return [
     'url' => env('APP_URL', 'http://localhost'),
     'url_podcast' => env('APP_URL_PODCAST', 'https://dbp4.org'),
     'api_url' => env('API_URL', 'https://api.dbp4.org'),
+    'getting_started_url' => env('GETTING_STARTED_URL', 'https://github.com/faithcomesbyhearing/dbp/blob/master/doc/STARTING.md.'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -56,7 +56,7 @@ return [
     'url' => env('APP_URL', 'http://localhost'),
     'url_podcast' => env('APP_URL_PODCAST', 'https://dbp4.org'),
     'api_url' => env('API_URL', 'https://api.dbp4.org'),
-    'getting_started_url' => env('GETTING_STARTED_URL', 'https://github.com/faithcomesbyhearing/dbp/blob/master/doc/STARTING.md.'),
+    'get_started_url' => env('GET_STARTED_URL', 'https://github.com/faithcomesbyhearing/dbp/blob/master/doc/STARTING.md'),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,7 +8,7 @@
         'size'      => 'medium',
         'image'     => '/images/dbp_icon.svg',
         'actions'   => [
-            route('docs.getting_started') => 'Get Started'
+            config('app.getting_started_url') => 'Get Started'
         ]
     ])
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -8,7 +8,7 @@
         'size'      => 'medium',
         'image'     => '/images/dbp_icon.svg',
         'actions'   => [
-            config('app.getting_started_url') => 'Get Started'
+            config('app.get_started_url') => 'Get Started'
         ]
     ])
 


### PR DESCRIPTION
# Description
- Added `get_started_url` to the app config file to allow an easy change or update of the getting started URL
- Now `https://github.com/faithcomesbyhearing/dbp/blob/master/doc/STARTING.md` is the link by default


## Issue Link
Original Story: [FCBH-684](https://fullstacklabs.atlassian.net/browse/FCBH-684) 
Review Story: [FCBH-768](https://fullstacklabs.atlassian.net/browse/FCBH-768) 

## How Do I QA This
- Run `http://dbp.test/`, click on `Get Started` and verify that the app navigates to `https://github.com/faithcomesbyhearing/dbp/blob/master/doc/STARTING.md`
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

