### PR TITLE
Improve status

### DIFF
--- a/app/Http/Controllers/ApiMetadataController.php
+++ b/app/Http/Controllers/ApiMetadataController.php
@@ -85,7 +85,7 @@ class ApiMetadataController extends APIController
         try {
             \Cache::forget('cache_test');
             \Cache::add('cache_test', 'live', 5);
-            $cache_test = \Cache::get('cache_test', 'cache_miss');
+            $cache_test = \Cache::get('cache_test');
 	    if ($cache_test != 'live') {
             	$status_code = 500;
 	    }

--- a/app/Http/Controllers/ApiMetadataController.php
+++ b/app/Http/Controllers/ApiMetadataController.php
@@ -86,8 +86,8 @@ class ApiMetadataController extends APIController
             \Cache::forget('cache_test');
             \Cache::add('cache_test', 'live', 5);
             $cache_test = \Cache::get('cache_test');
-	    if ($cache_test != 'live') {
-            	$status_code = 500;
+            if ($cache_test != 'live') {
+                $status_code = 500;
 	    }
         } catch (\Exception $e) {
             $cache_test = $e->getMessage();

--- a/app/Http/Controllers/ApiMetadataController.php
+++ b/app/Http/Controllers/ApiMetadataController.php
@@ -71,7 +71,7 @@ class ApiMetadataController extends APIController
             $user_connection_message = 'live';
         } catch (\Exception $e) {
             $user_connection_message = $e->getMessage();
-            $status_code = 417;
+            $status_code = 500;
         }
 
         try {
@@ -79,16 +79,19 @@ class ApiMetadataController extends APIController
             $dbp_connection_message = 'live';
         } catch (\Exception $e) {
             $dbp_connection_message = $e->getMessage();
-            $status_code = 417;
+            $status_code = 500;
         }
 
         try {
             \Cache::forget('cache_test');
             \Cache::add('cache_test', 'live', 5);
-            $cache_test = \Cache::get('cache_test', 'failed by default');
+            $cache_test = \Cache::get('cache_test', 'cache_miss');
+	    if ($cache_test != 'live') {
+            	$status_code = 500;
+	    }
         } catch (\Exception $e) {
             $cache_test = $e->getMessage();
-            $status_code = 417;
+            $status_code = 500;
         }
 
         $connection = [

--- a/config/cache.php
+++ b/config/cache.php
@@ -58,7 +58,7 @@ return [
             'servers' => [
                 [
                     'host'   => env('MEMCACHED_HOST', '127.0.0.1'),
-                    'port'   => env('MEMCACHED_PORT', 11211),
+                    'port'   => env('MEMCACHED_PORT', '11211'),
                     'weight' => 100,
                 ],
             ],


### PR DESCRIPTION
this is intended to make the /status endpoint more accurate by actually verifying cache behavior and returning 500 instead of 417 (client error)