### PR TITLE
FCBH-1171 Chapters returned without Content

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -8,13 +8,11 @@ use App\Traits\AccessControlAPI;
 use App\Traits\CallsBucketsTrait;
 use App\Http\Controllers\APIController;
 
-use App\Models\Bible\Bible;
 use App\Models\Bible\BibleFileset;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFilesetType;
 use App\Models\Bible\Book;
 use App\Models\Language\Language;
-use App\Models\User\Key;
 
 use App\Transformers\FileSetTransformer;
 use Illuminate\Http\Request;

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -217,6 +217,12 @@ class BiblesController extends APIController
      *          @OA\Schema(type="string"),
      *          description="The asset_id to filter results by. There are three buckets provided `dbp-prod`, `dbp-vid` & `dbs-web`"
      *     ),
+     *     @OA\Parameter(
+     *          name="asset_id",
+     *          in="query",
+     *          @OA\Schema(type="string"),
+     *          description="The asset_id to filter results by. There are three buckets provided `dbp-prod`, `dbp-vid` & `dbs-web`"
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -270,6 +276,12 @@ class BiblesController extends APIController
      *     @OA\Parameter(name="id",in="path",required=true,@OA\Schema(ref="#/components/schemas/Bible/properties/id")),
      *     @OA\Parameter(name="book_id",in="query", description="The book id. For a complete list see the `book_id` field in the `/bibles/books` route.",@OA\Schema(ref="#/components/schemas/Book/properties/id")),
      *     @OA\Parameter(name="testament",in="query",@OA\Schema(ref="#/components/schemas/Book/properties/book_testament")),
+     *     @OA\Parameter(
+     *          name="verify_content",
+     *          in="query",
+     *          @OA\Schema(type="boolean"),
+     *          description="Filter all the books that have content"
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -290,28 +290,81 @@ class BiblesController extends APIController
         $book_id   = checkParam('book_id', false, $book_id);
         $testament = checkParam('testament');
 
+        $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh.bucket');
+        $verify_content = checkParam('verify_content');
+        $verify_content = $verify_content && $verify_content != 'false';
+
         $bible = Bible::find($bible_id);
+        $access_control = $this->accessControl($this->key);
+        $cache_string = strtolower('bible_books_bible:' . $bible_id . ':' . $access_control->string . ':' . $verify_content . ':' . $asset_id);
+        $bible = \Cache::remember($cache_string, now()->addDay(), function () use ($access_control, $bible_id, $asset_id, $verify_content) {
+            if (!$verify_content) {
+                return Bible::find($bible_id);
+            }
+
+            return  Bible::with([
+                'filesets' => function ($query) use ($access_control, $asset_id) {
+                    $query->whereIn('bible_filesets.hash_id', $access_control->hashes);
+                    if ($asset_id) {
+                        $query->whereIn('bible_filesets.asset_id', explode(',', $asset_id));
+                    }
+                }
+            ])->find($bible_id);
+        });
+
+
         if (!$bible) {
             return $this->setStatusCode(404)->replyWithError(trans('api.bibles_errors_404', ['bible_id' => $bible_id]));
         }
 
-        $books = BibleBook::where('bible_id', $bible_id)
-            ->with(['book' => function ($query) use ($testament) {
-                if ($testament) {
+        $cache_string = strtolower('bible_books_books:' . $bible_id . ':' . $testament . ':' . $book_id);
+        $books = \Cache::remember($cache_string, now()->addDay(), function () use ($bible_id, $testament, $book_id, $bible) {
+            $books = BibleBook::where('bible_id', $bible_id)
+                ->when($testament, function ($query) use ($testament) {
                     $query->where('book_testament', $testament);
+                })
+                ->when($book_id, function ($query) use ($book_id) {
+                    $query->where('book_id', $book_id);
+                })
+                ->get()->sortBy('book.' . $bible->versification . '_order')
+                ->filter(function ($item) {
+                    return $item->book;
+                })->flatten();
+            return $books;
+        });
+
+        if ($verify_content) {
+            $cache_string = strtolower('bible_books_books_verified:' . $bible_id . ':' . $access_control->string . ':' . $verify_content . ':' . $asset_id . ':' . $testament . ':' . $book_id);
+            $books = \Cache::remember($cache_string, now()->addDay(), function () use ($books, $bible) {
+                $book_controller = new BooksController();
+                $active_books = [];
+                foreach ($bible->filesets as $fileset) {
+                    $books_fileset = $book_controller->getActiveBooksFromFileset($fileset->id, $fileset->asset_id, $fileset->set_type_code)->pluck('id');
+                    $active_books = $this->processActiveBooks($books_fileset, $active_books, $fileset->set_type_code);
                 }
-            }])
-            ->when($book_id, function ($query) use ($book_id) {
-                $query->where('book_id', $book_id);
-            })
-            ->get()->sortBy('book.' . $bible->versification . '_order')
-            ->filter(function ($item) {
-                return $item->book;
-            })->flatten();
+
+                return $books->map(function ($book) use ($active_books) {
+                    if (isset($active_books[$book->book_id])) {
+                        $book->content_types = array_unique($active_books[$book->book_id]);
+                    }
+                    return $book;
+                })->filter(function ($book) {
+                    return $book->content_types;
+                });
+            });
+        }
 
         return $this->reply(fractal($books, new BooksTransformer));
     }
 
+    private function processActiveBooks($books, $active_books, $set_type_code)
+    {
+        foreach ($books as $book) {
+            $active_books[$book] =  $active_books[$book] ?? [];
+            $active_books[$book][] = $set_type_code;
+        }
+        return $active_books;
+    }
 
     /**
      * @OA\GET(

--- a/app/Transformers/BooksTransformer.php
+++ b/app/Transformers/BooksTransformer.php
@@ -45,7 +45,7 @@ class BooksTransformer extends BaseTransformer
                     'dam_id'       => $book->bible_id,
                     'chapter_list' => implode(',', $book->sophia_chapters),
                     '_links'       => [
-                        'self' => [ 'href' => 'http://v3.dbt.io/search/'.$manufactured_id ]
+                        'self' => ['href' => 'http://v3.dbt.io/search/' . $manufactured_id]
                     ]
                 ];
 
@@ -61,7 +61,7 @@ class BooksTransformer extends BaseTransformer
                     'chapters'     => $book->chapters,
                     'chapter_list' => $book->chapters->pluck('number')->implode(','),
                     '_links'       => [
-                        'self' => [ 'href' => 'http://v3.dbt.io/search/'.$manufactured_id ]
+                        'self' => ['href' => 'http://v3.dbt.io/search/' . $manufactured_id]
                     ]
                 ];
         }
@@ -132,7 +132,7 @@ class BooksTransformer extends BaseTransformer
                 ];
 
             case 'v4_bible.books':
-                return [
+                $result = [
                     'book_id'         => $book->book->id,
                     'book_id_usfx'    => $book->book->id_usfx,
                     'book_id_osis'    => $book->book->id_osis,
@@ -143,6 +143,10 @@ class BooksTransformer extends BaseTransformer
                     'book_group'      => $book->book->book_group,
                     'chapters'        => array_map('\intval', explode(',', $book->chapters)),
                 ];
+                if ($book->content_types) {
+                    $result['content_types'] = $book->content_types;
+                }
+                return $result;
 
             case 'v4_bible_filesets.books':
             default:


### PR DESCRIPTION

# Description
- Added `verify_content` and `asset_id` parameters to `/bibles/{id}/book` endpoint in order to return only the books with content.
- Now the returned books have a `content_types` array with the the types of filests availables


## Issue Link
Original Story: [FCBH-1171](https://fullstacklabs.atlassian.net/browse/FCBH-1171) 

## How Do I QA This
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Test the body example on `https://dbp.test/api/bibles/TGKIBT/book?v=4&{API_KEY}&verify_content=true&asset_id=dbp-prod,dbp-vid` and verify that the books returned are only the ones with content

**Result:**
```javascript
[
       {
            "book_id": "RUT",
            "book_id_usfx": "RT",
            "book_id_osis": "Ruth",
            "name": "Рут",
            "testament": "OT",
            "testament_order": 8,
            "book_order": 8,
            "book_group": "Historical Books",
            "chapters": [
                1,
                2,
                3,
                4
            ],
            "content_types": [
                "text_plain",
                "text_format"
            ]
        },
  ...
]
```

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
