### PR TITLE
FCBH-948 Change API subdomain to Path

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -38,7 +38,7 @@ class APIController extends Controller
      * )
      *
      * @OA\Server(
-     *     url="https://api.dbp.test",
+     *     url="https://dbp.test/api",
      *     description="Development server",
      *     @OA\ServerVariable( serverVariable="schema", enum={"https"}, default="https")
      * )
@@ -137,8 +137,8 @@ class APIController extends Controller
     public function __construct()
     {
         $url           = explode('.', url()->current());
-        $subdomain     = array_shift($url);
-        if (Str::contains($subdomain, 'api')) {
+        $path     = array_pop($url);
+        if (Str::contains($path, 'api')) {
             $this->api = true;
             $this->v   = (int) checkParam('v', true, $this->preset_v);
             $this->key = checkParam('key', true);

--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -136,9 +136,8 @@ class APIController extends Controller
 
     public function __construct()
     {
-        $url           = explode('.', url()->current());
-        $path     = array_pop($url);
-        if (Str::contains($path, 'api')) {
+        $url = url()->current();
+        if (Str::contains($url, '/api')) {
             $this->api = true;
             $this->v   = (int) checkParam('v', true, $this->preset_v);
             $this->key = checkParam('key', true);

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -91,7 +91,7 @@ class UserPlan extends Model
                 return $completed;
             });
         ;
-        $this->attributes['percentage_completed'] = $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100;
+        $this->attributes['percentage_completed'] = $completed_per_day->sum('total_items') ? $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100 : 0;
         return $this;
     }
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -65,7 +65,8 @@ class RouteServiceProvider extends ServiceProvider
      */
     protected function mapApiRoutes()
     {
-        Route::middleware('api')
+        Route::prefix('api')
+                ->middleware('api')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/api.php'));
     }


### PR DESCRIPTION
# Description
- Removed API subdomain and moved to the path
- Fixed error on complete plan endpoint when a day is empty

## How Do I QA This
- Run `valet unlink api.dbp`
- Run `valet link dbp`
- Run `valet secure`
- Change the `API_URL` on the `.env` file to be `https://dbp.test/api` instead of `https://api.dbp.test`
- Run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test that the endpoints are working

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

