### PR TITLE
FCBH-1830 Improve pl/ans endpoints

### DIFF
--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -378,12 +378,11 @@ class TextController extends APIController
         }
 
         $playlists = Playlist::with('user')
+            ->where('draft', 0)
+            ->where('plan_id', 0)
             ->where('user_playlists.name', 'like', '%' . $query . '%')
             ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user) {
                 $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')->where('playlists_followers.user_id', $user->id);
-            })
-            ->leftJoin('plan_days', function ($join) {
-                $join->on('plan_days.playlist_id', '=', 'user_playlists.id')->whereNull('plan_days.playlist_id');
             })
             ->where('user_playlists.user_id', $user->id)
             ->orWhere('playlists_followers.user_id', $user->id)

--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -382,8 +382,8 @@ class TextController extends APIController
             ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user) {
                 $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')->where('playlists_followers.user_id', $user->id);
             })
-            ->whereNotIn('id', function ($query) {
-                $query->select('playlist_id')->from('plan_days');
+            ->leftJoin('plan_days', function ($join) {
+                $join->on('plan_days.playlist_id', '=', 'user_playlists.id')->whereNull('plan_days.playlist_id');
             })
             ->where('user_playlists.user_id', $user->id)
             ->orWhere('playlists_followers.user_id', $user->id)

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -173,17 +173,25 @@ class PlansController extends APIController
         ]);
 
         for ($i = 0; $i < intval($days); $i++) {
-            $data[] = ['name' => 'plan_' . $plan->id, 'user_id' => $user->id];
+            $data[] = [
+                'plan_id' => $plan->id,
+                'name' => 'plan_' . $plan->id,
+                'user_id' => $user->id
+            ];
         }
         Playlist::insert($data);
-        $new_playlists = Playlist::select(['id'])->where('name', 'plan_' . $plan->id)->where('user_id', $user->id)->get()->pluck('id');
+        $new_playlists = Playlist::select(['id'])
+            ->where('name', 'plan_' . $plan->id)
+            ->where('plan_id', $plan->id)
+            ->where('user_id', $user->id)
+            ->get()->pluck('id');
         $plan_days_data = $new_playlists->map(function ($item) use ($plan) {
             return [
                 'plan_id'               => $plan->id,
                 'playlist_id'           => $item,
             ];
         })->toArray();
