### PR TITLE
FCBH-1191 Fileset "has audio" endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -91,6 +91,7 @@ Route::name('v4_bible.defaults')->get('bibles/defaults/types',                  
 
 // VERSION 4 | Filesets
 Route::name('v4_filesets.types')->get('bibles/filesets/media/types',               'Bible\BibleFileSetsController@mediaTypes');
+Route::name('v4_filesets.checkTypes')->post('bibles/filesets/check/types',         'Bible\BibleFileSetsController@checkTypes');
 Route::name('v4_filesets.podcast')->get('bibles/filesets/{fileset_id}/podcast',    'Bible\BibleFilesetsPodcastController@index');
 Route::name('v4_filesets.download')->get('bibles/filesets/{fileset_id}/download',  'Bible\BibleFileSetsController@download');
 Route::name('v4_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright', 'Bible\BibleFileSetsController@copyright');


### PR DESCRIPTION
# Description
- Added `bibles/filesets/check/types` in order to validate Bible locations
- Now we can validate if the objects have audio and video

## Issue Link
Original Story: [FCBH-1191](https://fullstacklabs.atlassian.net/browse/FCBH-1191) 

## How Do I QA This
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Test the body example on `bibles/filesets/check/types` POST endpoint and verify that you get a `has_audio`, `has_video` response

**Body:**
```javascript
[
  {
    "fileset_id": "ENGESV",
    "book_id": "MAT",
    "chapter_start": 1,
    "chapter_end": 1,
    "verse_start": 1,
    "verse_end": 2
  },
  {
    "fileset_id": "ENGESV",
    "book_id": "GEN",
    "chapter_start": 1,
    "chapter_end": 1,
    "verse_start": 1,
    "verse_end": 2
  }
]
```

**Result:**

```javascript 
[
    {
        "fileset_id": "ENGESV",
        "book_id": "MAT",
        "chapter_start": 1,
        "chapter_end": 1,
        "verse_start": 1,
        "verse_end": 2,
        "has_audio": true,
        "has_video": false
    },
    {
        "fileset_id": "ENGESV",
        "book_id": "GEN",
        "chapter_start": 1,
        "chapter_end": 1,
        "verse_start": 1,
        "verse_end": 2,
        "has_audio": true,
        "has_video": false
    }
]
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
