### PR TITLE
FCBH-949 Implement HLS Byte Range

### DIFF
--- a/app/Models/Bible/StreamSegment.php
+++ b/app/Models/Bible/StreamSegment.php
@@ -9,4 +9,9 @@ class StreamSegment extends Model
     protected $connection = 'dbp';
     protected $table = 'bible_file_stream_segments';
     protected $fillable = ['file_name','runtime'];
+
+    public function timestamp()
+    {
+        return $this->belongsTo(Timestamp::class);
+    }
 }

--- a/app/Models/Bible/Timestamp.php
+++ b/app/Models/Bible/Timestamp.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models\Bible;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Timestamp extends Model
+{
+    protected $connection = 'dbp';
+    protected $table = 'bible_file_timestamps';
+
+    public function bibleFile()
+    {
+        return $this->belongsTo(BibleFile::class);
+    }
+}

--- a/database/migrations/2019_10_22_183925_add_byterange_support.php
+++ b/database/migrations/2019_10_22_183925_add_byterange_support.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddByterangeSupport extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_file_stream_segments')) {
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                $table->integer('bytes')->nullable()->after('runtime')->default(null);
+                $table->integer('offset')->nullable()->after('runtime')->default(null);
+                $table->integer('timestamp_id')->unsigned()->nullable()->after('runtime');
+                $table->string('file_name')->nullable()->change();
+                $table->foreign('timestamp_id', 'FK_bible_file_timestamp_stream_segments')->references('id')->on(config('database.connections.dbp.database').'.bible_file_timestamps')->onUpdate('cascade')->onDelete('cascade');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_file_stream_segments')) {
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                $table->dropColumn('bytes');
+                $table->dropColumn('offset');
+                $table->dropForeign('FK_bible_file_timestamp_stream_segments');
+                $table->dropColumn('timestamp_id');
+                $table->string('file_name')->nullable(false)->change();
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Description
- Added byte-range support migration
- Added Timestamp Model
- Added timestamp relation to the StreamSegment model
- Modified StreamController to support byte-range segments

## Issue Link
Original Story: [FCBH-949](https://fullstacklabs.atlassian.net/browse/FCBH-949) 
Review Story: [FCBH-1042](https://fullstacklabs.atlassian.net/browse/FCBH-1042) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Run the SQL dump query to seed the database
- Run `https://dbp.test/api/bibles/filesets/ENGESVN2SA?type=audio_stream&size=NTP&asset_id=dbp-prod&v=4&key={API_KEY}` and verify you get 2 chapters (JHN 1 is with ts segments, JHN 2 is with byte-range)
- Run `http://dbp.test/api/bible/filesets/ENGESVN2SA/1912079/playlist.m3u8?asset_id=dbp-prod&v=4&key={API_KEY}` on the hls demo app and verify the audio works.

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
