### PR TITLE
Add artisan command to show environment

### DIFF
--- a/app/Console/Commands/showEnvironment.php
+++ b/app/Console/Commands/showEnvironment.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class showEnvironment extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'showEnvironment';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show environment vars';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        var_dump($_ENV);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -43,6 +43,8 @@ class Kernel extends ConsoleKernel
 
         Commands\S3LogBackup::class,
         Commands\CleanAndImportKD::class,
+
+        Commands\showEnvironment::class,
     ];
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -65,8 +65,7 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function mapApiRoutes()
     {
-        Route::domain(config('app.api_url'))
-                ->middleware('api')
+        Route::middleware('api')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));
     }


### PR DESCRIPTION
# Description
- Added `php artisan showEnvironment` command in order to show the ENV vairables
- Removed domain check on API routes.

## How Do I QA This
- Run `php artisan showEnvironment` and verify you get the environment vars
- Set a wrong `API_URL` and verify that the API still works

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

