### PR TITLE
FCBH-1488 Get playlist/plan translations from server

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -771,7 +771,7 @@ class PlansController extends APIController
      *          in="query",
      *          required=true,
      *          @OA\Schema(ref="#/components/schemas/Bible/properties/id"),
-     *          description="The bible id"
+     *          description="The id of the bible that will be used to translate the plan"
      *     ),
      *     @OA\Response(response=200, ref="#/components/responses/plan")
      * )
@@ -800,7 +800,7 @@ class PlansController extends APIController
 
         $plan = $this->getPlan($plan_id, $user);
         if (!$plan) {
-            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+            return $this->setStatusCode(404)->replyWithError('Plan Not Found');
         }
 
         $playlist_controller = new PlaylistsController();

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Plan;
 use App\Traits\AccessControlAPI;
 use App\Http\Controllers\APIController;
 use App\Http\Controllers\Playlist\PlaylistsController;
+use App\Models\Bible\Bible;
 use App\Models\Plan\Plan;
 use App\Traits\CheckProjectMembership;
 use App\Models\Plan\PlanDay;
@@ -748,5 +749,71 @@ class PlansController extends APIController
             })->select($select)->first();
 
         return $plan;
+    }
+
+    /**
+     *
+     * @OA\Get(
+     *     path="/plans/{plan_id}/translate",
+     *     tags={"Plans"},
+     *     summary="Translate a user's plan",
+     *     operationId="v4_plans.translate",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(
+     *          name="plan_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Plan/properties/id"),
+     *          description="The plan id"
+     *     ),
+     *     @OA\Parameter(
+     *          name="bible_id",
+     *          in="query",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Bible/properties/id"),
+     *          description="The bible id"
+     *     ),
+     *     @OA\Response(response=200, ref="#/components/responses/plan")
+     * )
+     *
+     * @param $plan_id
+     *
+     * @return mixed
+     *
+     *
+     */
+    public function translate(Request $request, $plan_id)
+    {
+        $user = $request->user();
+
+        // Validate Project / User Connection
+        if (!empty($user) && !$this->compareProjects($user->id, $this->key)) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $bible_id = checkParam('bible_id', true);
+        $bible = Bible::whereId($bible_id)->first();
+
+        if (!$bible) {
+            return $this->setStatusCode(404)->replyWithError('Bible Not Found');
+        }
+
+        $plan = $this->getPlan($plan_id, $user);
+        if (!$plan) {
+            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+        }
+
+        $playlist_controller = new PlaylistsController();
+
+        $translated_days = [];
+        foreach ($plan->days as $day) {
+            $playlist_items = $playlist_controller->translate($request, $day->playlist_id);
+            $translated_days[] = [
+                'id' => $day->id,
+                'playlist_items' => $playlist_items->original,
+            ];
+        }
+
+        return $this->reply($translated_days);
     }
 }

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -585,7 +585,7 @@ class PlaylistsController extends APIController
      *          in="query",
      *          required=true,
      *          @OA\Schema(ref="#/components/schemas/Bible/properties/id"),
-     *          description="The bible id"
+     *          description="The id of the bible that will be used to translate the playlist"
      *     ),
      *     @OA\Response(response=200, ref="#/components/responses/playlist")
      * )

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -618,12 +618,15 @@ class PlaylistsController extends APIController
         }
 
 
-        $audio_fileset_types = collect(['audio_drama_stream', 'audio_stream', 'audio_drama', 'audio']);
+        $audio_fileset_types = collect(['audio_stream', 'audio_drama_stream', 'audio', 'audio_drama']);
         $bible_audio_filesets = $bible->filesets->whereIn('set_type_code', $audio_fileset_types);
 
         $translated_items = [];
 
         foreach ($playlist->items as $item) {
+            $ordered_types = $audio_fileset_types->filter(function ($type) use ($item) {
+                return $type !== $item->fileset->set_type_code;
+            })->prepend($item->fileset->set_type_code);
             $preferred_fileset = $audio_fileset_types->map(function ($type) use ($bible_audio_filesets, $item) {
                 return $this->getFileset($bible_audio_filesets, $type, $item->fileset->set_size_code);
             })->firstWhere('id');

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -627,7 +627,7 @@ class PlaylistsController extends APIController
             $ordered_types = $audio_fileset_types->filter(function ($type) use ($item) {
                 return $type !== $item->fileset->set_type_code;
             })->prepend($item->fileset->set_type_code);
-            $preferred_fileset = $audio_fileset_types->map(function ($type) use ($bible_audio_filesets, $item) {
+            $preferred_fileset = $ordered_types->map(function ($type) use ($bible_audio_filesets, $item) {
                 return $this->getFileset($bible_audio_filesets, $type, $item->fileset->set_size_code);
             })->firstWhere('id');
             $has_translation = isset($preferred_fileset);

--- a/routes/api.php
+++ b/routes/api.php
@@ -240,6 +240,8 @@ Route::name('v4_playlists_items.store')
     ->middleware('APIToken:check')->post('playlists/{playlist_id}/item',            'Playlist\PlaylistsController@storeItem');
 Route::name('v4_playlists_items.complete')
     ->middleware('APIToken:check')->post('playlists/item/{item_id}/complete',       'Playlist\PlaylistsController@completeItem');
+Route::name('v4_playlists.translate')
+    ->middleware('APIToken:check')->get('playlists/{playlist_id}/translate',       'Playlist\PlaylistsController@translate');
 Route::name('v4_playlists.hls')->get('playlists/{playlist_id}/hls',                 'Playlist\PlaylistsController@hls');
 Route::name('v4_playlists_item.hls')->get('playlists/{playlist_item_id}/item-hls',  'Playlist\PlaylistsController@itemHls');
 
@@ -261,6 +263,8 @@ Route::name('v4_plans.reset')
     ->middleware('APIToken:check')->post('plans/{plan_id}/reset',                   'Plan\PlansController@reset');
 Route::name('v4_plans.stop')
     ->middleware('APIToken:check')->delete('plans/{plan_id}/stop',                    'Plan\PlansController@stop');
+Route::name('v4_plans.translate')
+    ->middleware('APIToken:check')->get('plans/{plan_id}/translate',               'Plan\PlansController@translate');
 Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
 Route::name('v4_plans_days.complete')


### PR DESCRIPTION
# Description
- Added plan and playlist `/translate` endpoints.
- The endpoints have a `bible_id` parameter to verify if the playlist items have a translation on the bible filesets. If an item doesn't have translation it will have a `has_translation=false` parameter

## Issue Link
Original Story: [FCBH-1488](https://fullstacklabs.atlassian.net/browse/FCBH-1488)  
Review Story: [FCBH-1634](https://fullstacklabs.atlassian.net/browse/FCBH-1634)  

## How Do I QA This
- Run `/api/plans/{PLAN_ID}/translate?bible_id={BIBLE_ID}&v=4&key={API_KEY}& api_token={USER_API_TOKEN}` and verify that the list of days with the list of translated items
- Run `/api/playlists/{PLAYLISTS_ID}/translate?bible_id={BIBLE_ID}&v=4&key={API_KEY}& api_token={USER_API_TOKEN}` and verify that the list of translated items

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
