### PR TITLE
update Cloudwatch config for custom metrics (memory and disk)

### DIFF
--- a/.ebextensions/cloudwatch-memory.config
+++ b/.ebextensions/cloudwatch-memory.config
@@ -13,7 +13,7 @@ sources:
 container_commands:
   01-setupcron:
     command: |
-      echo '*/5 * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
+      echo '* * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
   02-changeperm:
     command: chmod 644 /etc/cron.d/cwpump
   03-changeperm:

--- a/.ebextensions/cloudwatch-memory.config
+++ b/.ebextensions/cloudwatch-memory.config
@@ -13,7 +13,7 @@ sources:
 container_commands:
   01-setupcron:
     command: |
-      echo '*/5 * * * * ec2-user perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
+      echo '*/5 * * * * root perl /opt/cloudwatch/aws-scripts-mon/mon-put-instance-data.pl `{"Fn::GetOptionSetting" : { "OptionName" : "CloudWatchMetrics", "DefaultValue" : "--mem-util --disk-space-util --disk-path=/" }}` >> /var/log/cwpump.log 2>&1' > /etc/cron.d/cwpump
   02-changeperm:
     command: chmod 644 /etc/cron.d/cwpump
   03-changeperm:
@@ -23,4 +23,4 @@ option_settings:
   "aws:autoscaling:launchconfiguration" :
     IamInstanceProfile : "aws-elasticbeanstalk-ec2-role"
   "aws:elasticbeanstalk:customoption" :
-    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling"
+    CloudWatchMetrics : "--mem-util --mem-used --mem-avail --disk-space-util --disk-space-used --disk-space-avail --disk-path=/ --auto-scaling --from-cron"


### PR DESCRIPTION
This PR updates the .ebextension configuration for pumping custom Cloudwatch metrics to use root instead of ec2-user. User "ec2-user" did not have permission to write to /var/log/cwpump. In addition, the frequency was changed from 5 minutes to 1 minute. This allows more time to adjust if an ec2 instance is nearing max memory