### PR TITLE
FCBH-833 Remove avatar from User fillable

### DIFF
--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -55,7 +55,7 @@ class User extends Authenticatable
 
     protected $connection = 'dbp_users';
     protected $table     = 'users';
-    protected $fillable  = ['id','v2_id','name', 'avatar', 'first_name', 'last_name', 'created_at', 'updated_at', 'last_login', 'email', 'password', 'activated', 'token', 'notes', 'signup_ip_address', 'signup_confirmation_ip_address', 'signup_sm_ip_address', 'admin_ip_address', 'updated_ip_address', 'deleted_ip_address'];
+    protected $fillable  = ['id','v2_id','name', 'first_name', 'last_name', 'created_at', 'updated_at', 'last_login', 'email', 'password', 'activated', 'token', 'notes', 'signup_ip_address', 'signup_confirmation_ip_address', 'signup_sm_ip_address', 'admin_ip_address', 'updated_ip_address', 'deleted_ip_address', 'freshchat_restore_id'];
     protected $hidden    = ['password', 'remember_token', 'activated', 'token'];
     protected $dates     = ['deleted_at'];
 

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -7,43 +7,43 @@ class UserTransformer extends BaseTransformer
     public function transform($user)
     {
         switch ($this->version) {
-            case 2:
-            case 3:
-                return $this->transformForV2($user);
-            case 4:
-            default:
-                return $this->transformForV4($user);
-        }
+      case 2:
+      case 3:
+        return $this->transformForV2($user);
+      case 4:
+      default:
+        return $this->transformForV4($user);
+    }
     }
 
     public function transformForV4($user)
     {
         switch ($this->route) {
-            /**
-             *
-             * @see Controller: \App\Http\Controllers\User\UsersControllerV2::index
-             * @see https://api.dbp.test/users?key=test_key&v=4
-             *
-             * @OA\Schema (
-             *    title="v4_user_index",
-             *    type="array",
-             *    schema="v4_user_index",
-             *    description="The v4 user index response",
-             *    @OA\Xml(name="v4_user_index"),
-             *    @OA\Items(
-             *        @OA\Property(property="id",       ref="#/components/schemas/User/properties/id"),
-             *        @OA\Property(property="name",     ref="#/components/schemas/User/properties/name"),
-             *        @OA\Property(property="email",    ref="#/components/schemas/User/properties/email")
-             *    )
-             *  )
-             *
-             */
-            case 'v4_user.index':
-                return [
-                    'id'        => $user->id,
-                    'name'      => $user->name,
-                    'email'     => $user->email
-                ];
+      /**
+       *
+       * @see Controller: \App\Http\Controllers\User\UsersControllerV2::index
+       * @see https://api.dbp.test/users?key=test_key&v=4
+       *
+       * @OA\Schema (
+       *    title="v4_user_index",
+       *    type="array",
+       *    schema="v4_user_index",
+       *    description="The v4 user index response",
+       *    @OA\Xml(name="v4_user_index"),
+       *    @OA\Items(
+       *        @OA\Property(property="id",       ref="#/components/schemas/User/properties/id"),
+       *        @OA\Property(property="name",     ref="#/components/schemas/User/properties/name"),
+       *        @OA\Property(property="email",    ref="#/components/schemas/User/properties/email")
+       *    )
+       *  )
+       *
+       */
+      case 'v4_user.index':
+        return [
+          'id' => $user->id,
+          'name' => $user->name,
+          'email' => $user->email
+        ];
 
             case 'v4_user.store':
                 return [

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -59,6 +59,7 @@ class UserTransformer extends BaseTransformer
                     'accounts'  => $user->accounts,
                     'keys'      => $user->keys,
                     'api_token' => $user->api_token,
+                    'freshchat_restore_id' => $user ->freshchat_restore_id
                 ];
 
             /**
@@ -89,6 +90,7 @@ class UserTransformer extends BaseTransformer
                     'profile'   => $user->profile,
                     'organizations' => $user->organizations,
                     'accounts'  => $user->accounts,
+                    'freshchat_restore_id' => $user ->freshchat_restore_id
                 ];
         }
     }

--- a/database/migrations/2019_10_24_174251_add_freshchat_restore_id_to_user.php
+++ b/database/migrations/2019_10_24_174251_add_freshchat_restore_id_to_user.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddFreshchatRestoreIdToUser extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('users', function (
+      Blueprint $table
+    ) {
+            $table
+        ->string('freshchat_restore_id')
+        ->after('token')
+        ->nullable()
+        ->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('users', function (
+      Blueprint $table
+    ) {
+            $table->dropColumn('freshchat_restore_id');
+        });
+    }
+}


### PR DESCRIPTION
The avatar column does not exist in the user table and was causing an error when trying to update the user.  It can be added back in when an implementation of the avatar is done.  Also added the `freshchat_restore_id` to the fillable.