### PR TITLE
FCBH-1114 Create separate byterate/segments tables

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -83,7 +83,7 @@ class StreamController extends APIController
             $fileset_type = 'video';
         }
 
-        $file = BibleFile::with('streamBandwidth.transportStream')->whereId($file_id)->first();
+        $file = BibleFile::with('streamBandwidth.transportStreamTS')->with('streamBandwidth.transportStreamBytes')->whereId($file_id)->first();
         if (!$file) {
             return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id]));
         }
@@ -100,6 +100,7 @@ class StreamController extends APIController
         } catch (\Exception $e) {
             Log::error($e);
         }
+        $currentBandwidth->transportStream = sizeof($currentBandwidth->transportStreamBytes) ? $currentBandwidth->transportStreamBytes : $currentBandwidth->transportStreamTS;
 
         $current_file = "#EXTM3U\n";
         $current_file .= '#EXT-X-TARGETDURATION:' . ceil($currentBandwidth->transportStream->max('runtime')) . "\n";

--- a/app/Models/Bible/StreamBandwidth.php
+++ b/app/Models/Bible/StreamBandwidth.php
@@ -15,8 +15,13 @@ class StreamBandwidth extends Model
         return $this->belongsTo(BibleFile::class, 'bible_file_id', 'id');
     }
 
-    public function transportStream()
+    public function transportStreamTS()
     {
-        return $this->hasMany(StreamSegment::class);
+        return $this->hasMany(StreamTS::class);
+    }
+
+    public function transportStreamBytes()
+    {
+        return $this->hasMany(StreamBytes::class);
     }
 }

--- a/app/Models/Bible/StreamBytes.php
+++ b/app/Models/Bible/StreamBytes.php
@@ -4,11 +4,10 @@ namespace App\Models\Bible;
 
 use Illuminate\Database\Eloquent\Model;
 
-class StreamSegment extends Model
+class StreamBytes extends Model
 {
     protected $connection = 'dbp';
-    protected $table = 'bible_file_stream_segments';
-    protected $fillable = ['file_name','runtime'];
+    protected $table = 'bible_file_stream_bytes';
 
     public function timestamp()
     {

--- a/app/Models/Bible/StreamTS.php
+++ b/app/Models/Bible/StreamTS.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models\Bible;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StreamTS extends Model
+{
+    protected $connection = 'dbp';
+    protected $table = 'bible_file_stream_ts';
+    protected $fillable = ['file_name','runtime'];
+}

--- a/database/migrations/2019_11_09_175918_create_bible_files_stream_bytes_table.php
+++ b/database/migrations/2019_11_09_175918_create_bible_files_stream_bytes_table.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateBibleFilesStreamBytesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::connection('dbp')->hasTable('bible_file_stream_bytes')) {
+            Schema::connection('dbp')->create('bible_file_stream_bytes', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('stream_bandwidth_id')->unsigned();
+                $table->foreign('stream_bandwidth_id', 'FK_bible_file_bandwidth_stream_bytes')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_stream_bandwidths')->onUpdate('cascade')->onDelete('cascade');
+                $table->float('runtime');
+                $table->integer('bytes');
+                $table->integer('offset');
+                $table->integer('timestamp_id')->unsigned();
+                $table->foreign('timestamp_id', 'FK_bible_file_timestamp_stream_bytes')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_timestamps')->onUpdate('cascade')->onDelete('cascade');
+                $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+                $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));
+            });
+        }
+
+        if (Schema::connection('dbp')->hasTable('bible_file_stream_segments')) {
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                \DB::connection('dbp')->statement('INSERT bible_file_stream_bytes (stream_bandwidth_id, runtime, bytes, offset, timestamp_id) SELECT stream_bandwidth_id, runtime, bytes, offset, timestamp_id FROM bible_file_stream_segments where file_name is null');
+                \DB::connection('dbp')->table('bible_file_stream_segments')->whereNull('file_name')->delete();
+                $table->dropColumn('bytes');
+                $table->dropColumn('offset');
+                $table->dropForeign('FK_bible_file_timestamp_stream_segments');
+                $table->dropColumn('timestamp_id');
+                $table->string('file_name')->nullable(false)->change();
+                $table->dropForeign('FK_stream_bandwidths_stream_segments');
+                $table->foreign('stream_bandwidth_id', 'FK_stream_bandwidths_stream_ts')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_stream_bandwidths')->onUpdate('cascade')->onDelete('cascade');
+            });
+            Schema::connection('dbp')->rename('bible_file_stream_segments', 'bible_file_stream_ts');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_file_stream_ts')) {
+            Schema::connection('dbp')->rename('bible_file_stream_ts', 'bible_file_stream_segments');
+            Schema::connection('dbp')->table('bible_file_stream_segments', function (Blueprint $table) {
+                $table->integer('bytes')->nullable()->after('runtime')->default(null);
+                $table->integer('offset')->nullable()->after('runtime')->default(null);
+                $table->integer('timestamp_id')->unsigned()->nullable()->after('runtime');
+                $table->string('file_name')->nullable()->change();
+                $table->foreign('timestamp_id', 'FK_bible_file_timestamp_stream_segments')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_timestamps')->onUpdate('cascade')->onDelete('cascade');
+                $table->dropForeign('FK_stream_bandwidths_stream_ts');
+                $table->foreign('stream_bandwidth_id', 'FK_stream_bandwidths_stream_segments')->references('id')->on(config('database.connections.dbp.database') . '.bible_file_stream_bandwidths')->onUpdate('cascade')->onDelete('cascade');
+            });
+        }
+        Schema::connection('dbp')->dropIfExists('bible_file_stream_bytes');
+    }
+}

