### PR TITLE
FCBH-1845 Resync Script for Notes

### DIFF
--- a/app/Console/Commands/reSyncV2Notes.php
+++ b/app/Console/Commands/reSyncV2Notes.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\User\Study\Note;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class reSyncV2Notes extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'reSyncV2:notes {note_id?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Re Sync the Notes that are not edited with the V2 Database';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $note_id = $this->argument('note_id');
+        echo "\n" . Carbon::now() . ': v2 to v4 notes re sync started.';
+        $db_v2_connection = DB::connection('dbp_users_v2');
+        $db_users_connection = DB::connection('dbp_users');
+
+        $chunk_size = 25;
+        do {
+            $v4_notes = $db_users_connection
+                ->table('user_notes')
+                ->where('v2_id', '!=', 0)
+                ->where('bookmark', '=', 0)
+                ->when($note_id, function ($query, $note_id) {
+                    return $query->whereId($note_id);
+                })
+                ->orderBy('v2_id')->limit($chunk_size)->get();
+            $v2_ids = $v4_notes->pluck('v2_id');
+            $v4_updated_dates = $v4_notes->pluck('updated_at', 'v2_id');
+            $v4_created_dates = $v4_notes->pluck('created_at', 'v2_id');
+            $v2_notes = $db_v2_connection->table('note')
+                ->select(['id', 'created', 'updated', 'note'])->whereIn('id', $v2_ids)->get();
+            $synced = 0;
+            foreach ($v2_notes as $v2_note) {
+                $note_changed = true;
+                // Different creation dates on v4 -> v2
+                if ($v4_created_dates[$v2_note->id] !== $v2_note->created) {
+                    // Same v4 updated_at and v4 created_at values means no change
+                    if ($v4_created_dates[$v2_note->id] === $v4_updated_dates[$v2_note->id]) {
+                        $note_changed = false;
+                    }
+                    // Same update dates on V4 -> v2 means no change
+                } elseif ($v4_updated_dates[$v2_note->id] === $v2_note->updated) {
+                    $note_changed = false;
+                }
+
+                // If note is not changed re sync
+                if (!$note_changed) {
+                    $db_users_connection->table('user_notes')
+                        ->where('v2_id', $v2_note->id)
+                        ->update([
+                            'notes' => encrypt($v2_note->note),
+                            'updated_at'  => Carbon::createFromTimeString($v2_note->updated),
+                            'bookmark' => 1,
+                        ]);
+                    $synced++;
+                    echo "\n" . Carbon::now() . ': Re synced ' . $synced . '/' . $chunk_size . ' v2 notes.';
+                }
+            }
+            $v4_ids = $v4_notes->pluck('id');
+            $db_users_connection->table('user_notes')->whereIn('id', $v4_ids)->update(['bookmark' => 1]);
+            $remaining = $db_users_connection
+                ->table('user_notes')
+                ->where('v2_id', '!=', 0)
+                ->when($note_id, function ($query, $note_id) {
+                    return $query->whereId($note_id);
+                })
+                ->where('bookmark', '=', 0)->count();
+            echo "\n" . Carbon::now() . ': ' . $remaining . ' remaining to process.';
+        } while (!$v4_notes->isEmpty());
+
+        echo "\n" . Carbon::now() . ": v2 to v4 notes re sync finalized.\n";
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends ConsoleKernel
         Commands\syncV2Bookmarks::class,
         Commands\syncV2Highlights::class,
         Commands\syncV2Notes::class,
+        Commands\reSyncV2Notes::class,
 
         Commands\syncPlaylistDuration::class,
         Commands\DeleteDraftPlaylistsPlans::class,


### PR DESCRIPTION
# Description
- Added `php artisan reSyncV2:notes {note_id?}` command in order to resync existing notes if the note exists on both v2 & v4, and has not changed on v4.
- Syncing a note takes 1 to 3 seconds on average so we are doing chunks of 25 notes to avoid overlapping with users interaction
- The script validates if the notes have not been changed before doing the resync
- There is a `bookmark` column that is not being used, so I used it as a flag to mark the resynced notes. So if for some reason we stop the script we don't lose the progress

## Issue Link
[FCBH-1845](https://fullstacklabs.atlassian.net/browse/FCBH-1845) 

## How Do I QA This
- Run `php artisan reSyncV2:notes {note_id}` to resync only 1 note
- Run `php artisan reSyncV2:notes` to resync all notes


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
