### PR TITLE
FCBH-1996 bad behavior when verse e0 data

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -429,7 +429,16 @@ class BibleFileSetsController extends APIController
 
         if ($is_stream) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
-                $fileset_chapters[$key]->file_name = route('v4_media_stream', ['fileset_id' => $fileset->id, 'file_id' => $fileset_chapter->id]);
+                $fileset_chapters[$key]->file_name = route(
+                    'v4_media_stream',
+                    [
+                        'fileset_id' => $fileset->id,
+                        'book_id' => $fileset_chapter->book_id,
+                        'chapter' => $fileset_chapter->chapter_start,
+                        'verse_start' => $fileset_chapter->verse_start,
+                        'verse_end' => $fileset_chapter->verse_end,
+                    ]
+                );
             }
         }
 

--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -39,13 +39,20 @@ class StreamController extends APIController
         $current_file = '#EXTM3U';
         foreach ($file->streamBandwidth as $bandwidth) {
             $current_file .= "\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=$bandwidth->bandwidth";
+
+            $transportStream = sizeof($bandwidth->transportStreamBytes) ? $bandwidth->transportStreamBytes : $bandwidth->transportStreamTS;
+
+            $extra_args = '';
+            if (sizeof($transportStream) && isset($transportStream[0]->timestamp) && $transportStream[0]->timestamp->verse_start === 0) {
+                $extra_args = '&v0=0';
+            }
             if ($bandwidth->resolution_width) {
                 $current_file .= ',RESOLUTION=' . $bandwidth->resolution_width . "x$bandwidth->resolution_height";
             }
             if ($bandwidth->codec) {
                 $current_file .= ",CODECS=\"$bandwidth->codec\"";
             }
-            $current_file .= "\n$bandwidth->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id;
+            $current_file .= "\n$bandwidth->file_name" . '?key=' . $this->key . '&v=4&asset_id=' . $asset_id . $extra_args;
         }
 
         return response($current_file, 200, [
@@ -105,8 +112,7 @@ class StreamController extends APIController
         $current_file = "#EXTM3U\n";
         $current_file .= '#EXT-X-TARGETDURATION:' . ceil($currentBandwidth->transportStream->sum('runtime')) . "\n";
         $current_file .= "#EXT-X-VERSION:4\n";
-        $current_file .= "#EXT-X-MEDIA-SEQUENCE:0\n";
-        $current_file .= '#EXT-X-ALLOW-CACHE:YES';
+        $current_file .= '#EXT-X-MEDIA-SEQUENCE:0';
 
         $signed_files = [];
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -957,8 +957,7 @@ class PlaylistsController extends APIController
         $current_file = "#EXTM3U\n";
         $current_file .= '#EXT-X-TARGETDURATION:' . ceil(collect($durations)->sum()) . "\n";
         $current_file .= "#EXT-X-VERSION:4\n";
-        $current_file .= "#EXT-X-MEDIA-SEQUENCE:0\n";
-        $current_file .= '#EXT-X-ALLOW-CACHE:YES';
+        $current_file .= '#EXT-X-MEDIA-SEQUENCE:0';
         $current_file .= $hls_items;
         $current_file .= "\n#EXT-X-ENDLIST";
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,8 @@ Route::name('v4_access_groups.destroy')->delete('access/groups/{group_id}',     
 // VERSION 4 | Stream
 Route::name('v4_media_stream')->get('bible/filesets/{fileset_id}/{file_id}/playlist.m3u8',    'Bible\StreamController@index');
 Route::name('v4_media_stream_ts')->get('bible/filesets/{fileset_id}/{file_id}/{file_name}',   'Bible\StreamController@transportStream');
+Route::name('v4_media_stream')->get('bible/filesets/{fileset_id}/{book_id}-{chapter}-{verse_start}-{verse_end}/playlist.m3u8',    'Bible\StreamController@index');
+Route::name('v4_media_stream_ts')->get('bible/filesets/{fileset_id}/{book_id}-{chapter}-{verse_start}-{verse_end}/{file_name}',   'Bible\StreamController@transportStream');
 
 // VERSION 4 | Bible
 Route::name('v4_bible.books')->get('bibles/{bible_id}/book/{book?}',               'Bible\BiblesController@books');


### PR DESCRIPTION
# Description
- Added v0=0 argument when there is no verse 0 only when there is no v0 segment
- Removed EXT-X-ALLOW-CACHE:YES
- Added `Book-Chapter-VerseStart-VerseEnd` instead of the file id on the `media_stream` url

## Issue Link
[FCBH-1996](https://fullstacklabs.atlassian.net/browse/FCBH-1996) 

## How do I QA this?

- Run `http://dbp.test/api/bible/filesets/ENGESVN1SA/MAT-13-1-/playlist.m3u8?v=4&key={KEY}` and verify is working
- Run `http://dbp.test/api/bible/filesets/ENGESVN1SA/2186122/playlist.m3u8?v=4&key={KEY}` and verify that is also working
- Run the app with the `develop` backend branch selected, then run the app with the `FCBH-1996` backend branch selected and verify that the audio and video are playing correctly
