### PR TITLE
FCBH-1520 Improve Playlists by separating items

### DIFF
--- a/app/Console/Commands/syncPlaylistDuration.php
+++ b/app/Console/Commands/syncPlaylistDuration.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Playlist\PlaylistItems;
+use Illuminate\Console\Command;
+use Carbon\Carbon;
+
+class syncPlaylistDuration extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sync:playlistDuration';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sync the playlist items duration with the database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        echo "\n" . Carbon::now() . ': playlist items sync started.';
+
+        $playlist_items = PlaylistItems::all();
+
+        foreach ($playlist_items as $playlist_item) {
+            $playlist_item->calculateDuration()->save();
+        }
+
+        echo "\n" . Carbon::now() . ": playlist items sync finalized.\n";
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -42,6 +42,8 @@ class Kernel extends ConsoleKernel
         Commands\syncV2Highlights::class,
         Commands\syncV2Notes::class,
 
+        Commands\syncPlaylistDuration::class,
+
         Commands\S3LogBackup::class,
         Commands\CleanAndImportKD::class,
 

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -270,7 +270,7 @@ class PlaylistItems extends Model implements Sortable
 
         return $timestamps->sum('duration');
     }
-    protected $appends = ['completed', 'full_chapter'];
+    protected $appends = ['completed', 'full_chapter', 'path'];
 
 
     public function calculateVerses()
@@ -345,6 +345,19 @@ class PlaylistItems extends Model implements Sortable
     public function getFullChapterAttribute()
     {
         return (bool) !$this->attributes['verse_start'] && !$this->attributes['verse_end'];
+    }
+
+    /**
+     * @OA\Property(
+     *   property="path",
+     *   title="path",
+     *   type="string",
+     *   description="Hls path of the playlist item"
+     * )
+     */
+    public function getPathAttribute()
+    {
+        return route('v4_playlists_item.hls', ['playlist_item_id'  => $this->attributes['id'], 'v' => checkParam('v'), 'key' => checkParam('key')]);
     }
 
     public function fileset()

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,6 +241,7 @@ Route::name('v4_playlists_items.store')
 Route::name('v4_playlists_items.complete')
     ->middleware('APIToken:check')->post('playlists/item/{item_id}/complete',       'Playlist\PlaylistsController@completeItem');
 Route::name('v4_playlists.hls')->get('playlists/{playlist_id}/hls',                 'Playlist\PlaylistsController@hls');
+Route::name('v4_playlists_item.hls')->get('playlists/{playlist_item_id}/item-hls',  'Playlist\PlaylistsController@itemHls');
 
 
 // VERSION 4 | Plans


### PR DESCRIPTION
# Description
- If there are no timestamps available try to get the duration from the bible files
- Added an artisan command `php artisan  sync:playlistDuration` to sync the duration of the currently created playlists
- Added individual hls path to playlist items
- This PR won't affect the previous behavior of this endpoint, we still have a path for the full playlists

## Issue Link
Story: [FCBH-1520](https://fullstacklabs.atlassian.net/browse/FCBH-1520)  

## How Do I QA This
- On your local environment run `php artisan  sync:playlistDuration` to update the duration of the playlist items, new playlist item will calculate the duration when are created
- Run `/api/playlists/{playlist_id}?v=4&key={API_KEY}` to get the detail of a playlists
- Verify that now the items have a path of the hls file
- Open the global path and the path of the items and verify that is working


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
