### PR TITLE
FCBH-1123 Delete completed day items

### DIFF
--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -4,6 +4,8 @@ namespace App\Models\Plan;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\Playlist\PlaylistItems;
+use App\Models\Playlist\PlaylistItemsComplete;
 
 /**
  * @OA\Schema (
@@ -104,6 +106,15 @@ class UserPlan extends Model
         ;
         $this->attributes['percentage_completed'] = 0;
         $this->attributes['start_date'] = $start_date;
+        
+        PlanDay::where('plan_id', $this->plan_id)->get()
+        ->each(function ($plan_day) {
+            $test = PlaylistItems::where('playlist_id', $plan_day->playlist_id)->get()
+            ->each(function ($playlist_item) {
+                PlaylistItemsComplete::where('playlist_item_id', $playlist_item->id)->delete();
+            });
+        });
+
         return $this;
     }
 }


### PR DESCRIPTION
When a plan is reset, the day items need to also be reset.  This quick enumeration of each plan day and playlist item accomplishes that.