### PR TITLE
FCBH-1208 Small fixes to support miniplayer/playlists

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -202,9 +202,6 @@ class PlaylistsController extends APIController
      */
     public function show(Request $request, $playlist_id)
     {
-        // Fetch and Assign $_GET params
-        $asset_id    = checkParam('bucket|bucket_id|asset_id') ?? config('filesystems.disks.s3.bucket');
-
         $user = $request->user();
 
         // Validate Project / User Connection
@@ -671,7 +668,7 @@ class PlaylistsController extends APIController
         return (object) ['hls_items' => $hls_items, 'signed_files' => $signed_files];
     }
 
-    private function processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, , $download, $item)
+    private function processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, $download, $item)
     {
         foreach ($bible_files as $bible_file) {
             $default_duration = $bible_file->duration ?? 180;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -601,7 +601,7 @@ class PlaylistsController extends APIController
                 $signed_files = $result->signed_files;
                 $durations[] = $this->getMaxRuntime($bible_files);
             } else {
-                $result = $this->processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, $download);
+                $result = $this->processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, $download, $item);
                 $hls_items = $result->hls_items;
                 $signed_files = $result->signed_files;
                 $durations[] = $bible_files->max('duration');
@@ -671,11 +671,11 @@ class PlaylistsController extends APIController
         return (object) ['hls_items' => $hls_items, 'signed_files' => $signed_files];
     }
 
-    private function processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, $download)
+    private function processMp3Audio($bible_files, $hls_items, $signed_files, $transaction_id, , $download, $item)
     {
         foreach ($bible_files as $bible_file) {
             $default_duration = $bible_file->duration ?? 180;
-            $hls_items .= "\n#EXTINF:$default_duration,";
+            $hls_items .= "\n#EXTINF:$default_duration," . $item->id;
 
             $bible_path = $bible_file->fileset->bible->first()->id;
             $file_path = 'audio/' . $bible_path . '/' . $bible_file->fileset->id . '/' . $bible_file->file_name;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -202,6 +202,9 @@ class PlaylistsController extends APIController
      */
     public function show(Request $request, $playlist_id)
     {
+        // Fetch and Assign $_GET params
+        $asset_id    = checkParam('bucket|bucket_id|asset_id') ?? config('filesystems.disks.s3.bucket');
+
         $user = $request->user();
 
         // Validate Project / User Connection

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -154,6 +154,5 @@ class Playlist extends Model
     public function items()
     {
         return $this->hasMany(PlaylistItems::class)->orderBy('order_column');
-        ;
     }
 }


### PR DESCRIPTION
# Description
- Now sending Bible Id for Playlist items so that we can display that properly and not just do the slice on the fileset string.
- Also fixed a tiny issue where the items weren't getting sent in when creating HLS for mp3 audio and thus the durations of the items were not being read by the client.

## Test Steps
- Do a get pull to get playlists with items and observe that the items have bible ids: `/playlists/{PLAYLIST_ID}?asset_id=dbp-prod&api_token={API_TOKEN}&v=4&key={API_KEY}`
- Get HLS for a playlist that has mp3 audio and ensure that each item has durations: `/playlists/{PLAYLIST_ID}/hls?v=4&key={API_KEY}`