### PR TITLE
FCBH-1093 Return a 401 error instead of 500 when the api_token is required and is not valid

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -85,6 +85,9 @@ class Handler extends ExceptionHandler
 
         if ($exception instanceof \Illuminate\Auth\AuthenticationException) {
             $exception = $this->unauthenticated($request, $exception);
+            if (!config('app.env') !== 'debug') {
+                return $exception;
+            }
         }
 
         if ($exception instanceof \Illuminate\Validation\ValidationException) {

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -143,8 +143,15 @@ class Handler extends ExceptionHandler
      */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        if ($request->expectsJson()) {
-            return response()->json(['error' => 'Unauthenticated.'], Response::HTTP_UNAUTHORIZED);
+        if ($request->expectsJson() || $exception->api_response) {
+            $response = [];
+            $response['error'] = Response::$statusTexts[Response::HTTP_UNAUTHORIZED];
+            if (config('app.debug')) {
+                $response['trace'] = $exception->getTrace();
+            }
+            $response['status_code'] = Response::HTTP_UNAUTHORIZED;
+            $response['host_name'] = gethostname();
+            return response()->json($response, Response::HTTP_UNAUTHORIZED);
         }
 
         return redirect()->guest(route('login'));

--- a/app/Http/Middleware/APIToken.php
+++ b/app/Http/Middleware/APIToken.php
@@ -43,7 +43,9 @@ class APIToken
 
         if ($type === 'check') {
             if (!$this->auth->guard($guard)->check()) {
-                throw new AuthenticationException(trans('auth.failed'));
+                $exception = new AuthenticationException(trans('auth.failed'));
+                $exception->api_response = true;
+                throw $exception;
             }
         }
 


### PR DESCRIPTION
# Description
- Added a `401` api_response when the api_token is required and is not valid

## Issue Link
Original Story: [FCBH-1093](https://fullstacklabs.atlassian.net/browse/FCBH-1093) 
Review Story: [FCBH-1145](https://fullstacklabs.atlassian.net/browse/FCBH-1145) 

## How Do I QA This
- On your local environment test `https://dbp.test/api/push_notifications?key={API_KEY}&v=4&api_token=wrong_api_token` GET endpoint and verify you get a 401 error


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
