### PR TITLE
FCBH-694 Language Ordering

### DIFF
--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -89,10 +89,11 @@ class LanguagesController extends APIController
         $cache_string = 'v'.$this->v.'_l_'.$country.$code.$GLOBALS['i18n_id'].$sort_by.$name.
                         $show_restricted.$include_alt_names.$asset_id.$access_control->string;
 
-        $order = $country ? 'country_population.population' : 'name';
+        $order = $country ? 'country_population.population' : 'languages.name';
+        $order_dir = $country ? 'desc' : 'asc';
         $select_country_population = $country ? 'country_population.population' : 'null';
 
-        $languages = \Cache::remember($cache_string, now()->addDay(), function () use ($country, $include_alt_names, $asset_id, $code, $name, $show_restricted, $access_control, $order, $select_country_population) {
+        $languages = \Cache::remember($cache_string, now()->addDay(), function () use ($country, $include_alt_names, $asset_id, $code, $name, $show_restricted, $access_control, $order, $order_dir, $select_country_population) {
             $languages = Language::includeCurrentTranslation()
                 ->includeAutonymTranslation()
                 ->includeExtraLanguages($show_restricted, $access_control, $asset_id)
@@ -101,7 +102,7 @@ class LanguagesController extends APIController
                 ->filterableByCountry($country)
                 ->filterableByIsoCode($code)
                 ->filterableByName($name)
-                ->orderBy($order, 'desc')
+                ->orderBy($order, $order_dir)
                 ->select([
                     'languages.id',
                     'languages.glotto_id',
@@ -109,7 +110,7 @@ class LanguagesController extends APIController
                     'languages.name as backup_name',
                     'current_translation.name as name',
                     'autonym.name as autonym',
-                    \DB::raw($select_country_population.' as country_population'),
+                    \DB::raw($select_country_population.' as country_population')
                 ])->withCount('bibles')->withCount('filesets')->get();
             return fractal($languages, new LanguageTransformer(), $this->serializer);
         });

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -90,7 +90,7 @@ class LanguagesController extends APIController
                         $show_restricted.$include_alt_names.$asset_id.$access_control->string;
 
         $order = $country ? 'country_population.population' : 'name';
-        $select_country_population = $country ? 'country_population.population' : '';
+        $select_country_population = $country ? 'country_population.population' : 'null';
 
         $languages = \Cache::remember($cache_string, now()->addDay(), function () use ($country, $include_alt_names, $asset_id, $code, $name, $show_restricted, $access_control, $order, $select_country_population) {
             $languages = Language::includeCurrentTranslation()
@@ -109,7 +109,7 @@ class LanguagesController extends APIController
                     'languages.name as backup_name',
                     'current_translation.name as name',
                     'autonym.name as autonym',
-                    $select_country_population.' as country_population',
+                    \DB::raw($select_country_population.' as country_population'),
                 ])->withCount('bibles')->withCount('filesets')->get();
             return fractal($languages, new LanguageTransformer(), $this->serializer);
         });

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -362,6 +362,18 @@ class Language extends Model
         });
     }
 
+    public function scopeIncludeCountryPopulation($query, $country)
+    {
+        return $query->when($country, function ($query) use ($country) {
+        $query->leftJoin('country_language as country_population', function ($join) use ($country) {
+            $join->on('country_population.language_id', '=', 'languages.id')
+                    ->where('country_population.country_id', '=', $country)
+                    ->limit(1);
+            });
+        });
+
+    }
+
     public function scopeFilterableByIsoCode($query, $code)
     {
         return $query->when($code, function ($query) use ($code) {
@@ -384,6 +396,13 @@ class Language extends Model
         return $query->when($name, function ($query) use ($name, $name_expression) {
             $query->where('languages.name', 'like', $name_expression);
         });
+    }
+
+    public function countryPopulation()
+    {
+        return $this->hasOne(CountryLanguage::class, 'language_id')
+                    ->where('language_id', $this->id)
+                    ->select('country_id', 'population');
     }
 
     public function population()

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -366,9 +366,8 @@ class Language extends Model
     {
         return $query->when($country, function ($query) use ($country) {
         $query->leftJoin('country_language as country_population', function ($join) use ($country) {
-            $join->on('country_population.language_id', '=', 'languages.id')
-                    ->where('country_population.country_id', '=', $country)
-                    ->limit(1);
+            $join->on('country_population.language_id', 'languages.id')
+                    ->where('country_population.country_id', $country);
             });
         });
 
@@ -396,13 +395,6 @@ class Language extends Model
         return $query->when($name, function ($query) use ($name, $name_expression) {
             $query->where('languages.name', 'like', $name_expression);
         });
-    }
-
-    public function countryPopulation()
-    {
-        return $this->hasOne(CountryLanguage::class, 'language_id')
-                    ->where('language_id', $this->id)
-                    ->select('country_id', 'population');
     }
 
     public function population()

--- a/app/Transformers/LanguageTransformer.php
+++ b/app/Transformers/LanguageTransformer.php
@@ -122,8 +122,11 @@ class LanguageTransformer extends BaseTransformer
                     'autonym'    => $language->autonym,
                     'bibles'     => $language->bibles_count,
                     'filesets'   => $language->filesets_count,
-                    'country_population' => $language->country_population
                 ];
+
+                if($language->country_population)
+                $output['country_population'] = $language->country_population;
+                
                 if ($language->relationLoaded('translations')) {
                     $output['translations'] = $language->translations->pluck('name', 'language_translation_id');
                 }

--- a/app/Transformers/LanguageTransformer.php
+++ b/app/Transformers/LanguageTransformer.php
@@ -115,13 +115,14 @@ class LanguageTransformer extends BaseTransformer
             default:
             case 'v4_languages.all':
                 $output = [
-                    'id'        => $language->id,
-                    'glotto_id' => $language->glotto_id,
-                    'iso'       => $language->iso,
-                    'name'      => $language->name ?? $language->backup_name,
-                    'autonym'   => $language->autonym,
-                    'bibles'    => $language->bibles_count,
-                    'filesets'  => $language->filesets_count,
+                    'id'         => $language->id,
+                    'glotto_id'  => $language->glotto_id,
+                    'iso'        => $language->iso,
+                    'name'       => $language->name ?? $language->backup_name,
+                    'autonym'    => $language->autonym,
+                    'bibles'     => $language->bibles_count,
+                    'filesets'   => $language->filesets_count,
+                    'country_population' => $language->country_population
                 ];
                 if ($language->relationLoaded('translations')) {
                     $output['translations'] = $language->translations->pluck('name', 'language_translation_id');


### PR DESCRIPTION
Added language ordering by country if the country param is sent in.  Jon thought this was already done, but languages were always returned ordered by their id.  Now they are either returned alphabetically if all languages are gotten or they are returned in country language population order if the country code is specified.