### PR TITLE
FCBH-1322 Bible search results should appear in bible book/chapter/verse order

### DIFF
--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -286,14 +286,12 @@ class TextController extends APIController
                 'glyph_end.glyph as verse_end_vernacular',
             ])
             ->unless($relevance_order, function ($query) {
-                $query->orderByRaw('IFNULL(books.testament_order, books.protestant_order), bible_verses.chapter, bible_verses.verse_start');
+                $query->orderByRaw('books.book_testament DESC, IFNULL(books.testament_order, books.protestant_order), bible_verses.chapter, bible_verses.verse_start');
             });
 
         if ($page) {
             $verses  = $verses->paginate($limit);
             return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses->getCollection(), TextTransformer::class)->paginateWith(new IlluminatePaginatorAdapter($verses))]);
-
-            return $this->reply(fractal($verses->getCollection(), TextTransformer::class)->paginateWith(new IlluminatePaginatorAdapter($verses)));
         }
         $verses  = $verses->limit($limit)->get();
         return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses, new TextTransformer(), $this->serializer)]);


### PR DESCRIPTION
# Description
- Fixed a SQL injection vulnerability
- Improved the speed on the search results by using `like` instead of `MATCH AGAINST`, this also fixes missing results when searching words like `the`, `i am`
## Issue Link
Original Story: [FCBH-1322](https://fullstacklabs.atlassian.net/browse/FCBH-1322) 
Review Story: [FCBH-1367](https://fullstacklabs.atlassian.net/browse/FCBH-1367) 

## How Do I QA This
- Test `/search?relevance_order=true&fileset_id=ENGNIV&page=1&v=4&key={API_KEY}&query={QUERY}` `GET` endpoint
   - Search for `QUERY=god` and verify that all the results are in book/chapter/verse order and the response time is improved
   - Search for a SQL character like `QUERY=god";SHOW DATABASES;` and verify that the SQL injection is fixed

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
