### PR TITLE
Documentation Annotations fix

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -295,7 +295,7 @@ class BibleFileSetsController extends APIController
     /**
      * Returns the Available Media Types for Filesets within the API.
      *
-     * @OA\GET(
+     * @OA\Get(
      *     path="/bibles/filesets/media/types",
      *     tags={"Bibles"},
      *     summary="Available fileset types",
@@ -332,7 +332,7 @@ class BibleFileSetsController extends APIController
     }
 
     /**
-     * @OA\POST(
+     * @OA\Post(
      *     path="/bibles/filesets/check/types",
      *     tags={"Bibles"},
      *     summary="Check fileset types",

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -377,7 +377,7 @@ class BiblesController extends APIController
     }
 
     /**
-     * @OA\GET(
+     * @OA\Get(
      *     path="/bibles/defaults/types",
      *     tags={"Bibles"},
      *     summary="Available bible defaults per language code",

--- a/app/Http/Controllers/Bible/Study/CommentaryController.php
+++ b/app/Http/Controllers/Bible/Study/CommentaryController.php
@@ -11,7 +11,7 @@ class CommentaryController extends APIController
 
     /**
      *
-     * @OA\GET(
+     * @OA\Get(
      *     path="/commentaries",
      *     tags={"StudyBible"},
      *     summary="Commentaries",
@@ -36,7 +36,7 @@ class CommentaryController extends APIController
 
     /**
      *
-     * @OA\GET(
+     * @OA\Get(
      *     path="/commentaries/{commentary_id}/chapters",
      *     tags={"StudyBible"},
      *     summary="Commentary Chapters",
@@ -111,7 +111,7 @@ class CommentaryController extends APIController
 
     /**
      *
-     * @OA\GET(
+     * @OA\Get(
      *     path="/commentaries/{commentary_id}/{book_id}/{chapter}",
      *     tags={"StudyBible"},
      *     summary="Commentary Sections",


### PR DESCRIPTION
# Description
- GET and POST Swagger Annotations was uppercase and the server is case sensitive. Now all the annotations are capitalized.

## How Do I QA This
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Run `http://dev.v4.dbt.io/open-api-v4.json` to get the new documentation
- Run `http://4.dbt.io/open-api-v4.json` to get the new documentation

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
