### PR TITLE
FCBH-528 HLS Audio Support and Serving

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -332,9 +332,9 @@ class BibleFileSetsController extends APIController
      */
     private function generateFilesetChapters($fileset, $fileset_chapters, $bible, $asset_id)
     {
-        if ($fileset->set_type_code === 'video_stream') {
+        if ($fileset->set_type_code === 'video_stream' || $fileset->set_type_code === 'audio_stream') {
             foreach ($fileset_chapters as $key => $fileSet_chapter) {
-                $fileset_chapters[$key]->file_name = route('v4_video_stream', ['fileset_id' => $fileset->id, 'file_id' => $fileSet_chapter->id]);
+                $fileset_chapters[$key]->file_name = route('v4_media_stream', ['fileset_id' => $fileset->id, 'file_id' => $fileSet_chapter->id]);
             }
         }
 

--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -332,13 +332,14 @@ class BibleFileSetsController extends APIController
      */
     private function generateFilesetChapters($fileset, $fileset_chapters, $bible, $asset_id)
     {
-        if ($fileset->set_type_code === 'video_stream' || $fileset->set_type_code === 'audio_stream') {
+        $is_stream = $fileset->set_type_code === 'video_stream' || $fileset->set_type_code === 'audio_stream';
+        if ($is_stream) {
             foreach ($fileset_chapters as $key => $fileSet_chapter) {
                 $fileset_chapters[$key]->file_name = route('v4_media_stream', ['fileset_id' => $fileset->id, 'file_id' => $fileSet_chapter->id]);
             }
         }
 
-        if ($fileset->set_type_code !== 'video_stream') {
+        if (!$is_stream) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
                 $fileset_chapters[$key]->file_name = $this->signedUrl($this->signedPath($bible, $fileset, $fileset_chapter), $asset_id, random_int(0, 10000000));
             }

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -105,9 +105,6 @@ class StreamController extends APIController
         }
         $current_file .= "\n#EXT-X-ENDLIST";
 
-        echo $current_file;
-        die();
-
         return response($current_file, 200, [
             'Content-Disposition' => 'attachment; filename="' . $file->file_name . '"',
             'Content-Type'        => 'application/x-mpegURL'

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -42,7 +42,10 @@ class StreamController extends APIController
             if ($bandwidth->resolution_width) {
                 $current_file .= ',RESOLUTION=' . $bandwidth->resolution_width . "x$bandwidth->resolution_height";
             }
-            $current_file .= ",CODECS=\"$bandwidth->codec\"\n$bandwidth->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id;
+            if ($bandwidth->codec) {
+                $current_file .= ",CODECS=\"$bandwidth->codec\"";
+            }
+            $current_file .= "\n$bandwidth->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id;
         }
 
         return response($current_file, 200, [

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers\Bible;
+
+use App\Http\Controllers\APIController;
+use App\Models\Bible\BibleFile;
+use App\Models\Bible\BibleFileset;
+use App\Traits\CallsBucketsTrait;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+class StreamController extends APIController
+{
+    use CallsBucketsTrait;
+
+    /**
+     *
+     * Generate the parent m3u8 file which contains the various resolution m3u8 files
+     *
+     * @param null $id
+     * @param null $file_id
+     *
+     * @return $this
+     */
+    public function index($id = null, $file_id = null)
+    {
+        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh_video.bucket');
+
+        $fileset = BibleFileset::uniqueFileset($id, $asset_id)->select('hash_id', 'id')->first();
+        if (!$fileset) {
+            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+        }
+
+        $file = BibleFile::with('streamBandwidth')->where('hash_id', $fileset->hash_id)->where('id', $file_id)->first();
+        if (!$file) {
+            return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id]));
+        }
+
+        $current_file = '#EXTM3U';
+        foreach ($file->streamBandwidth as $bandwidth) {
+            $current_file .= "\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=$bandwidth->bandwidth";
+            if ($bandwidth->resolution_width) {
+                $current_file .= ',RESOLUTION=' . $bandwidth->resolution_width . "x$bandwidth->resolution_height";
+            }
+            $current_file .= ",CODECS=\"$bandwidth->codec\"\n$bandwidth->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id;
+        }
+
+        return response($current_file, 200, [
+            'Content-Disposition' => 'attachment; filename="' . $file->file_name . '"',
+            'Content-Type'        => 'application/x-mpegURL'
+        ]);
+    }
+
+    /**
+     *
+     * Deliver the ts files referenced by file created by the generated m3u8
+     *
+     * @param null $fileset_id
+     * @param null $file_id
+     * @param null $file_name
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    public function transportStream(Response $response, $fileset_id = null, $file_id = null, $file_name = null)
+    {
+        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh_video.bucket');
+
+        $video_fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'video_stream')->select('hash_id', 'id', 'asset_id')->first();
+        $audio_fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'audio_stream')->select('hash_id', 'id', 'asset_id')->first();
+        if (!$video_fileset && !$audio_fileset) {
+            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+        }
+
+        if ($audio_fileset) {
+            $fileset = $audio_fileset;
+            $fileset_type = 'audio';
+        } else {
+            $fileset = $video_fileset;
+            $fileset_type = 'video';
+        }
+
+        $file = BibleFile::with('streamBandwidth.transportStream')->whereId($file_id)->first();
+        if (!$file) {
+            return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id]));
+        }
+
+        $bible_path    = $fileset->bible->first() !== null ? $fileset->bible->first()->id . '/' : '';
+        $current_file = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-ALLOW-CACHE:YES\n#EXT-X-TARGETDURATION:4";
+
+        $currentBandwidth = $file->streamBandwidth->where('file_name', $file_name)->first();
+        if (!$currentBandwidth) {
+            return $this->setStatusCode(404)->replyWithError(trans('api.file_errors_404_size'));
+        }
+        $transaction_id = random_int(0, 10000000);
+        try {
+            apiLogs(request(), $response->getStatusCode(), $transaction_id);
+        } catch (\Exception $e) {
+            Log::error($e);
+        }
+
+        foreach ($currentBandwidth->transportStream as $stream) {
+            $current_file_path = $this->signedUrl($fileset_type . '/' . $bible_path . $fileset->id . '/' . $stream->file_name, $fileset->asset_id, $transaction_id);
+            $current_file .= "\n#EXTINF:$stream->runtime\n$current_file_path";
+        }
+        $current_file .= "\n#EXT-X-ENDLIST";
+
+        echo $current_file;
+        die();
+
+        return response($current_file, 200, [
+            'Content-Disposition' => 'attachment; filename="' . $file->file_name . '"',
+            'Content-Type'        => 'application/x-mpegURL'
+        ]);
+    }
+}

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -86,7 +86,6 @@ class StreamController extends APIController
         }
 
         $bible_path    = $fileset->bible->first() !== null ? $fileset->bible->first()->id . '/' : '';
-        $current_file = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-ALLOW-CACHE:YES\n#EXT-X-TARGETDURATION:4";
 
         $currentBandwidth = $file->streamBandwidth->where('file_name', $file_name)->first();
         if (!$currentBandwidth) {
@@ -98,6 +97,8 @@ class StreamController extends APIController
         } catch (\Exception $e) {
             Log::error($e);
         }
+
+        $current_file = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-ALLOW-CACHE:YES\n#EXT-X-TARGETDURATION:" . ceil($currentBandwidth->transportStream->max('runtime'));
 
         foreach ($currentBandwidth->transportStream as $stream) {
             $current_file_path = $this->signedUrl($fileset_type . '/' . $bible_path . $fileset->id . '/' . $stream->file_name, $fileset->asset_id, $transaction_id);

--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -3,102 +3,11 @@
 namespace App\Http\Controllers\Bible;
 
 use App\Http\Controllers\APIController;
-use App\Models\Bible\BibleFile;
-use App\Models\Bible\BibleFileset;
-use App\Traits\CallsBucketsTrait;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Log;
 use App\Traits\ArclightConnection;
 
 class VideoStreamController extends APIController
 {
-    use CallsBucketsTrait;
     use ArclightConnection;
-
-    /**
-     *
-     * Generate the parent m3u8 file which contains the various resolution m3u8 files
-     *
-     * @param null $id
-     * @param null $file_id
-     *
-     * @return $this
-     */
-    public function index($id = null, $file_id = null)
-    {
-        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh_video.bucket');
-
-        $fileset = BibleFileset::uniqueFileset($id, $asset_id)->select('hash_id', 'id')->first();
-        if (!$fileset) {
-            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
-        }
-
-        $file = BibleFile::with('videoResolution')->where('hash_id', $fileset->hash_id)->where('id', $file_id)->first();
-        if (!$file) {
-            return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id]));
-        }
-
-        $current_file = '#EXTM3U';
-        foreach ($file->videoResolution as $resolution) {
-            $current_file .= "\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=$resolution->bandwidth,RESOLUTION=" . $resolution->resolution_width . "x$resolution->resolution_height,CODECS=\"$resolution->codec\"\n$resolution->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id;
-        }
-
-        return response($current_file, 200, [
-            'Content-Disposition' => 'attachment; filename="' . $file->file_name . '"',
-            'Content-Type'        => 'application/x-mpegURL'
-        ]);
-    }
-
-    /**
-     *
-     * Deliver the ts files referenced by file created by the generated m3u8
-     *
-     * @param null $fileset_id
-     * @param null $file_id
-     * @param null $file_name
-     *
-     * @return $this
-     * @throws \Exception
-     */
-    public function transportStream(Response $response, $fileset_id = null, $file_id = null, $file_name = null)
-    {
-        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh_video.bucket');
-
-        $fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'video_stream')->select('hash_id', 'id', 'asset_id')->first();
-        if (!$fileset) {
-            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
-        }
-
-        $file = BibleFile::with('videoResolution.transportStream')->whereId($file_id)->first();
-        if (!$file) {
-            return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id]));
-        }
-
-        $bible_path    = $fileset->bible->first() !== null ? $fileset->bible->first()->id . '/' : '';
-        $current_file = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-ALLOW-CACHE:YES\n#EXT-X-TARGETDURATION:4";
-
-        $currentResolution = $file->videoResolution->where('file_name', $file_name)->first();
-        if (!$currentResolution) {
-            return $this->setStatusCode(404)->replyWithError(trans('api.file_errors_404_size'));
-        }
-        $transaction_id = random_int(0, 10000000);
-        try {
-            apiLogs(request(), $response->getStatusCode(), $transaction_id);
-        } catch (\Exception $e) {
-            Log::error($e);
-        }
-
-        foreach ($currentResolution->transportStream as $stream) {
-            $current_file_path = $this->signedUrl('video' . '/' . $bible_path . $fileset->id . '/' . $stream->file_name, $fileset->asset_id, $transaction_id);
-            $current_file .= "\n#EXTINF:$stream->runtime\n$current_file_path";
-        }
-        $current_file .= "\n#EXT-X-ENDLIST";
-
-        return response($current_file, 200, [
-            'Content-Disposition' => 'attachment; filename="' . $file->file_name . '"',
-            'Content-Type'        => 'application/x-mpegURL'
-        ]);
-    }
 
     public function jesusFilmsLanguages()
     {

--- a/app/Models/Bible/BibleFile.php
+++ b/app/Models/Bible/BibleFile.php
@@ -233,8 +233,8 @@ class BibleFile extends Model
         return $this->hasOne(BibleFileTitle::class, 'file_id', 'id');
     }
 
