### PR TITLE
Fix missing parameters on jesusFilmChapters [sentry]

### DIFF
--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -33,7 +33,7 @@ class VideoStreamController extends APIController
         return $languages;
     }
 
-    public function jesusFilmChapters($iso)
+    public function jesusFilmChapters($iso = null)
     {
         $iso = checkParam('iso') ?? $iso;
         if ($iso) {


### PR DESCRIPTION
# Description
- Added default value to `$iso` parameter on jesusFilmChapters function

# Sentry issue
- [Link](https://sentry.io/organizations/fullstack-labs/issues/1586199917)

## How Do I QA This
- Run GET `http://dbp.test/api/arclight/jesus-film/chapters?v=4&key={KEY}&iso=cfm` and verify you get a correct response instead of a 500