### PR TITLE
FCBH-1017 Password requirements different on registration/reset password

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -688,7 +688,7 @@ class UsersController extends APIController
             'last_name'               => 'string|max:64|nullable',
             'remember_token'          => 'max:100',
             'verified'                => 'boolean',
-            'password'                => (request()->method() === 'POST') ? 'required|min:8' : '',
+            'password'                => (request()->method() === 'POST') ? 'required_without:social_provider_id|min:8' : '',
         ]);
 
         if ($validator->fails()) {

--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -332,7 +332,7 @@ class UsersController extends APIController
         ]);
 
         $sex = checkParam('sex') ?? 0;
-        $profile = Profile::create([
+        Profile::create([
             'user_id' => $user->id,
             'bio' => $request->bio,
             'address_1' => $request->address_1,
@@ -379,7 +379,7 @@ class UsersController extends APIController
             Auth::login($user, true);
             return redirect()->to('home');
         }
-        
+
         return $this->setStatusCode(200)->reply(fractal($user, new UserTransformer())->addMeta(['success' => 'User created']));
     }
 
@@ -398,7 +398,6 @@ class UsersController extends APIController
      *              @OA\Property(property="avatar",                  ref="#/components/schemas/User/properties/avatar"),
      *              @OA\Property(property="email",                   ref="#/components/schemas/User/properties/email"),
      *              @OA\Property(property="name",                    ref="#/components/schemas/User/properties/name"),
-     *              @OA\Property(property="password",                ref="#/components/schemas/User/properties/password"),
      *              @OA\Property(property="project_id",              ref="#/components/schemas/ProjectMember/properties/project_id"),
      *              @OA\Property(property="subscribed",              ref="#/components/schemas/ProjectMember/properties/subscribed"),
      *              @OA\Property(property="social_provider_id",      ref="#/components/schemas/Account/properties/provider_id"),
@@ -688,7 +687,8 @@ class UsersController extends APIController
             'first_name'              => 'string|max:64|nullable',
             'last_name'               => 'string|max:64|nullable',
             'remember_token'          => 'max:100',
-            'verified'                => 'boolean'
+            'verified'                => 'boolean',
+            'password'                => (request()->method() === 'POST') ? 'required|min:8' : '',
         ]);
 
         if ($validator->fails()) {


### PR DESCRIPTION
# Description
- Added 8 characters requirement to password on registration/reset password
- Removed password parameter on `/users` `PUT` endpoint  docs that is not being used 

## Issue Link
Original Story: [FCBH-1017](https://fullstacklabs.atlassian.net/browse/FCBH-1017) 
Review Story: [FCBH-1076](https://fullstacklabs.atlassian.net/browse/FCBH-1076) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Test `/users` `POST` endpoint and verify that now the password is being validated

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
