### PR TITLE
FCBH-962 Backend  Small Task Bucket

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -620,6 +620,7 @@ class PlansController extends APIController
      *   @OA\Property(property="id", ref="#/components/schemas/Plan/properties/id"),
      *   @OA\Property(property="name", ref="#/components/schemas/Plan/properties/name"),
      *   @OA\Property(property="featured", ref="#/components/schemas/Plan/properties/featured"),
+     *   @OA\Property(property="thumbnail", ref="#/components/schemas/Plan/properties/thumbnail"),
      *   @OA\Property(property="suggested_start_date", ref="#/components/schemas/Plan/properties/suggested_start_date"),
      *   @OA\Property(property="created_at", ref="#/components/schemas/Plan/properties/created_at"),
      *   @OA\Property(property="updated_at", ref="#/components/schemas/Plan/properties/updated_at"),

--- a/app/Models/Bible/BibleDefault.php
+++ b/app/Models/Bible/BibleDefault.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models\Bible;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BibleDefault extends Model
+{
+    protected $connection = 'dbp';
+    protected $table = 'bibles_defaults';
+    protected $hidden     = ['id'];
+
+    protected $id;
+    protected $type;
+    protected $bible_id;
+    protected $language_code;
+    public $timestamps = false;
+    
+    public function bible()
+    {
+        return $this->belongsTo(Bible::class);
+    }
+}

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -81,6 +81,17 @@ class Plan extends Model
     /**
      *
      * @OA\Property(
+     *   title="thumbnail",
+     *   type="string",
+     *   description="The image url",
+     *   maxLength=191
+     * )
+     *
+     */
+    protected $thumbnail;
+    /**
+     *
+     * @OA\Property(
      *   title="suggested_start_date",
      *   type="string",
      *   format="date",

--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -180,8 +180,8 @@ class Highlight extends Model
         $verses = BibleVerse::withVernacularMetaData($bible)
         ->where('hash_id', $fileset->hash_id)
         ->where('bible_verses.book_id', $highlight['book_id'])
-        ->where('verse_start', '>=',$verse_start)
-        ->where('verse_end', '<=',$verse_end)
+        ->where('verse_start', '>=', $verse_start)
+        ->where('verse_end', '<=', $verse_end)
         ->where('chapter', $chapter)
         ->orderBy('verse_start')
         ->select([

--- a/database/migrations/2019_10_17_122023_add_bibles_defaults_table.php
+++ b/database/migrations/2019_10_17_122023_add_bibles_defaults_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddBiblesDefaultsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::connection('dbp')->hasTable('bibles_defaults')) {
+            Schema::connection('dbp')->create('bibles_defaults', function (Blueprint $table) {
+                $table->increments('id');
+                $table->char('language_code', 6);
+                $table->string('bible_id', 12);
+                $table->string('type', 12);
+                $table->foreign('bible_id', 'FK_bibles_defaults')->references('id')->on(config('database.connections.dbp.database').'.bibles')->onDelete('cascade')->onUpdate('cascade');
+                $table->unique(['language_code', 'bible_id', 'type'], 'unique_bible_default');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp')->dropIfExists('bibles_defaults');
+    }
+}

--- a/database/migrations/2019_10_17_154139_add_plan_image.php
+++ b/database/migrations/2019_10_17_154139_add_plan_image.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPlanImage extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::connection('dbp_users')->hasTable('plans')) {
+            Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+                $table->string('thumbnail', 191)->nullable()->after('name')->default(null);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::connection('dbp_users')->hasTable('plans')) {
+            Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+                $table->dropColumn('thumbnail');
+            });
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -87,6 +87,7 @@ Route::name('v4_bible.links')->get('bibles/links',                              
 Route::name('v4_bible_books_all')->get('bibles/books/',                            'Bible\BooksController@index');
 Route::name('v4_bible.one')->get('bibles/{bible_id}',                              'Bible\BiblesController@show');
 Route::name('v4_bible.all')->get('bibles',                                         'Bible\BiblesController@index');
+Route::name('v4_bible.defaults')->get('bibles/defaults/types',                           'Bible\BiblesController@defaults');
 
 // VERSION 4 | Filesets
 Route::name('v4_filesets.types')->get('bibles/filesets/media/types',               'Bible\BibleFileSetsController@mediaTypes');

--- a/routes/api.php
+++ b/routes/api.php
@@ -143,7 +143,8 @@ Route::name('v4_user.destroy')->middleware('APIToken:check')->delete('users',   
 Route::name('v4_user.login')->post('/login',                                       'User\UsersController@login');
 Route::name('v4_user.oAuth')->get('/login/{driver}',                               'User\SocialController@redirect');
 Route::name('v4_user.oAuthCallback')->get('/login/{driver}/callback',              'User\SocialController@callback');
-Route::name('v4_user.password_reset')->post('users/password/reset/{token?}',       'User\PasswordsController@validatePasswordReset');
+Route::name('v4_user.password_reset')
+    ->middleware('APIToken')->post('users/password/reset/{token?}',                'User\PasswordsController@validatePasswordReset');
 Route::name('v4_user.password_email')->post('users/password/email',                'User\PasswordsController@triggerPasswordResetEmail');
 Route::name('v4_user.logout')
     ->middleware('APIToken:check')->post('/logout',                                'User\UsersController@logout');


### PR DESCRIPTION
# Description
- Added support for api_token and old_password on `/users/password/reset` endpoint
- Added `bibles/defaults/types` endpoint
- Added bibles_defaults table migration
- Added image field for plans
- Added support to filter bible filesets by input asset_id prop on `bible/{bible_id}` endpoint
- Added documentation

## Issue Link
Original Story: [FCBH-962](https://fullstacklabs.atlassian.net/browse/FCBH-962) 
Review Story: [FCBH-1054](https://fullstacklabs.atlassian.net/browse/FCBH-1054) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Test that the `old_password` field on `/users/password/reset` is working
- Test `bibles/defaults/types`
- Add an `image_url` to a featured plan and verify that is returned
- Verify that you can filter the filesets on the `bible/{bible_id}` endpoint

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
