### PR TITLE
FCBH-1206 Looking for unique filesets should include connections

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -223,9 +223,7 @@ class BibleFileset extends Model
                 } else {
                     $connections = \DB::table('bible_fileset_connections')
                     ->select('hash_id')
-                     ->where('bible_id', 'LIKE', $id . '%')->get()->map(function ($item) {
-                         return $item->hash_id;
-                     });
+                     ->where('bible_id', 'LIKE', $id . '%')->get()->pluck('hash_id');
 
                     if ($connections) {
                         $query->whereIn('bible_filesets.hash_id', $connections);

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -221,7 +221,17 @@ class BibleFileset extends Model
                         ->orWhere('bible_filesets.id', 'like',  substr($id, 0, 6))
                         ->orWhere('bible_filesets.id', 'like', substr($id, 0, -2) . '%');
                 } else {
-                    $query->where('bible_filesets.id', $id);
+                    $connections = \DB::table('bible_fileset_connections')
+                    ->select('hash_id')
+                     ->where('bible_id', 'LIKE', $id . '%')->get()->map(function ($item) {
+                         return $item->hash_id;
+                     });
+
+                    if ($connections) {
+                        $query->whereIn('bible_filesets.hash_id', $connections);
+                    } else {
+                        $query->where('bible_filesets.id', $id);
+                    }
                 }
             });
         })

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -225,11 +225,10 @@ class BibleFileset extends Model
                     ->select('hash_id')
                      ->where('bible_id', 'LIKE', $id . '%')->get()->pluck('hash_id');
 
-                    if ($connections) {
-                        $query->whereIn('bible_filesets.hash_id', $connections);
-                    } else {
-                        $query->where('bible_filesets.id', $id);
-                    }
+                    $query->where('bible_filesets.id', $id)
+                     ->when($connections, function ($q) use ($connections) {
+                         $q->orWhereIn('bible_filesets.hash_id', $connections);
+                     });
                 }
             });
         })


### PR DESCRIPTION
instead of relying on a bible id match, all connected filesets are gotten. If the connections are available, then we'll use the same old method of trying to match up by id.