-    public function videoResolution()
+    public function streamBandwidth()
     {
-        return $this->hasMany(VideoResolution::class);
+        return $this->hasMany(StreamBandwidth::class);
     }
 }

--- a/app/Models/Bible/StreamBandwidth.php
+++ b/app/Models/Bible/StreamBandwidth.php
@@ -4,10 +4,10 @@ namespace App\Models\Bible;
 
 use Illuminate\Database\Eloquent\Model;
 
-class VideoResolution extends Model
+class StreamBandwidth extends Model
 {
     protected $connection = 'dbp';
-    protected $table = 'bible_file_video_resolutions';
+    protected $table = 'bible_file_stream_bandwidths';
     protected $fillable = ['file_id','file_name','bandwidth','resolution_width','resolution_height','codec','stream'];
 
     public function file()
@@ -17,6 +17,6 @@ class VideoResolution extends Model
 
     public function transportStream()
     {
-        return $this->hasMany(VideoTransportStream::class);
+        return $this->hasMany(StreamSegment::class);
     }
 }

--- a/app/Models/Bible/StreamSegment.php
+++ b/app/Models/Bible/StreamSegment.php
@@ -4,9 +4,9 @@ namespace App\Models\Bible;
 
 use Illuminate\Database\Eloquent\Model;
 
