### PR TITLE
FCBH-856 Book Names are incorrect on created Annotations

### DIFF
--- a/app/Http/Controllers/User/UsersControllerV2.php
+++ b/app/Http/Controllers/User/UsersControllerV2.php
@@ -304,6 +304,7 @@ class UsersControllerV2 extends APIController
                 })->select([
                     'user_highlights.id',
                     'user_highlights.bible_id',
+                    'user_highlights.book_id',
                     'user_highlights.user_id',
                     'user_highlights.chapter',
                     'user_highlights.verse_start',

--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -149,7 +149,7 @@ class Highlight extends Model
 
     public function book()
     {
-        return $this->hasOne(BibleBook::class, 'book_id', 'book_id');
+        return $this->hasOne(BibleBook::class, 'book_id', 'book_id')->where('bible_id', $this['bible_id']);
     }
 
     public function tags()


### PR DESCRIPTION

# Description
- Fixed wrong book names filtering by bible id
- Fixed v2 Highlights endpoint by adding missing book_id

## Issue Link
Original Story: [FCBH-856](https://fullstacklabs.atlassian.net/browse/FCBH-856) 
Review Story: [FCBH-943](https://fullstacklabs.atlassian.net/browse/FCBH-943) 

## How Do I QA This

- Run `https://api.dbp.test/users/{USER_ID}/highlights?page=1&v=4&key={API_KEY}` and verify you get the correct book names

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

