### PR TITLE
FCBH-1607 Share plan

### DIFF
--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -4,8 +4,6 @@ namespace App\Models\Plan;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use App\Models\Playlist\PlaylistItems;
-use App\Models\Playlist\PlaylistItemsComplete;
 
 /**
  * @OA\Schema (
@@ -92,7 +90,6 @@ class UserPlan extends Model
                 $completed = $plan_day->verifyDayCompleted();
                 return $completed;
             });
-        ;
         $this->attributes['percentage_completed'] = $completed_per_day->sum('total_items') ? $completed_per_day->sum('total_items_completed') / $completed_per_day->sum('total_items') * 100 : 0;
         return $this;
     }
@@ -100,20 +97,11 @@ class UserPlan extends Model
     public function reset($start_date = null)
     {
         PlanDay::where('plan_id', $this->plan_id)->get()
-            ->map(function ($plan_day) {
+            ->each(function ($plan_day) {
                 $plan_day->unComplete();
             });
-        ;
         $this->attributes['percentage_completed'] = 0;
         $this->attributes['start_date'] = $start_date;
-        
-        PlanDay::where('plan_id', $this->plan_id)->get()
-        ->each(function ($plan_day) {
-            $test = PlaylistItems::where('playlist_id', $plan_day->playlist_id)->get()
-            ->each(function ($playlist_item) {
-                PlaylistItemsComplete::where('playlist_item_id', $playlist_item->id)->delete();
-            });
-        });
 
         return $this;
     }


### PR DESCRIPTION

# Description
- Fixed reset plan day function, now will only reset the plan for the user who is doing the request.
- Fixed when a user stops a plan that also hides the plan for the plans GET endpoint. 

## Issue Link
Story: [FCBH-1607](https://fullstacklabs.atlassian.net/browse/FCBH-1607)  

## How Do I QA This
- Run `/api/plans/{PLAN_ID}/stop?bible_id={BIBLE_ID}&v=4&key={API_KEY}& api_token={USER_API_TOKEN}` and verify that the plan is removed from the user_plan table

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
