### PR TITLE
FCBH-1202 Newly created yellow highlights returning green

### DIFF
--- a/app/Http/Controllers/User/HighlightsController.php
+++ b/app/Http/Controllers/User/HighlightsController.php
@@ -147,7 +147,7 @@ class HighlightsController extends APIController
                 'user_highlights.highlight_start',
                 'user_highlights.highlighted_words',
                 'user_highlights.highlighted_color',
-            ])->orderBy('user_highlights.'.$sort_by, $sort_dir)->paginate($limit);
+            ])->orderBy('user_highlights.' . $sort_by, $sort_dir)->paginate($limit);
 
         $highlight_collection = $highlights->getCollection();
 
@@ -429,6 +429,7 @@ class HighlightsController extends APIController
         preg_match_all('/#[a-zA-Z0-9]{6}/i', $highlightedColor, $matches, PREG_SET_ORDER);
         if (isset($matches[0][0])) {
             $selectedColor = $this->hexToRgb($color);
+            $selectedColor['hex'] = str_replace('#', '', $color);
         }
 
         // Try RGB
@@ -452,7 +453,7 @@ class HighlightsController extends APIController
         $highlightColor = HighlightColor::where($selectedColor)->first();
         if (!$highlightColor) {
             $selectedColor['color'] = 'generated_' . unique_random('dbp_users.user_highlight_colors', 'color', '8');
-            $selectedColor['hex'] = dechex($selectedColor['red']) . dechex($selectedColor['green']) . dechex($selectedColor['blue']);
+            $selectedColor['hex'] = sprintf('%02x%02x%02x', $selectedColor['red'], $selectedColor['green'], $selectedColor['blue']);
             $highlightColor = HighlightColor::create($selectedColor);
         }
         return $highlightColor->id;


### PR DESCRIPTION
# Description
- Fixed rgb to hex conversion on `HighlightsController`, the length of the hex color must be 6

## Issue Link
Original Story - [FCBH-1202](https://fullstacklabs.atlassian.net/browse/FCBH-1202) 
Review Story - [FCBH-1363](https://fullstacklabs.atlassian.net/browse/FCBH-1363) 

## How Do I QA This
- Run `https://dbp.test/open-api-v4.json` to get the new documentation
- Test `/users/{USER_ID}/highlights?v=4&key={API_KEY}` `POST` endpoint with the following body and verify on the database that the color is created correctly
```json
{
    "book_id": "GEN",
    "book_name": "Genesis",
    "chapter": 1,
    "verse_start": 1,
    "verse_end": 1,
    "bible_id": "EN1ESV",
    "highlighted_color": "#fce600",
    "highlight_start": 1,
    "highlighted_words": 10,
    "user_id": {USER_ID}
}
```


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
