### PR TITLE
FCBH-1228 App crashes in Danish when attempting to play Jesus films

### DIFF
--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -100,7 +100,13 @@ class VideoStreamController extends APIController
 
         $cache_string = 'arclight_media_components_' . $chapter_id . $language_id;
         $stream_file  = \Cache::remember($cache_string, now()->addDay(), function () use ($chapter_id, $language_id) {
-            $media_components = $this->fetchArclight('media-components/' . $chapter_id . '/languages/' . $language_id, $language_id, false);
+            try {
+                $media_components = $this->fetchArclight('media-components/' . $chapter_id . '/languages/' . $language_id, $language_id, false);
+            } catch (\Exception $e) {
+                $language_id = 529;
+                $media_components = $this->fetchArclight('media-components/' . $chapter_id . '/languages/' . $language_id, $language_id, false);
+            }
+
             return file_get_contents($media_components->streamingUrls->m3u8[0]->url);
         });
 

--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -57,7 +57,7 @@ class VideoStreamController extends APIController
         $metadataLanguageTag = isset($media_languages->bcp47) ? $media_languages->bcp47 : '';
 
         $metadata = \Cache::remember($cache_string, now()->addDay(), function () use ($arclight_id, $metadataLanguageTag) {
-            $media_components = $this->fetchArclight('media-components', $arclight_id, true, 'metadataLanguageTags=' . $metadataLanguageTag . ',en');
+            $media_components = $this->fetchArclight('media-components', $arclight_id . ',529', true, 'metadataLanguageTags=' . $metadataLanguageTag . ',en');
             $metadata = collect($media_components->mediaComponents)
                 ->map(function ($component) use ($arclight_id) {
                     return [


### PR DESCRIPTION
# Description
- Added default English arclight_id in order to get metadata results when are not available on the requested language. 


## Issue Link
 [FCBH-1228](https://fullstacklabs.atlassian.net/browse/FCBH-1228) 


## How Do I QA This
- Test `https://dbp.test/api/arclight/jesus-film/chapters?v=4&key={API_KEY}&iso=fra` and verify you get metadata results
- Test `https://dbp.test/api/arclight/jesus-film/chapters?v=4&key={API_KEY}&iso=dan` and verify you get metadata results

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
