### PR TITLE
FCBH-1302 Add Streaming Drama audio type

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -108,10 +108,10 @@ class BibleFileSetsController extends APIController
 
             if ($type === 'video_stream') {
                 $query->orderByRaw("FIELD(bible_files.book_id, 'MAT', 'MRK', 'LUK', 'JHN') ASC")
-                ->orderBy('chapter_start', 'ASC')
-                ->orderBy('verse_start', 'ASC');
+                    ->orderBy('chapter_start', 'ASC')
+                    ->orderBy('verse_start', 'ASC');
             }
-            
+
             $fileset_chapters = $query->get();
 
             if ($fileset_chapters->count() === 0) {
@@ -378,7 +378,7 @@ class BibleFileSetsController extends APIController
                     ->first()
                     ->bible
                     ->first()->filesets;
-                $audio_filesets_hashes = $filesets->whereIn('set_type_code', ['audio_drama', 'audio', 'audio_stream'])->pluck('hash_id')->flatten();
+                $audio_filesets_hashes = $filesets->whereIn('set_type_code', ['audio_drama', 'audio', 'audio_stream', 'audio_drama_stream'])->pluck('hash_id')->flatten();
                 $video_filesets_hashes = $filesets->where('set_type_code', 'video_stream')->flatten();
                 return ['audio' => $audio_filesets_hashes, 'video' => $video_filesets_hashes];
             });
@@ -411,7 +411,7 @@ class BibleFileSetsController extends APIController
      */
     private function generateFilesetChapters($fileset, $fileset_chapters, $bible, $asset_id)
     {
-        $is_stream = $fileset->set_type_code === 'video_stream' || $fileset->set_type_code === 'audio_stream';
+        $is_stream = $fileset->set_type_code === 'video_stream' || $fileset->set_type_code === 'audio_stream' || $fileset->set_type_code === 'audio_drama_stream';
         $is_video = Str::contains($fileset->set_type_code, 'video');
 
         if ($is_stream) {

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -70,7 +70,7 @@ class StreamController extends APIController
         $asset_id = checkParam('asset_id') ?? config('filesystems.disks.s3_fcbh_video.bucket');
 
         $video_fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'video_stream')->select('hash_id', 'id', 'asset_id')->first();
-        $audio_fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'audio_stream')->select('hash_id', 'id', 'asset_id')->first();
+        $audio_fileset = BibleFileset::uniqueFileset($fileset_id, $asset_id, 'audio', true)->select('hash_id', 'id', 'asset_id')->first();
         if (!$video_fileset && !$audio_fileset) {
             return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
         }

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -588,7 +588,7 @@ class PlaylistsController extends APIController
                 ->where('chapter_start', '>=', $item->chapter_start)
                 ->where('chapter_start', '<=', $item->chapter_end)
                 ->get();
-            if ($fileset->set_type_code === 'audio_stream') {
+            if ($fileset->set_type_code === 'audio_stream' || $fileset->set_type_code === 'audio_drama_stream') {
                 $result = $this->processHLSAudio($bible_files, $hls_items, $signed_files, $transaction_id, $item, $download);
                 $hls_items = $result->hls_items;
                 $signed_files = $result->signed_files;

--- a/database/migrations/2019_12_17_143936_udpate_type_code_length_to_fileset_types_table.php
+++ b/database/migrations/2019_12_17_143936_udpate_type_code_length_to_fileset_types_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class UdpateTypeCodeLengthToFilesetTypesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_fileset_types')) {
+            Schema::connection('dbp')->table('bible_fileset_types', function (Blueprint $table) {
+                $table->string('set_type_code', 18)->change();
+            });
+        }
+        if (Schema::connection('dbp')->hasTable('bible_filesets')) {
+            Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+                $table->string('set_type_code', 18)->change();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (Schema::connection('dbp')->hasTable('bible_filesets')) {
+            Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+                $table->dropForeign('FK_bible_fileset_types_bible_filesets');
+            });
+        }
+
+        if (Schema::connection('dbp')->hasTable('bible_fileset_types')) {
+            Schema::connection('dbp')->table('bible_fileset_types', function (Blueprint $table) {
+                $table->string('set_type_code', 16)->change();
+            });
+        }
+        if (Schema::connection('dbp')->hasTable('bible_filesets')) {
+            Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+                $table->string('set_type_code', 16)->change();
+                $table->foreign('set_type_code', 'FK_bible_fileset_types_bible_filesets')->references('set_type_code')->on(config('database.connections.dbp.database') . '.bible_fileset_types')->onUpdate('cascade')->onDelete('cascade');
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Description
- Added `audio_drama_stream` bible_fileset_types support
- Added migration to support 18 characters length of set_type_code

## Issue Link
Original Story: [FCBH-1302](https://fullstacklabs.atlassian.net/browse/FCBH-1302) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Verify that you can add `audio_drama_stream` type
```sql
INSERT INTO `bible_fileset_types` ( `set_type_code`, `name`)
VALUES ( 'audio_drama_stream', 'HLS Audio Drama Stream ');
```
- For testing purposes change `ENGESVN2SA` fileset type to `audio_drama_stream`
- Run `https://dbp.test/api/bibles/filesets/ENGESVN2SA?type=audio_drama_stream&size=NTP&asset_id=dbp-prod&v=4&key={API_KEY}` and verify is working 

**(*)Note:** If you want to reverse the migration run `php artisan migrate:rollback --database="dbp_users"`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.