### PR TITLE
FCBH-1561 Enable play button for temp playlists

### DIFF
--- a/app/Console/Commands/DeleteDraftPlaylistsPlans.php
+++ b/app/Console/Commands/DeleteDraftPlaylistsPlans.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Plan\Plan;
+use App\Models\Playlist\Playlist;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class DeleteDraftPlaylistsPlans extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'delete:draftPlaylistPlans';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Delete 24 hours old draft playlists and plans';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        echo "\n" . Carbon::now() . ': draft playlist and plans deletion started.';
+
+        Playlist::where('draft', 1)->where('created_at', '<', Carbon::now()->subDays(1)->toDateTimeString())->delete();
+        Plan::where('draft', 1)->where('created_at', '<', Carbon::now()->subDays(1)->toDateTimeString())->delete();
+
+        echo "\n" . Carbon::now() . ": draft playlist and plans deletion finalized.\n";
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Console\Commands\syncV2Database;
+use App\Console\Commands\DeleteDraftPlaylistsPlans;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -43,6 +44,7 @@ class Kernel extends ConsoleKernel
         Commands\syncV2Notes::class,
 
         Commands\syncPlaylistDuration::class,
+        Commands\DeleteDraftPlaylistsPlans::class,
 
         Commands\S3LogBackup::class,
         Commands\CleanAndImportKD::class,
@@ -60,6 +62,11 @@ class Kernel extends ConsoleKernel
     {
         $schedule->command(syncV2Database::class)
             ->everyFifteenMinutes()
+            ->onOneServer()
+            ->withoutOverlapping();
+
+        $schedule->command(DeleteDraftPlaylistsPlans::class)
+            ->hourly()
             ->onOneServer()
             ->withoutOverlapping();
     }

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -53,7 +53,7 @@ function checkParam(string $paramName, $required = false, $inPathValue = null)
 function checkBoolean(string $paramName, $required = false, $inPathValue = null)
 {
     $param = checkParam($paramName, $required, $inPathValue);
-    $param = $param && $param != 'false';
+    $param = (bool) $param && $param !== 'false';
     return $param;
 }
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -174,7 +174,7 @@ class PlaylistsController extends APIController
      *          @OA\Schema(
      *              @OA\Property(property="name",                  ref="#/components/schemas/Playlist/properties/name"),
      *              @OA\Property(property="draft",                 ref="#/components/schemas/Playlist/properties/draft"),
-     *              @OA\Property(property="external_content",      ref="#/components/schemas/Playlist/properties/external_content")
+     *              @OA\Property(property="external_content",      ref="#/components/schemas/Playlist/properties/external_content"),
      *              @OA\Property(property="items",                 ref="#/components/schemas/v4_playlist_items")
      *          )
      *     )),

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -15,6 +15,7 @@ use App\Models\User\User;
  * @property string $name
  * @property string $user_id
  * @property bool $featured
+ * @property bool $draft
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property Carbon $deleted_at
@@ -100,6 +101,16 @@ class Plan extends Model
      *
      */
     protected $suggested_start_date;
