### PR TITLE
FCBH-668 Multiple login tokens per Users

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -8,6 +8,7 @@ use App\Mail\ProjectVerificationEmail;
 use App\Models\User\Project;
 use App\Models\User\ProjectMember;
 use App\Models\User\Account;
+use App\Models\User\APIToken;
 use App\Models\User\Role;
 use App\Models\User\User;
 use App\Models\User\Key;
@@ -197,9 +198,10 @@ class UsersController extends APIController
         }
 
         $token = Str::random(60);
-        $user->forceFill([
+        APIToken::create([
+            'user_id'   => $user->id,
             'api_token' => hash('sha256', $token),
-        ])->save();
+        ]);
 
         $user->api_token = $token;
 
@@ -245,6 +247,9 @@ class UsersController extends APIController
         $user->forceFill([
             'api_token' => null,
         ])->save();
+
+        $api_token = APIToken::where('api_token', hash('sha256', $request->api_token))->first();
+        $api_token->delete();
 
         return $this->reply('User logged out');
     }
@@ -343,9 +348,11 @@ class UsersController extends APIController
         }
 
         $token = Str::random(60);
-        $user->forceFill([
+
+        APIToken::create([
+            'user_id'   => $user->id,
             'api_token' => hash('sha256', $token),
-        ])->save();
+        ]);
 
         $user->api_token = $token;
 

--- a/app/Http/Middleware/APIToken.php
+++ b/app/Http/Middleware/APIToken.php
@@ -39,7 +39,7 @@ class APIToken
      */
     public function handle($request, Closure $next, $type = '')
     {
-        $guard = 'api';
+        $guard = 'tokens';
 
         if ($type === 'check') {
             if (!$this->auth->guard($guard)->check()) {

--- a/app/Models/User/ApiToken.php
+++ b/app/Models/User/ApiToken.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models\User;
+
+use Illuminate\Database\Eloquent\Model;
+
+class APIToken extends Model
+{
+    protected $connection = 'dbp_users';
+    protected $table = 'user_api_tokens';
+    protected $fillable = ['api_token','user_id'];
+    protected $user_id;
+    protected $api_token;
+    protected $created_at;
+    public $timestamps = false;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use App\Services\Auth\APITokenGuard;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Auth;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -24,6 +26,9 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        //
+
+        Auth::extend('tokens', function ($app, $name, array $config) {
+            return new APITokenGuard(Auth::createUserProvider($config['provider']), $app->make('request'));
+        });
     }
 }

--- a/app/Services/Auth/ApiTokenGuard.php
+++ b/app/Services/Auth/ApiTokenGuard.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Services\Auth;
+
+use App\Models\User\APIToken;
+use Illuminate\Auth\GuardHelpers;
+use Illuminate\Http\Request;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\UserProvider;
+
+class APITokenGuard implements Guard
+{
+    use GuardHelpers;
+
+    protected $request;
+    protected $provider;
+    protected $user;
+    protected $inputKey;
+
+
+    public function __construct(UserProvider $provider, Request $request)
+    {
+        $this->request = $request;
+        $this->provider = $provider;
+        $this->user = null;
+        $this->inputKey = 'api_token';
+    }
+
+    public function check()
+    {
+        return !is_null($this->user());
+    }
+
+    public function user()
+    {
+        if (!is_null($this->user)) {
+            return $this->user;
+        }
+
+        $user = null;
+        $token = $this->getTokenForRequest();
+
+        if (!empty($token)) {
+            $api_token = APIToken::where('api_token', hash('sha256', $token))->first();
+            if ($api_token) {
+                $user = $this->provider->retrieveById($api_token->user_id);
+            }
+        }
+        return $this->user = $user;
+    }
+
+    public function getTokenForRequest()
+    {
+        $token = $this->request->query($this->inputKey);
+
+        if (empty($token)) {
+            $token = $this->request->input($this->inputKey);
+        }
+
+        if (empty($token)) {
+            $token = $this->request->bearerToken();
+        }
+
+        if (empty($token)) {
+            $token = $this->request->getPassword();
+        }
+
+        return $token;
+    }
+
+    public function validate(array $credentials = [])
+    {
+        if (empty($credentials[$this->inputKey])) {
+            return false;
+        }
+
+        $token =  $credentials[$this->inputKey];
+        $api_token = APIToken::where('api_token', hash('sha256', $token))->first();
+
+        if (!$api_token) {
+            return false;
+        }
+
+        if ($this->provider->retrieveById($api_token->user_id)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+
+        return $this;
+    }
+}

--- a/config/auth.php
+++ b/config/auth.php
@@ -46,6 +46,11 @@ return [
             'provider' => 'users',
             'hash' => true,
         ],
+
+        'tokens' => [
+            'driver' => 'tokens',
+            'provider' => 'users',
+        ],
     ],
 
     /*

--- a/database/migrations/2019_09_21_212431_create_user_api_tokens_table.php
+++ b/database/migrations/2019_09_21_212431_create_user_api_tokens_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUserApiTokensTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::connection('dbp_users')->hasTable('user_api_tokens')) {
+            Schema::connection('dbp_users')->create('user_api_tokens', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id', 'FK_users_user_api_tokens')->references('id')->on(config('database.connections.dbp_users.database').'.users')->onUpdate('cascade');
+                $table->string('api_token', 80)->unique();
+                $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->dropIfExists('user_api_tokens');
+    }
+}


### PR DESCRIPTION
# Description
- Created the migration to add a new table `user_api_tokens` in order to allow the user to log in on different devices
- Created new APIToken Guard and Model
- Updated APIToken middleware to use the new Guard
- Updated UsersController to use the new APIToken model on `login/register/logout` endpoints

## Issue Link
Original Story: [FCBH-668](https://fullstacklabs.atlassian.net/browse/FCBH-668) 
Review Story: [FCBH-857](https://fullstacklabs.atlassian.net/browse/FCBH-857) 

## How Do I QA This

- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Test that now you receive an `api_token` on login and registration as usual
- Try to get `plans`, `playlists`
- Try to `logout`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

