### PR TITLE
FCBH-682 Error messaging

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,10 +8,11 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Support\Facades\Log;
 use Mail;
-use Response;
+use ReflectionClass;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Debug\ExceptionHandler as SymfonyExceptionHandler;
-use Illuminate\Support\Arr;
+use Symfony\Component\HttpFoundation\Response;
+
 class Handler extends ExceptionHandler
 {
     /**
@@ -67,19 +68,54 @@ class Handler extends ExceptionHandler
             return parent::render($request, $exception);
         }
 
-        $message = $exception->getMessage();
-        if ($message === '') {
-            $message = 'Something has gone wrong';
-        }
-        if (\is_object($message)) {
-            $message = $message->toArray();
+        return $this->handleApiException($request, $exception);
+    }
+
+    private function handleApiException($request, Exception $exception)
+    {
+        $exception = $this->prepareException($exception);
+
+        if ($exception instanceof \Illuminate\Http\Exception\HttpResponseException) {
+            $exception = $exception->getResponse();
         }
 
-        return response()->json([
-            'errors'      => Arr::wrap($message),
-            'status_code' => method_exists($exception, 'getStatusCode') ? $exception->getStatusCode() : $exception->getCode(),
-            'host_name'   => gethostname()
-        ], method_exists($exception, 'getStatusCode') ? $exception->getStatusCode() : http_response_code(500));
+        if ($exception instanceof \Illuminate\Auth\AuthenticationException) {
+            $exception = $this->unauthenticated($request, $exception);
+        }
+
+        if ($exception instanceof \Illuminate\Validation\ValidationException) {
+            $exception = $this->convertValidationExceptionToResponse($exception, $request);
+        }
+
+        return $this->customApiResponse($exception);
+    }
+
+    private function customApiResponse($exception)
+    {
+        if (method_exists($exception, 'getStatusCode')) {
+            $statusCode = $exception->getStatusCode();
+        } else {
+            $statusCode = Response::HTTP_INTERNAL_SERVER_ERROR;
+        }
+
+        $response = [];
+        $response['error'] = Response::$statusTexts[$statusCode];
+
+        $class = new ReflectionClass(new Response());
+        $constants = (object) $class->getConstants();
+        
+        foreach ($constants as $key => $value) {
+            if($value === $statusCode){
+                $response['type'] = $key;
+            }
+        }
+
+        if (config('app.debug')) {
+            $response['trace'] = $exception->getTrace();
+        }
+        $response['status_code'] = method_exists($exception, 'getStatusCode') ? $exception->getStatusCode() : $exception->getCode();
+        $response['host_name'] = gethostname();
+        return response()->json($response, $statusCode);
     }
 
     /**
@@ -93,7 +129,7 @@ class Handler extends ExceptionHandler
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         if ($request->expectsJson()) {
-            return response()->json(['error' => 'Unauthenticated.'], 401);
+            return response()->json(['error' => 'Unauthenticated.'], Response::HTTP_UNAUTHORIZED);
         }
 
         return redirect()->guest(route('login'));

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -11,6 +11,7 @@ use Mail;
 use ReflectionClass;
 use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\Debug\ExceptionHandler as SymfonyExceptionHandler;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Response;
 
 class Handler extends ExceptionHandler
@@ -103,11 +104,22 @@ class Handler extends ExceptionHandler
 
         $class = new ReflectionClass(new Response());
         $constants = (object) $class->getConstants();
-        
+
         foreach ($constants as $key => $value) {
-            if($value === $statusCode){
+            if ($value === $statusCode) {
                 $response['type'] = $key;
             }
+        }
+
+        if ($statusCode === Response::HTTP_UNPROCESSABLE_ENTITY) {
+            $message = $exception->getMessage();
+            if($message === ''){
+                $message = Response::$statusTexts[$statusCode];
+            }
+            if (\is_object($message)) {
+                $message = $message->toArray();
+            }
+            $response['error'] = $message;
         }
 
         if (config('app.debug')) {

--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -243,7 +243,7 @@ class APIController extends Controller
 
         return response()->json(['error' => [
             'message'     => $message,
-            'status code' => $this->statusCode,
+            'status_code' => $this->statusCode,
             'action'      => $action ?? ''
         ]], $this->statusCode);
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -249,12 +249,3 @@ Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
 Route::name('v4_plans_days.complete')
     ->middleware('APIToken:check')->post('plans/day/{day_id}/complete',             'Plan\PlansController@completeDay');
-
-// Errors
-
-Route::fallback(function () {
-    return response()->json(['error' => [
-        'message' => 'Route Not Found.',
-        'status_code' => 404
-    ]], 404);
-});

--- a/routes/api.php
+++ b/routes/api.php
@@ -249,3 +249,12 @@ Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
 Route::name('v4_plans_days.complete')
     ->middleware('APIToken:check')->post('plans/day/{day_id}/complete',             'Plan\PlansController@completeDay');
+
+// Errors
+
+Route::fallback(function () {
+    return response()->json(['error' => [
+        'message' => 'Route Not Found.',
+        'status_code' => 404
+    ]], 404);
+});


### PR DESCRIPTION
# Description
- Added friendly message for each error type
- Added type error to the response
- Removed all SQL error from the response

## Issue Link
Original Story: [FCBH-682](https://fullstacklabs.atlassian.net/browse/FCBH-682) 
Review Story: [FCBH-798](https://fullstacklabs.atlassian.net/browse/FCBH-798) 

## How Do I QA This
1) Change your `.env` file

```javascript
APP_ENV=production
APP_DEBUG=false
```
2) Run `https://api.dbp.test/test_test` to get a `404` error because the route doesn't exist

![image](https://user-images.githubusercontent.com/41348080/64627937-216fe280-d3b6-11e9-9e25-2eeeec5b50fe.png)

3) For testing purposes change the name of one table for example (user_notes to user_notess): 

![image](https://user-images.githubusercontent.com/41348080/64628109-71e74000-d3b6-11e9-9e34-3a62176af6d5.png)
Now run `https://api.dbp.test/users/1118817/notes?page=1&key={API_KEY}&v=4` and verify you get a 500 error without SQL text, we just get a code that will help us to find the issue

![image](https://user-images.githubusercontent.com/41348080/64628351-dbffe500-d3b6-11e9-8938-a741367ace93.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