-        Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'updated_at']);
+        Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'created_at']);
         PlanDay::insert($plan_days_data);
 
         UserPlan::create([
@@ -515,17 +523,25 @@ class PlansController extends APIController
 
         $data = [];
         for ($i = 0; $i < intval($days); $i++) {
-            $data[] = ['name' => 'plan_' . $plan_id, 'user_id' => $user->id];
+            $data[] = [
+                'plan_id' => $plan->id,
+                'name' => 'plan_' . $plan->id,
+                'user_id' => $user->id
+            ];
         }
         Playlist::insert($data);
-        $new_playlists = Playlist::select(['id'])->where('name', 'plan_' . $plan_id)->where('user_id', $user->id)->get()->pluck('id');
+        $new_playlists = Playlist::select(['id'])
+            ->where('name', 'plan_' . $plan->id)
+            ->where('plan_id', $plan->id)
+            ->where('user_id', $user->id)
+            ->get()->pluck('id');
         $plan_days_data = $new_playlists->map(function ($item) use ($plan) {
             return [
                 'plan_id'               => $plan->id,
                 'playlist_id'           => $item,
             ];
         })->toArray();
-        Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'updated_at']);
+        Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'created_at']);
         PlanDay::insert($plan_days_data);
 
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -124,27 +124,35 @@ class PlaylistsController extends APIController
 
     private function getPlaylists($show_details, $user, $featured, $sort_by, $sort_dir, $limit, $show_text)
     {
-        $select = ['user_playlists.*', DB::Raw('IF(playlists_followers.user_id, true, false) as following')];
+        $has_user = !empty($user);
+        $featured = $featured || !$has_user;
+
+        $select = ['user_playlists.*'];
+
+        $following_playlists = [];
+        if ($has_user) {
+            $following_playlists = PlaylistFollower::where('user_id', $user->id)->get();
+        }
+
         $playlists = Playlist::with('user')
             ->where('draft', 0)
+            ->where('plan_id', 0)
             ->when($show_details, function ($query) {
                 $query->with('items');
             })
-            ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user) {
-                $user_id = empty($user) ? 0 : $user->id;
-                $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')->where('playlists_followers.user_id', $user_id);
-            })
-            ->leftJoin('plan_days', function ($join) {
-                $join->on('plan_days.playlist_id', '=', 'user_playlists.id')->whereNull('plan_days.playlist_id');
-            })
-            ->when($featured || empty($user), function ($q) {
+            ->when($featured, function ($q) {
                 $q->where('user_playlists.featured', '1');
-            })->unless($featured, function ($q) use ($user) {
+            })
+            ->unless($featured, function ($q) use ($user, $following_playlists) {
                 $q->where('user_playlists.user_id', $user->id)
-                    ->orWhere('playlists_followers.user_id', $user->id);
+                    ->orWhereIn('user_playlists.id', $following_playlists->pluck('playlist_id'));
             })
             ->select($select)
             ->orderBy($sort_by, $sort_dir)->paginate($limit);
+
+        if ($has_user) {
+            $following_playlists = $following_playlists->pluck('playlist_id', 'playlist_id');
+        }
 
         foreach ($playlists->getCollection() as $playlist) {
             if ($show_details) {
@@ -156,8 +164,8 @@ class PlaylistsController extends APIController
                 }
             }
             $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
+            $playlist->following = $following_playlists[$playlist->id] ?? false;
         }
-
         return $playlists;
     }
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -134,8 +134,8 @@ class PlaylistsController extends APIController
                 $user_id = empty($user) ? 0 : $user->id;
                 $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')->where('playlists_followers.user_id', $user_id);
             })
-            ->whereNotIn('id', function ($query) {
-                $query->select('playlist_id')->from('plan_days');
+            ->leftJoin('plan_days', function ($join) {
+                $join->on('plan_days.playlist_id', '=', 'user_playlists.id')->whereNull('plan_days.playlist_id');
             })
             ->when($featured || empty($user), function ($q) {
                 $q->where('user_playlists.featured', '1');

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -35,7 +35,7 @@ class Playlist extends Model
     protected $connection = 'dbp_users';
     public $table         = 'user_playlists';
     protected $fillable   = ['user_id', 'name', 'external_content', 'draft'];
-    protected $hidden     = ['user_id', 'deleted_at'];
+    protected $hidden     = ['user_id', 'deleted_at', 'plan_id'];
     protected $dates      = ['deleted_at'];
     /**
      *

--- a/database/migrations/2020_05_15_172217_add_plan_to_playlist_table.php
+++ b/database/migrations/2020_05_15_172217_add_plan_to_playlist_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPlanToPlaylistTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->bigInteger('plan_id')->unsigned();
+        });
+        \DB::connection('dbp_users')
+            ->statement('UPDATE user_playlists left join plan_days on plan_days.playlist_id = user_playlists.id set user_playlists.plan_id = IFNULL(plan_days.plan_id,0);');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->dropColumn('plan_id');
+        });
+    }
+}


### PR DESCRIPTION
# Description
- Improved playlists endpoint by using a left join with `plan_days `
- Improved plan creation
- Improved plan days creation
- Added cache where is missed

## Issue Link
[FCBH-1714](https://fullstacklabs.atlassian.net/browse/FCBH-1714) 

## How Do I QA This
- Change your .env file to `CACHE_DRIVER=array` to remove the cache (just for testing)
- On your local environment run php artisan migrate --database="dbp_users" to run the migrations
- Run `http://dbp.test/api/playlists?v=4&key={KEY}` and verify that now the query takes less than a second
- Try to create a plan with 1095 days and verify that now takes a couple of seconds


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