-class VideoTransportStream extends Model
+class StreamSegment extends Model
 {
     protected $connection = 'dbp';
-    protected $table = 'bible_file_video_transport_stream';
+    protected $table = 'bible_file_stream_segments';
     protected $fillable = ['file_name','runtime'];
 }

--- a/database/migrations/2019_09_27_144323_hls_audio.php
+++ b/database/migrations/2019_09_27_144323_hls_audio.php
@@ -1,0 +1,86 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class HlsAudio extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_file_video_resolutions')) {
+            Schema::connection('dbp')->table('bible_file_video_resolutions', function (Blueprint $table) {
+                if (Schema::connection('dbp')->hasColumn('bible_file_video_resolutions', 'resolution_width')) {
+                    $table->integer('resolution_width')->unsigned()->nullable()->change();
+                }
+                if (Schema::connection('dbp')->hasColumn('bible_file_video_resolutions', 'resolution_height')) {
+                    $table->integer('resolution_height')->unsigned()->nullable()->change();
+                }
+            });
+        }
+
+        if (Schema::connection('dbp')->hasTable('bible_file_video_resolutions') && Schema::connection('dbp')->hasTable('bible_file_video_transport_stream')) {
+            Schema::connection('dbp')->table('bible_file_video_resolutions', function (Blueprint $table) {
+                $table->dropForeign('FK_bible_files_bible_file_video_resolutions');
+            });
+            Schema::connection('dbp')->table('bible_file_video_transport_stream', function (Blueprint $table) {
+                $table->dropForeign('FK_bible_file_video_resolutions_bible_file_video_transport_strea');
+            });
+
+            Schema::connection('dbp')->rename('bible_file_video_resolutions', 'bible_file_stream_bandwidths');
+            Schema::connection('dbp')->rename('bible_file_video_transport_stream', 'bible_file_stream_segments');
+
+            Schema::connection('dbp')->table('bible_file_stream_bandwidths', function (Blueprint $table) {
+                $table->foreign('bible_file_id', 'FK_bible_files_bible_file_stream_bandwidths')->references('id')->on(config('database.connections.dbp.database') . '.bible_files')->onUpdate('cascade')->onDelete('cascade');
+            });
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                $table->renameColumn('video_resolution_id', 'stream_bandwidth_id');
+                $table->foreign('stream_bandwidth_id', 'FK_stream_bandwidths_stream_segments')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_stream_bandwidths')->onUpdate('cascade')->onDelete('cascade');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_file_stream_bandwidths') && Schema::connection('dbp')->hasTable('bible_file_stream_segments')) {
+            Schema::connection('dbp')->table('bible_file_stream_bandwidths', function (Blueprint $table) {
+                $table->dropForeign('FK_bible_files_bible_file_stream_bandwidths');
+            });
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                $table->dropForeign('FK_stream_bandwidths_stream_segments');
+            });
+
+            Schema::connection('dbp')->rename('bible_file_stream_bandwidths', 'bible_file_video_resolutions');
+            Schema::connection('dbp')->rename('bible_file_stream_segments', 'bible_file_video_transport_stream');
+
+            Schema::connection('dbp')->table('bible_file_video_resolutions', function (Blueprint $table) {
+                $table->foreign('bible_file_id', 'FK_bible_files_bible_file_video_resolutions')->references('id')->on(config('database.connections.dbp.database') . '.bible_files')->onUpdate('cascade')->onDelete('cascade');
+            });
+            Schema::connection('dbp')->table('bible_file_video_transport_stream', function (Blueprint $table) {
+                $table->renameColumn('stream_bandwidth_id', 'video_resolution_id');
+                $table->foreign('video_resolution_id', 'FK_bible_file_video_resolutions_bible_file_video_transport_strea')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_video_resolutions')->onUpdate('cascade')->onDelete('cascade');
+            });
+        }
+
+        if (Schema::connection('dbp')->hasTable('bible_file_video_resolutions')) {
+            Schema::connection('dbp')->table('bible_file_video_resolutions', function (Blueprint $table) {
+                if (Schema::connection('dbp')->hasColumn('bible_file_video_resolutions', 'resolution_width')) {
+                    $table->integer('resolution_width')->unsigned()->nullable(false)->change();
+                }
+                if (Schema::connection('dbp')->hasColumn('bible_file_video_resolutions', 'resolution_height')) {
+                    $table->integer('resolution_height')->unsigned()->nullable(false)->change();
+                }
+            });
+        }
+    }
+}

