### PR TITLE
FCBH-1086 Backend Small Bucket

### DIFF
--- a/app/Http/Controllers/User/NotesController.php
+++ b/app/Http/Controllers/User/NotesController.php
@@ -183,7 +183,7 @@ class NotesController extends APIController
             'chapter'     => $request->chapter,
             'verse_start' => $request->verse_start,
             'verse_end'   => $request->verse_end ?? $request->verse_start,
-            'notes'       => isset($request->notes) ? encrypt($request->notes) : null,
+            'notes'       =>  encrypt(isset($request->notes) ? $request->notes : ''),
         ]);
 
         $this->handleTags($note);
@@ -248,7 +248,7 @@ class NotesController extends APIController
             return $this->setStatusCode(404)->replyWithError(trans('api.user_notes_404'));
         }
 
-        $note->fill($request->only(['bible_id','book_id','chapter','verse_start','verse_end','notes']));
+        $note->fill($request->only(['bible_id', 'book_id', 'chapter', 'verse_start', 'verse_end']));
         if (isset($request->notes)) {
             $note->notes = encrypt($request->notes);
         }

--- a/app/Models/User/Study/Note.php
+++ b/app/Models/User/Study/Note.php
@@ -6,7 +6,7 @@ use App\Models\Bible\Bible;
 use App\Models\Bible\BibleBook;
 use App\Models\Bible\BibleFileset;
 use App\Models\Bible\BibleVerse;
-use App\Models\Bible\Book;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Crypt;
 
@@ -160,7 +160,11 @@ class Note extends Model
 
     public function getNotesAttribute($note)
     {
-        return Crypt::decrypt($note);
+        try {
+            return Crypt::decrypt($note);
+        } catch (DecryptException $e) {
+            return '';
+        }
     }
 
     /**


### PR DESCRIPTION
# Description
- On the `POST/PUT` notes endpoints added logic to avoid null values on the notes
- Retrieving an empty string instead of a 500 error when the notes decryption is not successful
- This was affecting all the notes if just one note has an issue with decryption the user could not get the other ones.

## Issue Link
Original Story: [FCBH-1086](https://fullstacklabs.atlassian.net/browse/FCBH-1086) 
Review Story: [FCBH-1116](https://fullstacklabs.atlassian.net/browse/FCBH-1116) 

## How Do I QA This
- On your local environment change the value of one of the notes to `NULL`
- Call `https://dbp.test/api/users/{USER_ID}/notes?chapter_id=4&limit=25&page=1&sort_by=updated_at&sort_dir=desc&key={API_KEY}&v=4` and verify you don't get an error

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
