### PR TITLE
Fix note delete() on null [sentry]

### DIFF
--- a/app/Http/Controllers/User/NotesController.php
+++ b/app/Http/Controllers/User/NotesController.php
@@ -312,7 +312,7 @@ class NotesController extends APIController
 
         $note = Note::where('user_id', $user_id)->where('id', $note_id)->first();
         if (!$note) {
-            $this->setStatusCode(404)->replyWithError('Note Not Found');
+            return $this->setStatusCode(404)->replyWithError('Note Not Found');
         }
         $note->delete();
 


### PR DESCRIPTION
# Description
- Fixed note delete() on null by adding the missing 404 response when a note is not present

# Sentry issue
- [Link](https://sentry.io/organizations/fullstack-labs/issues/1586387591/?project=1728656&query=is%3Aunresolved)

## How Do I QA This
- Run DELETE `https://dbp.test/api/users/{USER_ID}/notes/{NOTE_ID}?api_token={API_TOKEN}&v=4&key={KEY}` and verify you get a 404 instead of a 500