### PR TITLE
FCBH-1078 Fileset issue edge cases

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -250,7 +250,7 @@ class BiblesController extends APIController
 
         if ($asset_id) {
             $bible->filesets = $bible->filesets->filter(function ($fileset) use ($asset_id) {
-                return $fileset->asset_id === $asset_id;
+                return in_array($fileset->asset_id, explode(',', $asset_id));
             });
         }
 


### PR DESCRIPTION
Allow for an array of filesets when getting a bible's version detail.

**Also:** Jesus films have duplicate language ids solely based on iso code. We are now taking the one with the most number of speakers. The ones were were previously getting listed no speakers and threw an error for the specified ID.