### PR TITLE
FCBH-1771 Get Timestamps for streaming audio

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -876,14 +876,8 @@ class BiblesController extends APIController
             }
 
             // Get timestamps
-            $bible_files = BibleFile::where('hash_id', $fileset->hash_id)->where('book_id', $book->id)->where('chapter_start', $chapter)->get();
-            $audioTimestamps = BibleFileTimestamp::whereIn('bible_file_id', $bible_files->pluck('id'))->orderBy('verse_start')
-                ->get()->map(function ($timestamp) {
-                    return [
-                        'timestamp' => $timestamp->timestamp,
-                        'verse_start' => $timestamp->verse_start
-                    ];
-                });
+            $audio_controller = new AudioController();
+            $audioTimestamps = $audio_controller->timestampsByReference($fileset->id, $book->id,  $chapter, $fileset->asset_id)->original['data'] ?? [];
             $results->timestamps->$name = $audioTimestamps;
         }
         return $results;

--- a/app/Transformers/AudioTransformer.php
+++ b/app/Transformers/AudioTransformer.php
@@ -98,6 +98,11 @@ class AudioTransformer extends BaseTransformer
                     'verse_start'    => (string) $audio->verse_start,
                     'timestamp'      => $audio->timestamp
                 ];
+            case 'v4_bible.chapter':
+                return [
+                    'verse_start'    => (string) $audio->verse_start,
+                    'timestamp'      => $audio->timestamp
+                ];
             default:
                 /**
                  * @OA\Schema (


### PR DESCRIPTION
# Description
- Added timestamps from `transportStreamBytes` if are not available on the timestamps.bible_file_id table
- Updated `/timestamps/{fileset_id}/{book}/{chapter}` endpoint
- Updated `/bibles/{bible_id}/chapter` endpoint

## Issue Link
[FCBH-1771](https://fullstacklabs.atlassian.net/browse/FCBH-1771) 

## How Do I QA This
- Run `http://dbp.test/api/timestamps/ENGESVN2SA/MRK/1?asset_id=dbp-prod&v=4&key={API_KEY}` and verify you get timestamps results
- Run` http://dbp.test/api/bibles/ENGESV/chapter?asset_id=dbp-prod&v=4&key={API_KEY}&chapter=1&book_id=MRK` and verify you get timestamps results


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
