### PR TITLE
FCBH-1836 Improve languages endpoints

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -253,3 +253,10 @@ if (!function_exists('validateV2Annotation')) {
         return true;
     }
 }
+
+if (!function_exists('arrayToCommaSeparatedValues')) {
+    function arrayToCommaSeparatedValues($array)
+    {
+        return  "'" . implode("','", $array) . "'";
+    }
+}

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -61,6 +61,12 @@ class LanguagesController extends APIController
      *          description="Will show all entries"
      *     ),
      *     @OA\Parameter(
+     *          name="random",
+     *          in="query",
+     *          @OA\Schema(type="boolean"),
+     *          description="Will order the entries randomly"
+     *     ),
+     *     @OA\Parameter(
      *          name="show_bibles",
      *          in="query",
      *          @OA\Schema(type="boolean"),
@@ -112,6 +118,7 @@ class LanguagesController extends APIController
         $include_alt_names     = checkParam('include_alt_names');
         $asset_id              = checkParam('bucket_id|asset_id');
         $name                  = checkParam('name|language_name');
+        $random                  = checkParam('random');
         $show_restricted       = checkBoolean('show_all|show_restricted');
         $show_bibles           = checkBoolean('show_bibles');
         $limit      = checkParam('limit');
@@ -119,21 +126,26 @@ class LanguagesController extends APIController
 
         $access_control = $this->accessControl($this->key);
 
-        $cache_params = [$this->v,  $country, $code, $GLOBALS['i18n_id'], $sort_by, $name, $show_restricted, $include_alt_names, $asset_id, $access_control->string, $limit, $page, $show_bibles];
+        $cache_params = [$this->v,  $country, $code, $GLOBALS['i18n_id'], $sort_by, $name, $show_restricted, $include_alt_names, $asset_id, $access_control->string, $limit, $page, $show_bibles, $random];
 
         $order = $country ? 'country_population.population' : 'ifnull(current_translation.name, languages.name)';
         $order_dir = $country ? 'desc' : 'asc';
         $select_country_population = $country ? 'country_population.population' : 'null';
-        $languages = cacheRemember('languages_all', $cache_params, now()->addDay(), function () use ($country, $include_alt_names, $asset_id, $code, $name, $show_restricted, $access_control, $order, $order_dir, $select_country_population, $limit, $page) {
+        $languages = cacheRemember('languages_all', $cache_params, now()->addDay(), function () use ($country, $include_alt_names, $asset_id, $code, $name, $show_restricted, $access_control, $order, $order_dir, $select_country_population, $limit, $page, $random) {
             $languages = Language::includeCurrentTranslation()
                 ->includeAutonymTranslation()
-                ->includeExtraLanguages($show_restricted, $access_control, $asset_id)
+                ->includeExtraLanguages($show_restricted, arrayToCommaSeparatedValues($access_control->hashes), $asset_id)
                 ->includeExtraLanguageTranslations($include_alt_names)
                 ->includeCountryPopulation($country)
                 ->filterableByCountry($country)
                 ->filterableByIsoCode($code)
                 ->filterableByName($name)
-                ->orderByRaw($order . ' ' . $order_dir)
+                ->when($random, function ($query) {
+                    return $query->inRandomOrder();
+                })
+                ->unless($random, function ($query) use ($order, $order_dir) {
+                    return $query->orderByRaw($order . ' ' . $order_dir);
+                })
                 ->select([
                     'languages.id',
                     'languages.glotto_id',
@@ -217,7 +229,7 @@ class LanguagesController extends APIController
         $cache_params = [$id, $access_control->string];
         $language = cacheRemember('language', $cache_params, now()->addDay(), function () use ($id, $access_control) {
             $language = Language::where('id', $id)->orWhere('iso', $id)
-                ->includeExtraLanguages(false, $access_control, false)
+                ->includeExtraLanguages(false, arrayToCommaSeparatedValues($access_control->hashes), false)
                 ->first();
             if (!$language) {
                 return $this->setStatusCode(404)->replyWithError("Language not found for ID: $id");

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -124,7 +124,9 @@ class LanguagesController extends APIController
         $limit      = checkParam('limit');
         $page       = checkParam('page');
 
-        $access_control = $this->accessControl($this->key);
+        $access_control = cacheRemember('access_control', [$this->key], now()->addHour(), function () {
+            return $this->accessControl($this->key);
+        });
 
         $cache_params = [$this->v,  $country, $code, $GLOBALS['i18n_id'], $sort_by, $name, $show_restricted, $include_alt_names, $asset_id, $access_control->string, $limit, $page, $show_bibles, $random];
 
@@ -225,7 +227,9 @@ class LanguagesController extends APIController
      */
     public function show($id)
     {
-        $access_control = $this->accessControl($this->key);
+        $access_control = cacheRemember('access_control', [$this->key], now()->addHour(), function () {
+            return $this->accessControl($this->key);
+        });
         $cache_params = [$id, $access_control->string];
         $language = cacheRemember('language', $cache_params, now()->addDay(), function () use ($id, $access_control) {
             $language = Language::where('id', $id)->orWhere('iso', $id)

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -347,11 +347,11 @@ class Language extends Model
         });
     }
 
-    public function scopeIncludeExtraLanguages($query, $show_restricted, $access_control, $asset_id)
+    public function scopeIncludeExtraLanguages($query, $show_restricted, $access_control_hashes, $asset_id)
     {
-        return $query->when(!$show_restricted, function ($query) use ($access_control, $asset_id) {
-            $query->whereHas('filesets', function ($query) use ($access_control, $asset_id) {
-                $query->whereIn('hash_id', $access_control->hashes);
+        return $query->when(!$show_restricted, function ($query) use ($access_control_hashes, $asset_id) {
+            $query->whereHas('filesets', function ($query) use ($access_control_hashes, $asset_id) {
+                $query->whereRaw('hash_id in (' . $access_control_hashes . ')');
                 if ($asset_id) {
                     $asset_id = explode(',', $asset_id);
                     $query->whereHas('fileset', function ($query) use ($asset_id) {


### PR DESCRIPTION

# Description
- Improved `v4_languages.one` and `v4_languages.all` endpoints by processing the hash access control codes only one time
- Added random parameter to the `v4_languages.all` endpoint

## Issue Link
[FCBH-1836](https://fullstacklabs.atlassian.net/browse/FCBH-1836) 

## How Do I QA This
- Run `http://dbp.test/api/languages?v=4&key={API_KEY}` and verify that the query is faster than the develop branch

Before: 
![image](https://user-images.githubusercontent.com/41348080/82386322-bb823300-99f9-11ea-9697-b7e7b9c35436.png)


After: 
![image](https://user-images.githubusercontent.com/41348080/82386284-a73e3600-99f9-11ea-9c10-c25f73c1e5ff.png)



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
