### PR TITLE
FCBH-2000 Translation plan/playlist

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -911,20 +911,30 @@ class PlansController extends APIController
 
         $new_plan = Plan::create($plan_data);
         $playlist_controller = new PlaylistsController();
-
+        $translation_data = [];
+        $translated_percentage = 0;
         foreach ($plan->days as $day) {
             $playlist = (object) $playlist_controller->translate($request, $day->playlist_id)->original;
+
             PlanDay::create([
                 'plan_id'               => $new_plan->id,
                 'playlist_id'           => $playlist->id,
             ]);
+            $translation_data[] = $playlist->translation_data;
+            $translated_percentage += $playlist->translated_percentage;
         }
+        $translated_percentage = sizeof($plan->days) ? $translated_percentage / sizeof($plan->days) : 0;
+
 
         UserPlan::create([
             'user_id'               => $user->id,
             'plan_id'               => $new_plan->id
         ]);
 
-        return $this->show($request, $new_plan->id);
+        $plan = $this->show($request, $new_plan->id)->original;
+        $plan['translation_data'] = $translation_data;
+        $plan['translated_percentage'] = $translated_percentage;
+
+        return $plan;
     }
 }

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -521,7 +521,7 @@ class PlaylistsController extends APIController
         return $this->reply($single_item ? $created_playlist_items[0] : $created_playlist_items);
     }
 
-    private function createPlaylistItems($playlist, $playlist_items)
+    private function createPlaylistItems($playlist, $playlist_items, $set_translated_id = false)
     {
         $created_playlist_items = [];
 
@@ -549,6 +549,9 @@ class PlaylistsController extends APIController
             $created_playlist_item->calculateDuration()->save();
             if (!$verses) {
                 $created_playlist_item->calculateVerses()->save();
+            }
+            if ($set_translated_id) {
+                $created_playlist_item->translated_id = $playlist_item->translated_id;
             }
             $created_playlist_items[] = $created_playlist_item;
         }
@@ -689,7 +692,8 @@ class PlaylistsController extends APIController
         $bible_audio_filesets = $bible->filesets->whereIn('set_type_code', $audio_fileset_types);
 
         $translated_items = [];
-
+        $metadata_items = [];
+        $total_translated_items = 0;
         foreach ($playlist->items as $item) {
             $ordered_types = $audio_fileset_types->filter(function ($type) use ($item) {
                 return $type !== $item->fileset->set_type_code;
@@ -704,6 +708,7 @@ class PlaylistsController extends APIController
                 $item->fileset_id = $preferred_fileset->id;
                 $is_streaming = $preferred_fileset->set_type_code === 'audio_stream' || $preferred_fileset->set_type_code === 'audio_drama_stream';
                 $translated_items[] = (object)[
+                    'translated_id' => $item->id,
                     'fileset_id' => $item->fileset_id,
                     'book_id' => $item->book_id,
                     'chapter_start' => $item->chapter_start,
@@ -711,8 +716,11 @@ class PlaylistsController extends APIController
                     'verse_start' => $is_streaming ? $item->verse_start : null,
                     'verse_end' => $is_streaming ? $item->verse_end : null,
                 ];
+                $total_translated_items += 1;
             }
+            $metadata_items[] = $item;
         }
+        $translated_percentage = sizeof($playlist->items) ? $total_translated_items / sizeof($playlist->items) : 0;
 
         $playlist_data = [
             'user_id'           => $user->id,
@@ -724,9 +732,27 @@ class PlaylistsController extends APIController
 
 
         $playlist = Playlist::create($playlist_data);
-        $this->createPlaylistItems($playlist, $translated_items);
+        $items = collect($this->createPlaylistItems($playlist, $translated_items, true));
 
-        return $this->show($request, $playlist->id);
+
+        foreach ($metadata_items as $item) {
+            $new_item = $items->first(function ($new_item) use ($item) {
+                return $new_item->translated_id === $item->id;
+            });
+            if ($new_item) {
+                unset($new_item->translated_id);
+                $item->translation_item = $new_item;
+            }
+        }
+
+        $playlist = $this->getPlaylist($user, $playlist_id);
+        $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist_id, 'v' => $this->v, 'key' => $this->key]);
+        $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist_id)->sum('duration');
+
+        $playlist->translation_data = $metadata_items;
+        $playlist->translated_percentage = $translated_percentage * 100;
+
+        return $this->reply($playlist);
     }
 
     /**

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -745,9 +745,9 @@ class PlaylistsController extends APIController
             }
         }
 
-        $playlist = $this->getPlaylist($user, $playlist_id);
-        $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist_id, 'v' => $this->v, 'key' => $this->key]);
-        $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist_id)->sum('duration');
+        $playlist = $this->getPlaylist($user, $playlist->id);
+        $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist->id, 'v' => $this->v, 'key' => $this->key]);
+        $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
 
         $playlist->translation_data = $metadata_items;
         $playlist->translated_percentage = $translated_percentage * 100;


### PR DESCRIPTION
# Description
- Added metadata information about the translation to the pl/ans translate endpoint. This way we avoid the user making multiple calls to the server

## Issue Link
 [FCBH-2000](https://fullstacklabs.atlassian.net/browse/FCBH-2000) 

## How Do I QA This
- Run `http://dbp.test/api/plans/{PLAN_ID}/translate?api_token={API_TOKEN}&v=4&key=52e62d4c-f7c8-4a8b-9008-8634d0fbddb0&show_details=true&bible_id={BIBLE_ID}` and verify you get `translation_data` and `translated_percentage`
- Run `http://dbp.test/api/playlists/{PLAYLIST_ID}/translate?api_token={API_TOKEN}&v=4&key=52e62d4c-f7c8-4a8b-9008-8634d0fbddb0&show_details=true&bible_id={BIBLE_ID}` and verify you get `translation_data` and `translated_percentage`


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
