### PR TITLE
FCBH-1268 Fix empty languages for Gospel Films

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -50,15 +50,22 @@ function checkParam(string $paramName, $required = false, $inPathValue = null)
     }
 }
 
+function checkBoolean(string $paramName, $required = false, $inPathValue = null)
+{
+    $param = checkParam($paramName, $required, $inPathValue);
+    $param = $param && $param != 'false';
+    return $param;
+}
+
 function apiLogs($request, $status_code, $s3_string = false, $ip_address = null)
 {
-    $log_string = time().'∞'.config('app.server_name').'∞'.$status_code.'∞'.$request->path().'∞';
-    $log_string .= '"'.$request->header('User-Agent').'"'.'∞';
+    $log_string = time() . '∞' . config('app.server_name') . '∞' . $status_code . '∞' . $request->path() . '∞';
+    $log_string .= '"' . $request->header('User-Agent') . '"' . '∞';
     foreach ($_GET as $header => $value) {
-        $log_string .= ($value !== '') ? $header.'='.$value.'|' : $header.'|';
+        $log_string .= ($value !== '') ? $header . '=' . $value . '|' : $header . '|';
     }
     $log_string = rtrim($log_string, '|');
-    $log_string .= '∞'.$ip_address.'∞';
+    $log_string .= '∞' . $ip_address . '∞';
     if ($s3_string) {
         $log_string .= $s3_string;
     }
@@ -68,7 +75,7 @@ function apiLogs($request, $status_code, $s3_string = false, $ip_address = null)
     }
 }
 
