### PR TITLE
Fix bookmark delete() on null [sentry]

### DIFF
--- a/app/Http/Controllers/User/BookmarksController.php
+++ b/app/Http/Controllers/User/BookmarksController.php
@@ -270,6 +270,9 @@ class BookmarksController extends APIController
         }
 
         $bookmark = Bookmark::where('id', $bookmark_id)->where('user_id', $user_id)->first();
+        if (!$bookmark) {
+            return $this->setStatusCode(404)->replyWithError('Bookmark not found');
+        }
         $bookmark->delete();
 
         return $this->reply('bookmark successfully deleted');


### PR DESCRIPTION
# Description
- Fixed bookmark delete() on null by adding a 404 response when a bookmark is not present

# Sentry issue
- [Link](https://sentry.io/organizations/fullstack-labs/issues/1559570330)

## How Do I QA This
- Run DELETE `https://dbp.test/api/users/{USER_ID}/bookmarks/{BOOKMARK_ID}?api_token={API_TOKEN}&v=4&key={KEY}` and verify you get a 404 instead of a 500