### PR TITLE
FCBH-1173 Long loads on Playlists

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -470,9 +470,13 @@ class PlaylistsController extends APIController
                 'chapter_start'     => $playlist_item->chapter_start,
                 'chapter_end'       => $playlist_item->chapter_end,
                 'verse_start'       => $playlist_item->verse_start,
-                'verse_end'         => $playlist_item->verse_end
+                'verse_end'         => $playlist_item->verse_end,
+                'verses'            => $playlist_item->verses
             ]);
             $created_playlist_item->calculateDuration()->save();
+            if (!$playlist_item->verses) {
+                $created_playlist_item->calculateVerses()->save();
+            }
             $created_playlist_items[] = $created_playlist_item;
         }
 

--- a/database/migrations/2019_11_21_084934_add_verses_to_playlist_items_table.php
+++ b/database/migrations/2019_11_21_084934_add_verses_to_playlist_items_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Playlist\PlaylistItems;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddVersesToPlaylistItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('playlist_items', function (Blueprint $table) {
+            $table->integer('verses')->after('verse_end')->unsigned();
+        });
+        $play_list_items = PlaylistItems::all();
+        foreach ($play_list_items as $play_list_item) {
+            $play_list_item->calculateVerses()->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('playlist_items', function (Blueprint $table) {
+            $table->dropColumn('verses');
+        });
+    }
+}


### PR DESCRIPTION
# Description
- Added `verses` row to PlayListItem to avoid multiple calculations when the query of the playlist items, now the calculation is being done when the item is created
- Added migration that also fills the new verses row

## Issue Link
Original Story: [FCBH-1173](https://fullstacklabs.atlassian.net/browse/FCBH-1173) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Test `playlists` GET and verify that is working correctly

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