--- a/database/seeds/RealDataSeeder.php
+++ b/database/seeds/RealDataSeeder.php
@@ -33,7 +33,7 @@ use App\Models\Bible\BibleFilesetCopyright;
 use App\Models\Bible\BibleFilesetCopyrightRole;
 use App\Models\Bible\BibleFilesetCopyrightOrganization;
 use App\Models\Bible\StreamBandwidth;
-use App\Models\Bible\StreamSegment;
+use App\Models\Bible\StreamTS;
 
 use App\Models\Organization\Asset;
 use App\Models\Organization\Organization;
@@ -86,7 +86,7 @@ class RealDataSeeder extends Seeder
         $this->seedData('/bibles/bible_fileset_copyright_organizations', BibleFilesetCopyrightOrganization::class);
         $this->seedData('/bibles/bible_files',                           BibleFile::class);
         $this->seedData('/bibles/bible_file_video_resolutions',          StreamBandwidth::class);
-        $this->seedData('/bibles/bible_file_video_transport_stream',     StreamSegment::class);
+        $this->seedData('/bibles/bible_file_video_transport_stream',     StreamTS::class);
         $this->seedData('/bibles/bible_organization',                    BibleOrganization::class);
         $this->seedData('/bibles/equivalents/bible-gateway',             BibleEquivalent::class);
         $this->seedData('/access/access_groups',                         AccessGroup::class);


### PR DESCRIPTION
# Description
- Added migration to create `bible_file_stream_bytes` table
- Removed `bytes, offset and timestamp_id` from `bible_file_stream_segments` table
- Renamed `bible_file_stream_segments` to `bible_file_stream_ts`
- Updated StreamController and PlaylistController to work with the new tables schema

## Issue Link
Original Story: [FCBH-1114](https://fullstacklabs.atlassian.net/browse/FCBH-1114) 
Review Story: [FCBH-1142](https://fullstacklabs.atlassian.net/browse/FCBH-1142) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Test `playlists/{id}/`, `/playlists?showDetails=true` endpoints and verify that now you get the path parameter with the hls file of the playlist 
- Test `ENGESV` chapters are working

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
