### PR TITLE
Add limit to plan days / playlists items [sentry]

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -18,7 +18,7 @@ class PlansController extends APIController
     use AccessControlAPI;
     use CheckProjectMembership;
 
-    protected $days_limit = 365;
+    protected $days_limit = 1095;
 
     /**
      * Display a listing of the resource.

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -18,6 +18,8 @@ class PlansController extends APIController
     use AccessControlAPI;
     use CheckProjectMembership;
 
+    protected $days_limit = 365;
+
     /**
      * Display a listing of the resource.
      *
@@ -146,7 +148,8 @@ class PlansController extends APIController
         }
 
         $name = checkParam('name', true);
-        $days = checkParam('days', true);
+        $days = intval(checkParam('days', true));
+        $days = $days > $this->days_limit ? $this->days_limit : $days;
         $suggested_start_date = checkParam('suggested_start_date');
 
         $plan = Plan::create([
@@ -486,7 +489,11 @@ class PlansController extends APIController
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');
         }
 
-        $days = checkParam('days', true);
+        $days = intval(checkParam('days', true));
+        $current_days_size = sizeof($plan->days);
+        $total_days = $current_days_size + $days;
+        $days = $total_days > $this->days_limit ? $this->days_limit - $current_days_size : $days;
+
 
         $created_plan_days = [];
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -24,7 +24,7 @@ class PlaylistsController extends APIController
     use CheckProjectMembership;
     use CallsBucketsTrait;
 
-    protected $items_limit = 100;
+    protected $items_limit = 1000;
 
     /**
      * Display a listing of the resource.

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -24,6 +24,8 @@ class PlaylistsController extends APIController
     use CheckProjectMembership;
     use CallsBucketsTrait;
 
+    protected $items_limit = 100;
+
     /**
      * Display a listing of the resource.
      *
@@ -484,6 +486,14 @@ class PlaylistsController extends APIController
         }
 
         $created_playlist_items = [];
+
+        $current_items_size = sizeof($playlist->items);
+        $new_items_size = sizeof($playlist_items);
+
+        if ($current_items_size + $new_items_size > $this->items_limit) {
+            $allowed_size = $this->items_limit - $current_items_size;
+            $playlist_items = array_slice($playlist_items, 0, $allowed_size);
+        }
 
         foreach ($playlist_items as $playlist_item) {
             $verses = $playlist_items->verses ?? 0;


### PR DESCRIPTION
# Description
- Added 365 size limit to plan days
- Added 100 size limit to playlists items
# Sentry issue
- [Link](https://sentry.io/organizations/fullstack-labs/issues/1585049464/?project=1728656&query=is%3Aunresolved+v4_plans.store&statsPeriod=14d)

## How Do I QA This
- Run POST `https://dbp.test/api/plans?api_token={API_TOKEN}&v=4&key={KEY}` and verify that you can only create 365 days of a plan
- Run POST `https://dbp.test/api/plans/{plan_id}/day?api_token={API_TOKEN}&v=4&key={KEY}` and verify that you can not add more than 365 total days
- Run POST `https://dbp.test/api/playlists/{playlist_id}/item?api_token={API_TOKEN}&v=4&key={KEY}` and verify that you can not add more than 100 total playlist items