--- a/database/seeds/RealDataSeeder.php
+++ b/database/seeds/RealDataSeeder.php
@@ -32,8 +32,8 @@ use App\Models\Bible\BibleFilesetConnection;
 use App\Models\Bible\BibleFilesetCopyright;
 use App\Models\Bible\BibleFilesetCopyrightRole;
 use App\Models\Bible\BibleFilesetCopyrightOrganization;
-use App\Models\Bible\VideoResolution;
-use App\Models\Bible\VideoTransportStream;
+use App\Models\Bible\StreamBandwidth;
+use App\Models\Bible\StreamSegment;
 
 use App\Models\Organization\Asset;
 use App\Models\Organization\Organization;
@@ -85,8 +85,8 @@ class RealDataSeeder extends Seeder
         $this->seedData('/bibles/bible_fileset_copyrights',              BibleFilesetCopyright::class);
         $this->seedData('/bibles/bible_fileset_copyright_organizations', BibleFilesetCopyrightOrganization::class);
         $this->seedData('/bibles/bible_files',                           BibleFile::class);
-        $this->seedData('/bibles/bible_file_video_resolutions',          VideoResolution::class);
-        $this->seedData('/bibles/bible_file_video_transport_stream',     VideoTransportStream::class);
+        $this->seedData('/bibles/bible_file_video_resolutions',          StreamBandwidth::class);
+        $this->seedData('/bibles/bible_file_video_transport_stream',     StreamSegment::class);
         $this->seedData('/bibles/bible_organization',                    BibleOrganization::class);
         $this->seedData('/bibles/equivalents/bible-gateway',             BibleEquivalent::class);
         $this->seedData('/access/access_groups',                         AccessGroup::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -77,8 +77,8 @@ Route::name('v4_access_groups.update')->put('access/groups/{group_id}',         
 Route::name('v4_access_groups.destroy')->delete('access/groups/{group_id}',        'User\AccessGroupController@destroy');
 
 // VERSION 4 | Stream
-Route::name('v4_video_stream')->get('bible/filesets/{fileset_id}/{file_id}/playlist.m3u8',    'Bible\VideoStreamController@index');
-Route::name('v4_video_stream_ts')->get('bible/filesets/{fileset_id}/{file_id}/{file_name}',   'Bible\VideoStreamController@transportStream');
+Route::name('v4_media_stream')->get('bible/filesets/{fileset_id}/{file_id}/playlist.m3u8',    'Bible\StreamController@index');
+Route::name('v4_media_stream_ts')->get('bible/filesets/{fileset_id}/{file_id}/{file_name}',   'Bible\StreamController@transportStream');
 
 // VERSION 4 | Bible
 Route::name('v4_bible.books')->get('bibles/{bible_id}/book/{book?}',               'Bible\BiblesController@books');

--- a/tests/Integration/VideoRoutesTest.php
+++ b/tests/Integration/VideoRoutesTest.php
@@ -4,14 +4,14 @@ namespace Tests\Integration;
 
 use App\Http\Controllers\Bible\VideoStreamController;
 use App\Models\Bible\BibleFile;
-use App\Models\Bible\VideoResolution;
+use App\Models\Bible\StreamBandwidth;
 
 class VideoRoutesTest extends ApiV4Test
 {
 
     /**
      * @category V4_API
-     * @category Route Name: v4_video_stream
+     * @category Route Name: v4_media_stream
      * @category Route Path: https://api.dbp.test/?v=4&key={key}/stream/{file_id}/playlist.m3u8
      * @see      VideoStreamController::index
      * @group    V4
@@ -23,7 +23,7 @@ class VideoRoutesTest extends ApiV4Test
         $this->markTestIncomplete('Travis not handling files');
 
         $bible_file = BibleFile::with('fileset')->where('file_name', 'like', '%.m3u8')->inRandomOrder()->first();
-        $path = route('v4_video_stream', array_merge($this->params, [
+        $path = route('v4_media_stream', array_merge($this->params, [
             'file_id'    => $bible_file->id,
             'fileset_id' => $bible_file->fileset->id,
             'file_name'  => $bible_file->file_name
@@ -39,7 +39,7 @@ class VideoRoutesTest extends ApiV4Test
 
     /**
      * @category V4_API
-     * @category Route Name: v4_video_stream_ts
+     * @category Route Name: v4_media_stream_ts
      * @category Route Path: https://api.dbp.test/bible/filesets/{fileset_id}/stream/{file_id}/{file_name}?v=4&key={key}
      * @see      VideoStreamController::transportStream
      * @group    V4
@@ -48,8 +48,8 @@ class VideoRoutesTest extends ApiV4Test
      */
     public function videoStreamTs()
     {
-        $resolution = VideoResolution::with('file.fileset')->inRandomOrder()->first();
-        $path = route('v4_video_stream_ts', array_merge([
+        $resolution = StreamBandwidth::with('file.fileset')->inRandomOrder()->first();
+        $path = route('v4_media_stream_ts', array_merge([
             'file_id'    => $resolution->bible_file_id,
             'fileset_id' => $resolution->file->fileset->id,
             'file_name'  => $resolution->file_name


### PR DESCRIPTION
# Description
- Added an HLS migration in order to do:
    - Renamed `bible_file_video_resolutions` to `bible_file_stream_bandwidths`
    - Renamed `bible_file_video_transport_stream` to `bible_file_stream_segments`
    - Made nullable `resolution_width` and `resolution_height` on `bible_file_stream_bandwidths` table
    - Changed `video_resolution_id` column name to `stream_bandwidth_id`
- Renamed `VideoResolution` Model to `StreamBandwidth`
- Renamed `VideoTransportStream` Model to `StreamSegment`
- Created StreamController file to handle the `HLS` api requests
- Updated BibleFileSetsController to support `video_stream` and `audio_stream`


## Issue Link
Original Story: [FCBH-528](https://fullstacklabs.atlassian.net/browse/FCBH-528) 
Review Story: [FCBH-859](https://fullstacklabs.atlassian.net/browse/FCBH-859) 

## How Do I QA This

- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations

- Run `https://api.dbp.test/bibles/filesets/ENGNIVP2DV?book_id=MAT&chapter_id=1&id=ENGNIVP2DV&type=video_stream&size=NTP&asset_id=dbp-vid&v=4&key={API_KEY}` and verify that you get the videos (the same will be with audio)

- Run `https://api.dbp.test/bible/filesets/ENGNIVP2DV/1833778/playlist.m3u8?asset_id=dbp-vid&v=4&key={API_KEY}` and verify that you get the `m3u8` with the different bandwidths

- Run `https://api.dbp.test/bible/filesets/ENGNIVP2DV/1833778/English_MAT_1-1-17_1_av720p.m3u8?key={API_KEY}&v=4&asset_id=dbp-vid` and verify that you get the `m3u8` with all the segments

- Finally, run the app locally and navigate to `My Bible -> Select Mathew -> Select chapter 1`, click on the video icon and verify that the video works

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

