### PR TITLE
Use the correct route for the open-api JSON generation

### DIFF
--- a/resources/views/docs/sdk.blade.php
+++ b/resources/views/docs/sdk.blade.php
@@ -44,7 +44,7 @@
 
             <div>
                 <p>You can generate your own SDK using our swagger specifications located here: <span></span>. In order to do so you'll need to swagger-codegen.</p>
-                <code><pre>swagger-codegen generate -i {{ route('swagger', ['version' => 4]) }} -l php -o /Sites/dbp/public/sdk/</pre></code>
+                <code><pre>swagger-codegen generate -i {{ route('swagger_docs_gen', ['version' => 4]) }} -l php -o /Sites/dbp/public/sdk/</pre></code>
                 <p>Or use one of pre generated SDKs for commonly used programming languages.</p>
             </div>
 


### PR DESCRIPTION
The current url in the documentation is the HTML pages allowing users to interact with the documentation.  The route `swagger_docs_gen` is the correct route for generating the Open API JSON.