-if (! function_exists('csvToArray')) {
+if (!function_exists('csvToArray')) {
     function csvToArray($csvfile)
     {
         $csv      = [];
@@ -98,7 +105,7 @@ if (! function_exists('csvToArray')) {
     }
 }
 
-if (! function_exists('unique_random')) {
+if (!function_exists('unique_random')) {
     /**
      *
      * Generate a unique random string of characters

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -108,8 +108,7 @@ class BiblesController extends APIController
         $size               = checkParam('size');
         $size_exclude       = checkParam('size_exclude');
         $bitrate            = checkParam('bitrate');
-        $show_restricted    = checkParam('show_all|show_restricted');
-        $show_restricted = $show_restricted && $show_restricted != 'false';
+        $show_restricted    = checkBoolean('show_all|show_restricted');
         $limit      = checkParam('limit');
         $page       = checkParam('page');
 
@@ -303,8 +302,7 @@ class BiblesController extends APIController
         $testament = checkParam('testament');
 
         $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh.bucket');
-        $verify_content = checkParam('verify_content');
-        $verify_content = $verify_content && $verify_content != 'false';
+        $verify_content = checkBoolean('verify_content');
 
         $bible = Bible::find($bible_id);
         $access_control = $this->accessControl($this->key);

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -85,8 +85,7 @@ class PlansController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
-        $featured = checkParam('featured');
-        $featured = $featured && $featured != 'false' || empty($user);
+        $featured = checkBoolean('featured') || empty($user);
         $limit        = (int) (checkParam('limit') ?? 25);
         $sort_by    = checkParam('sort_by') ?? 'name';
         $sort_dir   = checkParam('sort_dir') ?? 'asc';
@@ -221,8 +220,7 @@ class PlansController extends APIController
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');
         }
 
-        $show_details = checkParam('show_details');
-        $show_details = $show_details && $show_details != 'false';
+        $show_details = checkBoolean('show_details');
 
         $playlist_controller = new PlaylistsController();
         if ($show_details) {

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -90,14 +90,12 @@ class PlaylistsController extends APIController
         $sort_by    = checkParam('sort_by') ?? 'name';
         $sort_dir   = checkParam('sort_dir') ?? 'asc';
 
-        $featured = checkParam('featured');
-        $featured = $featured && $featured != 'false' || empty($user);
+        $featured = checkBoolean('featured') || empty($user);
         $limit    = (int) (checkParam('limit') ?? 25);
 
         $select = ['user_playlists.*', DB::Raw('IF(playlists_followers.user_id, true, false) as following')];
 
-        $show_details = checkParam('show_details');
-        $show_details = $show_details && $show_details != 'false';
+        $show_details = checkBoolean('show_details');
         $playlists = Playlist::with('user')
             ->when($show_details, function ($query) {
                 $query->with('items');
@@ -369,8 +367,7 @@ class PlaylistsController extends APIController
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
         }
 
-        $follow = checkParam('follow');
-        $follow = $follow && $follow != 'false';
+        $follow = checkBoolean('follow');
 
 
         if ($follow) {
@@ -564,8 +561,7 @@ class PlaylistsController extends APIController
 
     public function hls(Response $response, $playlist_id)
     {
-        $download = checkParam('download');
-        $download = $download && $download != 'false';
+        $download = checkBoolean('download');
         $playlist = Playlist::with('items')->find($playlist_id);
         if (!$playlist) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');

--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -595,11 +595,9 @@ class UsersController extends APIController
             return $this->setStatusCode(401)->reply(['valid' => false]);
         }
 
-        $user_details = checkParam('user_details');
-        $user_details = $user_details && $user_details != 'false';
+        $user_details = checkBoolean('user_details');
 
-        $renew_token = checkParam('renew_token');
-        $renew_token = $renew_token && $renew_token != 'false';
+        $renew_token = checkBoolean('renew_token');
 
         $response = ['valid' => true];
         $api_token = checkParam('api_token');

--- a/app/Transformers/LanguageTransformer.php
+++ b/app/Transformers/LanguageTransformer.php
@@ -45,7 +45,7 @@ class LanguageTransformer extends BaseTransformer
                     'language_family_iso_2T'    => ($language->parent ? $language->parent->iso2T : $language->iso2T) ?? '',
                     'language_family_iso_1'     => ($language->parent ? $language->parent->iso1 : $language->iso1) ?? '',
                     'media'                     => ['text'],
-                    'delivery'                  => ['mobile','web','subsplash'],
+                    'delivery'                  => ['mobile', 'web', 'subsplash'],
                     'resolution'                => []
                 ];
 
@@ -103,32 +103,33 @@ class LanguageTransformer extends BaseTransformer
                     'resources'            => $language->resources
                 ];
 
-            /**
-             * @OA\Response(
-             *   response="v4_languages.all",
-             *   description="The minimized language return for the single language route",
-             *   @OA\MediaType(
-             *     mediaType="application/json",
-             *     @OA\Schema(ref="#/components/schemas/Language")
-             *   )
-             * )
-             */
+                /**
+                 * @OA\Response(
+                 *   response="v4_languages.all",
+                 *   description="The minimized language return for the single language route",
+                 *   @OA\MediaType(
+                 *     mediaType="application/json",
+                 *     @OA\Schema(ref="#/components/schemas/Language")
+                 *   )
+                 * )
+                 */
             default:
             case 'v4_languages.all':
+                $show_bibles = checkBoolean('show_bibles');
                 $output = [
                     'id'         => $language->id,
                     'glotto_id'  => $language->glotto_id,
                     'iso'        => $language->iso,
                     'name'       => $language->name ?? $language->backup_name,
                     'autonym'    => $language->autonym,
-                    'bibles'     => $language->bibles_count,
+                    'bibles'     => $show_bibles ? $language->bibles : $language->bibles->count(),
                     'filesets'   => $language->filesets_count,
                 ];
 
                 if ($language->country_population) {
                     $output['country_population'] = $language->country_population;
                 }
-                
+
                 if ($language->relationLoaded('translations')) {
                     $output['translations'] = $language->translations->pluck('name', 'language_translation_id');
                 }


### PR DESCRIPTION
# Description
- Added `checkBoolean` helper function to validate boolean parameters
- Added `show_bibles` parameter to `/languages` endpoint to retrieve the content of the bibles
- The `filesets` and `bibles` on `/languages` endpoint are now filtered by the `asset_id` parameter

## Issue Link
Original Story: [FCBH-1268](https://fullstacklabs.atlassian.net/browse/FCBH-1268) 

## How Do I QA This
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Test `http://dbp.test/api/languages?key={API_KEY}&v=4&show_bibles=true&asset_id=dbp-vid`GET` endpoint and verify that you get only the bibles with videos and also you get the content of the bibles. 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
