### PR TITLE
FCBH-1292 Sending in verse start/end breaks whole chapter playlist items

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -619,18 +619,6 @@ class PlaylistsController extends APIController
         ]);
     }
 
-    private function getMaxRuntime($bible_files)
-    {
-        $runtimes = [];
-        foreach ($bible_files as $bible_file) {
-            foreach ($bible_file->streamBandwidth as $bandwidth) {
-                $runtimes[] = $bandwidth->transportStreamTS->max('runtime');
-                $runtimes[] = $bandwidth->transportStreamBytes->max('runtime');
-            }
-        }
-        return collect($runtimes)->max();
-    }
-
     private function processHLSAudio($bible_files, $hls_items, $signed_files, $transaction_id, $item, $download)
     {
         $durations = [];


### PR DESCRIPTION
# Description
- Fixed the way we collected the duration from the items to get the highest one.

## Issue Link
Original Story: [FCBH-1292](https://fullstacklabs.atlassian.net/browse/FCBH-1292) 

## How Do I QA This
- Test `http://dbp.test/api/playlists/{PLAYLIST_ID}/hls?v=4&key={API_KEY}` GET endpoint and verify that the `#EXT-X-TARGETDURATION` value is the highest value of the `#EXTINF` values


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.