### PR TITLE
FCBH-1045 Edit account broken with brand new account

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -11,6 +11,7 @@ use App\Models\User\Account;
 use App\Models\User\APIToken;
 use App\Models\User\Role;
 use App\Models\User\User;
+use App\Models\User\Profile;
 use App\Models\User\Key;
 use App\Models\User\Study\Note;
 use App\Traits\CheckProjectMembership;
@@ -329,6 +330,24 @@ class UsersController extends APIController
             'notes'         => $request->notes,
             'password'      => \Hash::make($request->password),
         ]);
+
+        $sex = checkParam('sex') ?? 0;
+        $profile = Profile::create([
+            'user_id' => $user->id,
+            'bio' => $request->bio,
+            'address_1' => $request->address_1,
+            'address_2' => $request->address_2,
+            'address_3' => $request->address_3,
+            'city' => $request->city,
+            'state' => $request->state,
+            'zip' => $request->zip,
+            'country_id' => $request->country_id,
+            'avatar' => $request->avatar,
+            'phone' => $request->phone,
+            'birthday' => $request->birthday,
+            'sex' => $sex,
+        ]);
+
         if ($request->project_id) {
             $user_role = Role::where('slug', 'user')->first();
             if (!$user_role) {
@@ -360,7 +379,7 @@ class UsersController extends APIController
             Auth::login($user, true);
             return redirect()->to('home');
         }
-
+        
         return $this->setStatusCode(200)->reply(fractal($user, new UserTransformer())->addMeta(['success' => 'User created']));
     }
 
@@ -665,9 +684,9 @@ class UsersController extends APIController
             'project_id'              => 'required|exists:dbp_users.projects,id',
             'social_provider_id'      => 'required_with:social_provider_user_id',
             'social_provider_user_id' => 'required_with:social_provider_id',
-            'name'                    => 'string|max:191',
-            'first_name'              => 'string|max:64',
-            'last_name'               => 'string|max:64',
+            'name'                    => 'string|max:191|nullable',
+            'first_name'              => 'string|max:64|nullable',
+            'last_name'               => 'string|max:64|nullable',
             'remember_token'          => 'max:100',
             'verified'                => 'boolean'
         ]);

--- a/app/Models/User/Profile.php
+++ b/app/Models/User/Profile.php
@@ -24,6 +24,7 @@ class Profile extends Model
      *
      * @var string
      */
+    protected $connection = 'dbp_users';
     protected $table = 'profiles';
     protected $primaryKey = 'user_id';
 
@@ -51,6 +52,7 @@ class Profile extends Model
         'avatar',
         'phone',
         'birthday',
+        'sex',
         'created_at',
         'updated_at',
     ];

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -49,6 +49,8 @@ class UserTransformer extends BaseTransformer
                 return [
                     'id'        => $user->id,
                     'name'      => $user->name,
+                    'first_name'=> $user->first_name,
+                    'last_name' => $user->last_name,
                     'nickname'  => $user->nickname,
                     'avatar'    => $user->avatar,
                     'email'     => $user->email,

--- a/database/migrations/2019_10_28_133905_users_name_column_nullable.php
+++ b/database/migrations/2019_10_28_133905_users_name_column_nullable.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class UsersNameColumnNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function ($table) {
+            $table->string('name', 191)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $table->string('name', 191)->change();
+    }
+}

--- a/database/migrations/2019_10_28_133905_users_name_column_nullable.php
+++ b/database/migrations/2019_10_28_133905_users_name_column_nullable.php
@@ -24,6 +24,8 @@ class UsersNameColumnNullable extends Migration
      */
     public function down()
     {
-        $table->string('name', 191)->change();
+        Schema::table('users', function ($table) {
+            $table->string('name', 191)->nullable(false)->change();
+        });
     }
 }


### PR DESCRIPTION
# Description
Removed requirements around names for registration and user validation in general. This required a migration to make the name field of the user nullable. Also, generated a profile on registration for the new user and altered the Profile model to be able to do such.

## Issue Link
[FCBH-1045(https://fullstacklabs.atlassian.net/browse/FCBH-1045)

## How Do I QA This

**Note:** To run the test suite refer to the Readme.md

- On your local environment run `php artisan migrate --database="dbp_users"` to run the migration to make name a nullable field on User
- Register a user with no name and observe that this functions with no error from the backend and also returns the newly created profile object as part of the response.