### PR TITLE
FCBH-1347 Social login issues

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -172,12 +172,12 @@ class UsersController extends APIController
         $email = checkParam('email');
         $social_provider_id = checkParam('social_provider_id');
 
-        if ($email) {
-            $password = checkParam('password');
-            $user = $this->loginWithEmail($email, $password);
-        } elseif ($social_provider_id) {
+        if ($social_provider_id) {
             $social_provider_user_id = checkParam('social_provider_user_id');
             $user = $this->loginWithSocialProvider($social_provider_id, $social_provider_user_id);
+        } elseif ($email) {
+            $password = checkParam('password');
+            $user = $this->loginWithEmail($email, $password);
         }
 
         if (!$user) {


### PR DESCRIPTION
# Description
This PR changes the auth priority to favor social id over email. Basically, if a social provider id is passed into the service, the assumption is that we should use that ID to auth instead of a potential email address.

## Issue Link
[FCBH-1347](https://fullstacklabs.atlassian.net/browse/FCBH-1347)