+    /**
+     *
+     * @OA\Property(
+     *   title="draft",
+     *   type="boolean",
+     *   description="If the plan is draft"
+     * )
+     *
+     */
+    protected $draft;
     /** @OA\Property(
      *   title="updated_at",
      *   type="string",
@@ -128,6 +139,11 @@ class Plan extends Model
     public function getFeaturedAttribute($featured)
     {
         return (bool) $featured;
+    }
+
+    public function getDraftAttribute($draft)
+    {
+        return (bool) $draft;
     }
 
     public function user()

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -34,7 +34,7 @@ class Plan extends Model
 
     protected $connection = 'dbp_users';
     public $table         = 'plans';
-    protected $fillable   = ['user_id', 'name', 'suggested_start_date'];
+    protected $fillable   = ['user_id', 'name', 'suggested_start_date', 'draft'];
     protected $hidden     = ['user_id', 'deleted_at', 'plan_id'];
     protected $dates      = ['deleted_at'];
 

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -15,6 +15,7 @@ use App\Models\User\User;
  * @property string $name
  * @property string $user_id
  * @property bool $featured
+ * @property bool $draft
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property Carbon $deleted_at
@@ -101,6 +102,16 @@ class Playlist extends Model
     /**
      *
      * @OA\Property(
+     *   title="draft",
+     *   type="boolean",
+     *   description="If the playlist is draft"
+     * )
+     *
+     */
+    protected $draft;
+    /**
+     *
+     * @OA\Property(
      *   title="created_at",
      *   type="string",
      *   description="The timestamp the playlist was created at"
@@ -117,6 +128,12 @@ class Playlist extends Model
     {
         return (bool) $featured;
     }
+
+    public function getDraftAttribute($draft)
+    {
+        return (bool) $draft;
+    }
+
     /**
      *
      * @OA\Property(

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -34,7 +34,7 @@ class Playlist extends Model
 
     protected $connection = 'dbp_users';
     public $table         = 'user_playlists';
-    protected $fillable   = ['user_id', 'name', 'external_content'];
+    protected $fillable   = ['user_id', 'name', 'external_content', 'draft'];
     protected $hidden     = ['user_id', 'deleted_at'];
     protected $dates      = ['deleted_at'];
     /**

--- a/database/migrations/2020_03_11_173257_add_draft_playlists_plans.php
+++ b/database/migrations/2020_03_11_173257_add_draft_playlists_plans.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDraftPlaylistsPlans extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+            $table->boolean('draft')
+                ->after('suggested_start_date')
+                ->default(false);
+        });
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->boolean('draft')
+                ->after('user_id')
+                ->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->dropColumn('draft');
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,9 +241,11 @@ Route::name('v4_playlists_items.store')
 Route::name('v4_playlists_items.complete')
     ->middleware('APIToken:check')->post('playlists/item/{item_id}/complete',       'Playlist\PlaylistsController@completeItem');
 Route::name('v4_playlists.translate')
-    ->middleware('APIToken:check')->get('playlists/{playlist_id}/translate',       'Playlist\PlaylistsController@translate');
+    ->middleware('APIToken:check')->get('playlists/{playlist_id}/translate',        'Playlist\PlaylistsController@translate');
 Route::name('v4_playlists.hls')->get('playlists/{playlist_id}/hls',                 'Playlist\PlaylistsController@hls');
 Route::name('v4_playlists_item.hls')->get('playlists/{playlist_item_id}/item-hls',  'Playlist\PlaylistsController@itemHls');
+Route::name('v4_playlists.draft')
+    ->middleware('APIToken:check')->post('playlists/{playlist_id}/draft',           'Playlist\PlaylistsController@draft');
 
 
 // VERSION 4 | Plans
@@ -264,11 +266,13 @@ Route::name('v4_plans.reset')
 Route::name('v4_plans.stop')
     ->middleware('APIToken:check')->delete('plans/{plan_id}/stop',                    'Plan\PlansController@stop');
 Route::name('v4_plans.translate')
-    ->middleware('APIToken:check')->get('plans/{plan_id}/translate',               'Plan\PlansController@translate');
+    ->middleware('APIToken:check')->get('plans/{plan_id}/translate',                'Plan\PlansController@translate');
 Route::name('v4_plans_days.store')
     ->middleware('APIToken:check')->post('plans/{plan_id}/day',                     'Plan\PlansController@storeDay');
 Route::name('v4_plans_days.complete')
     ->middleware('APIToken:check')->post('plans/day/{day_id}/complete',             'Plan\PlansController@completeDay');
+Route::name('v4_plans.draft')
+    ->middleware('APIToken:check')->post('plans/{plan_id}/draft',                   'Plan\PlansController@draft');
 
 // VERSION 4 | Push tokens
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -264,7 +264,7 @@ Route::name('v4_plans.start')
 Route::name('v4_plans.reset')
     ->middleware('APIToken:check')->post('plans/{plan_id}/reset',                   'Plan\PlansController@reset');
 Route::name('v4_plans.stop')
-    ->middleware('APIToken:check')->delete('plans/{plan_id}/stop',                    'Plan\PlansController@stop');
+    ->middleware('APIToken:check')->delete('plans/{plan_id}/stop',                  'Plan\PlansController@stop');
 Route::name('v4_plans.translate')
     ->middleware('APIToken:check')->get('plans/{plan_id}/translate',                'Plan\PlansController@translate');
 Route::name('v4_plans_days.store')


### PR DESCRIPTION
# Description
- Added migration in order to add a draft column to plans and playlists
- Added plans and playlists /draft `POST` endpoint in order to change the draft status
- Remove draft plans and playlist from the `GET` all endpoints
- Added `DeleteDraftPlaylistsPlans` command in order to delete all the draft plans and playlists of more than 1 day old
- Added items and draft to `POST`  playlist endpoint
- Fixed wrong boolean validation on checkBoolean helper function

## Issue Link
Story: [FCBH-1561](https://fullstacklabs.atlassian.net/browse/FCBH-1561)  

## How Do I QA This
**Requirements:**
   - Select the `FCBH-1561` client branch
   - On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations

**Search temporary playlist:**
- Navigate to `My Bible -> Search`
- Search for any word `Jesus`
- Click on the play icon on the top right corner
- Verify that now you can play temporary playlists

**Highlights temporary playlist:**
- Navigate to `My Library -> Highlights`
- Click on the play icon on the top right corner
- Verify that now you can play temporary playlists

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
