### PR TITLE
FCBH-861 Token Validator Endpoint

### DIFF
--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -180,8 +180,8 @@ class Highlight extends Model
         $verses = BibleVerse::withVernacularMetaData($bible)
         ->where('hash_id', $fileset->hash_id)
         ->where('bible_verses.book_id', $highlight['book_id'])
-        ->where('verse_start', '>=',$verse_start)
-        ->where('verse_end', '<=',$verse_end)
+        ->where('verse_start', '>=', $verse_start)
+        ->where('verse_end', '<=', $verse_end)
         ->where('chapter', $chapter)
         ->orderBy('verse_start')
         ->select([

--- a/app/Services/Auth/ApiTokenGuard.php
+++ b/app/Services/Auth/ApiTokenGuard.php
@@ -41,7 +41,7 @@ class APITokenGuard implements Guard
         $token = $this->getTokenForRequest();
 
         if (!empty($token)) {
-            $api_token = APIToken::where('api_token', hash('sha256', $token))->first();
+            $api_token = $this->getApiToken($token);
             if ($api_token) {
                 $user = $this->provider->retrieveById($api_token->user_id);
             }
@@ -75,8 +75,8 @@ class APITokenGuard implements Guard
         }
 
         $token =  $credentials[$this->inputKey];
-        $api_token = APIToken::where('api_token', hash('sha256', $token))->first();
 
+        $api_token = $this->getApiToken($token);
         if (!$api_token) {
             return false;
         }
@@ -93,5 +93,12 @@ class APITokenGuard implements Guard
         $this->request = $request;
 
         return $this;
+    }
+
+    private function getApiToken($token)
+    {
+        return  APIToken::where('api_token', hash('sha256', $token))
+            ->where('created_at', '>', \DB::raw('DATE_SUB(NOW(), INTERVAL 1 YEAR)'))
+            ->first();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -115,7 +115,7 @@ Route::name('v4_lexicon_index')->get('lexicons',                                
 
 // VERSION 4 | Timestamps
 Route::name('v4_timestamps')->get('timestamps',                                    'Bible\AudioController@availableTimestamps');
-Route::name('v4_timestamps.tag')->get('timestamps/search',                        'Bible\AudioController@timestampsByTag');
+Route::name('v4_timestamps.tag')->get('timestamps/search',                         'Bible\AudioController@timestampsByTag');
 Route::name('v4_timestamps.verse')->get('timestamps/{id}/{book}/{chapter}',        'Bible\AudioController@timestampsByReference');
 
 // VERSION 4 | Countries
@@ -147,6 +147,8 @@ Route::name('v4_user.password_reset')->post('users/password/reset/{token?}',    
 Route::name('v4_user.password_email')->post('users/password/email',                'User\PasswordsController@triggerPasswordResetEmail');
 Route::name('v4_user.logout')
     ->middleware('APIToken:check')->post('/logout',                                'User\UsersController@logout');
+Route::name('v4_api_token.validate')
+    ->middleware('APIToken')->post('/token/validate',                               'User\UsersController@validateApiToken');
 
 // VERSION 4 | Accounts
 Route::name('v4_user_accounts.index')->get('accounts',                             'User\AccountsController@index');


### PR DESCRIPTION
# Description
- Added 1 year expiration time to the user api_tokens
- Added `/token/validate` endpoint to validate, renew and get user details
- Updated documentation

## Issue Link
Original Story: [FCBH-861](https://fullstacklabs.atlassian.net/browse/FCBH-861) 
Review Story: [FCBH-980](https://fullstacklabs.atlassian.net/browse/FCBH-980) 

## How Do I QA This
- Run `http://dbp.test/open-api-v4.json` to get the new documentation
- Test that the `/token/validate` endpoint validates the user `api_token`
- Test that `user_details` param retrieves the user on the response
- Test that `renew_token` param deletes the `old_token` and generates a new one

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

