### PR TITLE
FCBH-1770 Downloads still not working in background on iOS

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -677,6 +677,12 @@ class BiblesController extends APIController
             $drama = checkBoolean('drama') ? 'drama' : 'non-drama';
         }
 
+        $book = Book::whereId($book_id)->first();
+
+        if (!$book) {
+            return $this->setStatusCode(404)->replyWithError('Book not found');
+        }
+
         $result = (object) [];
 
         if ($show_annotations) {
@@ -708,8 +714,6 @@ class BiblesController extends APIController
         if ($zip) {
             $chapter_filesets->downloads = [];
         }
-
-        $book = Book::whereId($book_id)->first();
 
         $text_plain = $this->getFileset($bible->filesets, 'text_plain', $book->book_testament);
         if ($text_plain) {
@@ -743,13 +747,14 @@ class BiblesController extends APIController
             }
         }
 
+        $drama_all = $drama === 'all';
 
-        if ($drama === 'drama' || $drama === 'all') {
-            $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio_drama', 'drama', $zip);
+        if ($drama === 'drama' || $drama_all) {
+            $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio_drama', 'drama', $zip, 'audio', 'non_drama', !$drama_all && $zip);
         }
 
-        if ($drama === 'non-drama' || $drama === 'all') {
-            $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio', 'non_drama', $zip);
+        if ($drama === 'non-drama' || $drama_all) {
+            $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio', 'non_drama', $zip, 'audio_drama', 'drama', !$drama_all && $zip);
         }
 
         $video_stream = $this->getFileset($bible->filesets, 'video_stream', $book->book_testament);
@@ -840,12 +845,15 @@ class BiblesController extends APIController
         return false;
     }
 
-    private function getAudioFilesetData($results, $bible, $book, $chapter, $type, $name, $download = false)
+    private function getAudioFilesetData($results, $bible, $book, $chapter, $type, $name, $download = false, $secondary_type, $secondary_name, $get_secondary = false)
     {
         $fileset_controller = new BibleFileSetsController();
-        $stream = $download ? false : $this->getFileset($bible->filesets, $type . '_stream', $book->book_testament);
-        $non_stream = $this->getFileset($bible->filesets,  $type, $book->book_testament);
-        $fileset = $stream ? $stream :  $non_stream;
+        $fileset = $this->getStreamNonStreamFileset($download, $bible, $type, $book);
+
+        if (!$fileset && $get_secondary) {
+            $name = $secondary_name;
+            $fileset = $this->getStreamNonStreamFileset($download, $bible, $secondary_type, $book);
+        }
 
         if ($fileset) {
             $fileset = BibleFileset::where([
@@ -878,8 +886,14 @@ class BiblesController extends APIController
                 });
             $results->timestamps->$name = $audioTimestamps;
         }
-
         return $results;
+    }
+
+    private function getStreamNonStreamFileset($download, $bible, $type, $book)
+    {
+        $stream = $download ? false : $this->getFileset($bible->filesets, $type . '_stream', $book->book_testament);
+        $non_stream = $this->getFileset($bible->filesets,  $type, $book->book_testament);
+        return $stream ? $stream :  $non_stream;
     }
 
     private function replyWithDownload($result, $zip, $bible, $book, $chapter)


### PR DESCRIPTION
# Description
- When the user is trying to download a chapter and a non-drama or drama option is selected to retrieve the available option.
- Added 404 response when a book is not found

## Issue Link
Story: [FCBH-1770](https://fullstacklabs.atlassian.net/browse/FCBH-1770) 

## How Do I QA This
- Run `http://dbp.test/api/bibles/EN1ESV/chapter?asset_id=dbp-prod&book_id=GEN&chapter=13&key={API_KEY}&v=4&zip=true&drama=true` and verify that the non_drama content is retrieved. 



