### PR TITLE
FCBH-550 Filter all endpoints for permissions

### DIFF
--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -351,13 +351,13 @@ class Language extends Model
     {
         return $query->when(!$show_restricted, function ($query) use ($access_control, $asset_id) {
             $query->whereHas('filesets', function ($query) use ($access_control, $asset_id) {
-            $query->whereIn('hash_id', $access_control->hashes);
-            if ($asset_id) {
-                $asset_id = explode(',', $asset_id);
-                $query->whereHas('fileset', function ($query) use ($asset_id) {
-                    $query->whereIn('asset_id', $asset_id);
-                });
-            }
+                $query->whereIn('hash_id', $access_control->hashes);
+                if ($asset_id) {
+                    $asset_id = explode(',', $asset_id);
+                    $query->whereHas('fileset', function ($query) use ($asset_id) {
+                        $query->whereIn('asset_id', $asset_id);
+                    });
+                }
             });
         });
     }


### PR DESCRIPTION
# Description
- Verified that the languages, bibles and volumes content is being filtered by permissions
- Added permissions filter to detail endpoints `blibes/{id}`, `languages/{id}`
- Added `show_all` parameter to `languages` and `bibles`
- Updated documentation

## Issue Link
Original Story: [FCBH-550](https://fullstacklabs.atlassian.net/browse/FCBH-550) 
Review Story: [FCBH-822](https://fullstacklabs.atlassian.net/browse/FCBH-822) 

## How Do I QA This
- Run `http://dbp.test/open-api-v4.json` to get the new documentation
- Add `show_all` parameter to `/languages` and `/bibles` endpoint and verify that all the content is being retrieved
- Run `/languages/{id}` and `/bibles/{id}` on a restricted bible or language and verify that now is not retrieved 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
