### PR TITLE
FCBH-806 Jesus Film API Additions

### DIFF
--- a/app/Traits/ArclightConnection.php
+++ b/app/Traits/ArclightConnection.php
@@ -4,7 +4,7 @@ namespace App\Traits;
 
 trait ArclightConnection
 {
-    private function fetchArclight($path, $language_id = null, $include_refs = false)
+    private function fetchArclight($path, $language_id = null, $include_refs = false, $parameters = '')
     {
         $base_url = 'https://api.arclight.org/v2/';
         $key      = config('services.arclight.key');
@@ -19,6 +19,8 @@ trait ArclightConnection
             $refs = implode(',', array_keys($this->getIdReferences()));
             $path .= '&ids='.$refs;
         }
+
+        $path .= '&'.$parameters;
 
         $results = json_decode(file_get_contents($path));
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -199,8 +199,8 @@ Route::name('v4_resources.index')->get('resources',                             
 Route::name('v4_resources.show')->get('resources/{resource_id}',                   'Organization\ResourcesController@show');
 
 Route::name('v4_video_jesus_film_languages')->get('arclight/jesus-film/languages', 'Bible\VideoStreamController@jesusFilmsLanguages');
-Route::name('v4_video_jesus_film_language')->get('arclight/jesus-film/chapters',   'Bible\VideoStreamController@jesusFilmChapters');
-Route::name('v4_video_jesus_film_language')->get('arclight/jesus-film',            'Bible\VideoStreamController@jesusFilmFile');
+Route::name('v4_video_jesus_film_chapters')->get('arclight/jesus-film/chapters',   'Bible\VideoStreamController@jesusFilmChapters');
+Route::name('v4_video_jesus_film_file')->get('arclight/jesus-film',                'Bible\VideoStreamController@jesusFilmFile');
 
 // VERSION 4 | API METADATA
 Route::name('v4_api.versions')->get('/api/versions',                               'HomeController@versions');


### PR DESCRIPTION
# Description
- Updated `arclight/jesus-film/chapters` endpoint:
    - Added metadata (thumbs, descriptions, file url)
    - Added `iso` parameter
    - Added cache

## Issue Link
Original Story: [FCBH-806](https://fullstacklabs.atlassian.net/browse/FCBH-654) 
Review Story: [FCBH-847](https://fullstacklabs.atlassian.net/browse/FCBH-847) 

## How Do I QA This
- On your local environment run `https://api.dbp.test/arclight/jesus-film/chapters?v=4&key={API_KEY}&iso=spa` and verify that now you get the chapter metadata sending the `iso` parameter
- Run `https://api.dbp.test/arclight/jesus-film/chapters?v=4&key={API_KEY}&arclight_id=21046` and verify that the endpoint also works with `arclight_id` language parameter

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
