### PR TITLE
FCBH-1397 Improve v2->v4 sync scheduling and reporting

### DIFF
--- a/app/Console/Commands/syncV2Database.php
+++ b/app/Console/Commands/syncV2Database.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Notifications\NotifyToSlack;
+use App\Notifications\SyncNotification;
+use Illuminate\Console\Command;
+use Exception;
+
+class syncV2Database extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'syncV2:database';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync the v4 Database with the V2 Database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        try {
+            $this->call('syncV2:users');
+            $this->call('syncV2:profiles');
+            $this->call('syncV2:highlights');
+            $this->call('syncV2:bookmarks');
+            $this->call('syncV2:notes');
+        } catch (Exception $e) {
+            $notification = new SyncNotification();
+            $notification->title = 'v2 - v4 sync failed';
+            $notification->message = $e->getMessage();
+            (new NotifyToSlack())->notify($notification);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\syncV2Database;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -34,6 +35,7 @@ class Kernel extends ConsoleKernel
 
         Commands\loaderPush::class,
 
+        Commands\syncV2Database::class,
         Commands\syncV2Users::class,
         Commands\syncV2Profiles::class,
         Commands\syncV2Bookmarks::class,
@@ -54,13 +56,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('syncV2Users')->hourly();
-        $schedule->command('syncV2Profiles')->hourly();
-        $schedule->command('syncV2Highlights')->hourly();
-        $schedule->command('syncV2Notes')->hourly();
-        $schedule->command('syncV2Bookmarks')->hourly();
-
-        $schedule->command('BackUpLogs')->cron('5 * * * *');
+        $schedule->command(syncV2Database::class)
+            ->everyFifteenMinutes()
+            ->onOneServer()
+            ->withoutOverlapping();
     }
 
     /**

--- a/app/Models/Notifications/NotifyToSlack.php
+++ b/app/Models/Notifications/NotifyToSlack.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models\Notifications;
+
+use Illuminate\Notifications\Notifiable;
+
+class NotifyToSlack
+{
+    use Notifiable;
+    public function routeNotificationForSlack()
+    {
+        return config('logging.channels.slack.url');
+    }
+}

--- a/app/Notifications/SyncNotification.php
+++ b/app/Notifications/SyncNotification.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Notifications\Messages\SlackMessage;
+
+class SyncNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    /**
+     * Get the slack representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage)
+            ->error()
+            ->attachment(function ($attachment) {
+                $attachment->title($this->title)
+                    ->content($this->message);
+            });
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "intouch/laravel-newrelic": "~2.0",
         "josiasmontag/laravel-localization": "^0.5.0",
         "laravel/framework": "5.8.*",
+        "laravel/slack-notification-channel": "^2.0",
         "laravel/socialite": "^3.2",
         "laravel/tinker": "^1.0",
         "league/flysystem-aws-s3-v3": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3251cd7f75db1507de9a44e913e1bb4a",
+    "content-hash": "23788058b17a9bb4e36609270ef63c9f",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2167,6 +2167,63 @@
                 "laravel"
             ],
             "time": "2019-02-27T14:02:36+00:00"
+        },
+        {
+            "name": "laravel/slack-notification-channel",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/slack-notification-channel.git",
+                "reference": "ecc90a70791195d6f5e20b2732a5eb1eb9619d10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/slack-notification-channel/zipball/ecc90a70791195d6f5e20b2732a5eb1eb9619d10",
+                "reference": "ecc90a70791195d6f5e20b2732a5eb1eb9619d10",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "illuminate/notifications": "~5.8.0|^6.0|^7.0",
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^7.0|^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Illuminate\\Notifications\\SlackChannelServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Notifications\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Slack Notification Channel for laravel.",
+            "keywords": [
+                "laravel",
+                "notifications",
+                "slack"
+            ],
+            "time": "2019-08-27T14:40:26+00:00"
         },
         {
             "name": "laravel/socialite",
@@ -6569,6 +6626,7 @@
                 "psr",
                 "psr-7"
             ],
+            "abandoned": "laminas/laminas-diactoros",
             "time": "2019-07-10T16:13:25+00:00"
         },
         {


### PR DESCRIPTION
# Description
- Installed "laravel/slack-notification-channel" in order to notify the slack channel when an error is present
- Created syncV2Database in order to:
   - Catch an error
   - Do the sync in order, if an error in users exists won't continue the sync

## Issue Link
[FCBH-1397](https://fullstacklabs.atlassian.net/browse/FCBH-1397) 

## How Do I QA This
- On your local environment run `composer install` to install the notification library
- Add to your `.env` file the `LOG_SLACK_WEBHOOK_URL` env variable
- Add this cron job to your environment
`* * * * * cd /path-to-your-project && php artisan schedule:run >> /dev/null 2>&1`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.





