### PR TITLE
Add cache for featured plans and playlists

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -91,6 +91,19 @@ class PlansController extends APIController
         $sort_by    = checkParam('sort_by') ?? 'name';
         $sort_dir   = checkParam('sort_dir') ?? 'asc';
 
+        if ($featured) {
+            $cache_string = generateCacheString('v4_plan_index', [$featured, $limit, $sort_by, $sort_dir]);
+            $plans = \Cache::remember($cache_string, now()->addDay(), function () use ($featured, $limit, $sort_by, $sort_dir, $user) {
+                return $this->getPlans($featured, $limit, $sort_by, $sort_dir, $user);
+            });
+            return $this->reply($plans);
+        }
+
+        return $this->reply($this->getPlans($featured, $limit, $sort_by, $sort_dir, $user));
+    }
+
+    private function getPlans($featured, $limit, $sort_by, $sort_dir, $user)
+    {
         $plans = Plan::with('days')
             ->with('user')
             ->when($featured || empty($user), function ($q) {
@@ -107,8 +120,7 @@ class PlansController extends APIController
             $plan->total_days = sizeof($plan->days);
             unset($plan->days);
         }
-
-        return $this->reply($plans);
+        return $plans;
     }
 
     /**


### PR DESCRIPTION
# Description
- Added cache for featured plans and playlists

## How Do I QA This
- Run `https://dbp.test/api/plans?featured=true&api_token={API_TOKEN}&v=4&key={KEY}` and verify that the featured plans are being cached
- Run `https://dbp.test/api/playlists?featured=true&api_token={API_TOKEN}&v=4&key={KEY}` and verify that the featured playlists are being cached

- Run `https://dbp.test/api/plans?featured=false&api_token={API_TOKEN}&v=4&key={KEY}` and verify that the user plans are not being cached
- Run `https://dbp.test/api/playlists?featured=false&api_token={API_TOKEN}&v=4&key={KEY}` and verify that the user playlists are not being cached
