### PR TITLE
FCBH-1690 HLS byterange truncated audio and resume from pause

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -111,7 +111,7 @@ class StreamController extends APIController
         $signed_files = [];
 
         foreach ($currentBandwidth->transportStream as $stream) {
-            $current_file .= "\n#EXTINF:$stream->runtime";
+            $current_file .= "\n#EXTINF:$stream->runtime,";
             if (isset($stream->timestamp)) {
                 $current_file .= "\n#EXT-X-BYTERANGE:$stream->bytes@$stream->offset";
                 $fileset = $stream->timestamp->bibleFile->fileset;

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -103,7 +103,7 @@ class StreamController extends APIController
         $currentBandwidth->transportStream = sizeof($currentBandwidth->transportStreamBytes) ? $currentBandwidth->transportStreamBytes : $currentBandwidth->transportStreamTS;
 
         $current_file = "#EXTM3U\n";
-        $current_file .= '#EXT-X-TARGETDURATION:' . ceil($currentBandwidth->transportStream->max('runtime')) . "\n";
+        $current_file .= '#EXT-X-TARGETDURATION:' . ceil($currentBandwidth->transportStream->sum('runtime')) . "\n";
         $current_file .= "#EXT-X-VERSION:4\n";
         $current_file .= "#EXT-X-MEDIA-SEQUENCE:0\n";
         $current_file .= '#EXT-X-ALLOW-CACHE:YES';
@@ -111,7 +111,7 @@ class StreamController extends APIController
         $signed_files = [];
 
         foreach ($currentBandwidth->transportStream as $stream) {
-            $current_file .= "\n#EXTINF:$stream->runtime,";
+            $current_file .= "\n#EXTINF:$stream->runtime";
             if (isset($stream->timestamp)) {
                 $current_file .= "\n#EXT-X-BYTERANGE:$stream->bytes@$stream->offset";
                 $fileset = $stream->timestamp->bibleFile->fileset;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -752,7 +752,7 @@ class PlaylistsController extends APIController
 
             foreach ($transportStream as $stream) {
                 $durations[] = $stream->runtime;
-                $hls_items .= "\n#EXTINF:$stream->runtime";
+                $hls_items .= "\n#EXTINF:$stream->runtime," . $item->id;
                 if (isset($stream->timestamp)) {
                     $hls_items .= "\n#EXT-X-BYTERANGE:$stream->bytes@$stream->offset";
                     $fileset = $stream->timestamp->bibleFile->fileset;
@@ -778,7 +778,7 @@ class PlaylistsController extends APIController
         foreach ($bible_files as $bible_file) {
             $default_duration = $bible_file->duration ?? 180;
             $durations[] = $default_duration;
-            $hls_items .= "\n#EXTINF:$default_duration";
+            $hls_items .= "\n#EXTINF:$default_duration," . $item->id;
 
             $bible_path = $bible_file->fileset->bible->first()->id;
             $file_path = 'audio/' . $bible_path . '/' . $bible_file->fileset->id . '/' . $bible_file->file_name;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -752,7 +752,7 @@ class PlaylistsController extends APIController
 
             foreach ($transportStream as $stream) {
                 $durations[] = $stream->runtime;
-                $hls_items .= "\n#EXTINF:$stream->runtime," . $item->id;
+                $hls_items .= "\n#EXTINF:$stream->runtime";
                 if (isset($stream->timestamp)) {
                     $hls_items .= "\n#EXT-X-BYTERANGE:$stream->bytes@$stream->offset";
                     $fileset = $stream->timestamp->bibleFile->fileset;
@@ -778,7 +778,7 @@ class PlaylistsController extends APIController
         foreach ($bible_files as $bible_file) {
             $default_duration = $bible_file->duration ?? 180;
             $durations[] = $default_duration;
-            $hls_items .= "\n#EXTINF:$default_duration," . $item->id;
+            $hls_items .= "\n#EXTINF:$default_duration";
 
             $bible_path = $bible_file->fileset->bible->first()->id;
             $file_path = 'audio/' . $bible_path . '/' . $bible_file->fileset->id . '/' . $bible_file->file_name;


### PR DESCRIPTION
# Description
- Fixed resume from pause by changing the #EXT-X-TARGETDURATION to the duration of the audio
- Removed EXTINF extra metadata


## Issue Link
Story: [FCBH-1690](https://fullstacklabs.atlassian.net/browse/FCBH-1690)  

## How Do I QA This
- Run the app on iOS
- Select an HLS chapter
- Verify that you can pause and resume after more than 2 minutes

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
