### PR TITLE
Hotfix - Assign v2 to v4 new users to a project

### DIFF
--- a/app/Http/Controllers/User/AccountsController.php
+++ b/app/Http/Controllers/User/AccountsController.php
@@ -39,9 +39,9 @@ class AccountsController extends APIController
      */
     public function index()
     {
-        $user = $this->verifyProjectUserConnection();
+        $result = $this->verifyProjectUserConnection();
 
-        return $this->reply($user->accounts);
+        return $this->reply($result->accounts ?? $result);
     }
 
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -48,6 +48,11 @@ return [
     'v2V4SyncChunkSize' => env('V2_V4_SYNC_CHUNK_SIZE', 5000),
 
     /*
+     * Default project id to assign to v2 to v4 users
+     */
+    'defaultProjectId' => env('USER_DEFAULT_PROJECT_ID', 52341),
+
+    /*
      * User restore encryption key
      */
     'restoreKey' => env('USER_RESTORE_ENCRYPTION_KEY', 'sup3rS3cr3tR35t0r3K3y21!'),

--- a/resources/lang/eng/api.php
+++ b/resources/lang/eng/api.php
@@ -63,6 +63,7 @@ return [
     'projects_developer_not_a_member'        => 'The project ID provided is not associated with your developer key',
     'projects_users_not_connected'           => 'This user needs to be connected with one of your projects.',
     'projects_users_error_404'               => 'This user either does not exist',
+    'project_users_404'                      => 'The specified user is not a member of the project_id provided.',
     'projects_users_needs_to_connect'        => 'This user needs to be connected with this project. A verification email has been sent to them',
 
     'organizations_relationship_members_404' => 'No membership connection found.',


### PR DESCRIPTION
- Added the v2 users that don't have a project assigned to the default project after the user's sync finalizes
- Added missing translation for `project_users_404`