### PR TITLE
Catch 404 response on Jesus Film Query [sentry]

### DIFF
--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -37,7 +37,7 @@ class VideoStreamController extends APIController
     {
         $iso = checkParam('iso') ?? $iso;
         if ($iso) {
-            $cache_string =  'arclight_languages' . $iso;
+            $cache_string =  generateCacheString('arclight_languages', [$iso]);
             $languages = \Cache::remember($cache_string, now()->addDay(), function () use ($iso) {
                 $languages = collect($this->fetchArclight('media-languages', false, false, 'iso3=' . $iso)->mediaLanguages);
                 $languages = $languages->where('counts.speakerCount.value', $languages->max('counts.speakerCount.value'))->keyBy('iso3')->map(function ($item) {
@@ -58,22 +58,26 @@ class VideoStreamController extends APIController
             $arclight_id = checkParam('arclight_id', true);
         }
 
-        $cache_string =  'arclight_chapters_' . $arclight_id;
+        $cache_string =  generateCacheString('arclight_chapters_', [$arclight_id]);
 
         $component = \Cache::remember($cache_string, now()->addDay(), function () use ($arclight_id) {
             $component = $this->fetchArclight('media-components/1_jf-0-0/languages/' . $arclight_id);
             return $component;
         });
 
-        $cache_string =  'arclight_chapters_language_tag' . $arclight_id;
+        if (!$component) {
+            return $this->setStatusCode(404)->replyWithError('Jesus Film component not found');
+        }
+
+        $cache_string =  generateCacheString('arclight_chapters_language_tag', [$arclight_id]);
 
         $media_languages = \Cache::remember($cache_string, now()->addDay(), function () use ($arclight_id) {
             $media_languages = $this->fetchArclight('media-languages/' . $arclight_id);
             return $media_languages;
         });
-        $cache_string =  'arclight_chapters_metadata' . $arclight_id;
 
         $metadataLanguageTag = isset($media_languages->bcp47) ? $media_languages->bcp47 : '';
+        $cache_string =  generateCacheString('arclight_chapters_metadata', [$arclight_id, $metadataLanguageTag]);
 
         $metadata = \Cache::remember($cache_string, now()->addDay(), function () use ($arclight_id, $metadataLanguageTag) {
             $media_components = $this->fetchArclight('media-components', $arclight_id, true, 'metadataLanguageTags=' . $metadataLanguageTag . ',en');

--- a/app/Traits/ArclightConnection.php
+++ b/app/Traits/ArclightConnection.php
@@ -2,6 +2,8 @@
 
 namespace App\Traits;
 
+use Exception;
+
 trait ArclightConnection
 {
     private function fetchArclight($path, $language_id = null, $include_refs = false, $parameters = '')
@@ -22,7 +24,11 @@ trait ArclightConnection
 
         $path .= '&'.$parameters;
 
-        $results = json_decode(file_get_contents($path));
+        try {
+            $results = json_decode(file_get_contents($path));
+        } catch (Exception $e) {
+            return null;
+        }
 
         if (isset($results->_embedded)) {
             return $results->_embedded;


### PR DESCRIPTION
# Description
- Added a 404 response instead of a 500 when a Jesus film component is not found

# Sentry issue
- [Link](https://sentry.io/organizations/fullstack-labs/issues/1537582457)

## How Do I QA This
- Run GET `http://dbp.test/api/arclight/jesus-film/chapters?arclight_id=23179&v=4&key={KEY}` and verify retrieves content
- Run GET `http://dbp.test/api/arclight/jesus-film/chapters?arclight_id=4823&v=4&key={KEY}` and verify retrieves a 404 instead of a 500 