### PR TITLE
FCBH-1091 Pl/an item reset improvement

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -248,6 +248,7 @@ class PlansController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\Parameter(name="days", in="query",@OA\Schema(type="string"), description="Comma-separated ids of the days to be sorted or deleted"),
+     *     @OA\Parameter(name="delete_days", in="query",@OA\Schema(type="boolean"), description="Will delete all days"),
      *     @OA\RequestBody(required=true, @OA\MediaType(mediaType="application/json",
      *          @OA\Schema(
      *              @OA\Property(property="name", ref="#/components/schemas/Plan/properties/name"),
@@ -293,10 +294,14 @@ class PlansController extends APIController
         $plan->update($update_values);
 
         $days = checkParam('days');
+        $delete_days = checkBoolean('delete_days');
 
-        if ($days) {
-            $days_ids = explode(',', $days);
-            PlanDay::setNewOrder($days_ids);
+        if ($days || $delete_days) {
+            $days_ids = [];
+            if (!$delete_days) {
+                $days_ids = explode(',', $days);
+                PlanDay::setNewOrder($days_ids);
+            }
             $deleted_days = PlanDay::whereNotIn('id', $days_ids)->where('plan_id', $plan->id);
             $playlists_ids = $deleted_days->pluck('playlist_id')->unique();
             $playlists = Playlist::whereIn('id', $playlists_ids);

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -228,6 +228,7 @@ class PlaylistsController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="playlist_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Playlist/properties/id")),
      *     @OA\Parameter(name="items", in="query", @OA\Schema(type="string"), description="Comma-separated ids of the playlist items to be sorted or deleted"),
+     *     @OA\Parameter(name="delete_items", in="query",@OA\Schema(type="boolean"), description="Will delete all items"),
      *     @OA\RequestBody(required=true, @OA\MediaType(mediaType="application/json",
      *          @OA\Schema(
      *              @OA\Property(property="name", ref="#/components/schemas/Playlist/properties/name"),
@@ -275,10 +276,14 @@ class PlaylistsController extends APIController
         $playlist->update($update_values);
 
         $items = checkParam('items');
+        $delete_items = checkBoolean('delete_items');
 
-        if ($items) {
-            $items_ids = explode(',', $items);
-            PlaylistItems::setNewOrder($items_ids);
+        if ($items || $delete_items) {
+            $items_ids = [];
+            if (!$delete_items) {
+                $items_ids = explode(',', $items);
+                PlaylistItems::setNewOrder($items_ids);
+            }
             $deleted_items = PlaylistItems::whereNotIn('id', $items_ids)->where('playlist_id', $playlist->id);
             $deleted_items->delete();
         }


### PR DESCRIPTION

# Description
- Added `delete_days` and `delete_items` to update Plans/Playlists endpoints'

## Issue Link
Original Story: [FCBH-1091](https://fullstacklabs.atlassian.net/browse/FCBH-1091) 
Review Story: [FCBH-1370](https://fullstacklabs.atlassian.net/browse/FCBH-1370) 

## How Do I QA This
- Test `/playlists/{playlist_id}?v=4&key={API_KEY}&delete_items=true` `Put` endpoint and verify that all the items are deleted
- Test `/plans/{plan_id}?v=4&key={API_KEY}&delete_days=true` `Put` endpoint and verify that all the days are deleted

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
