### PR TITLE
FCBH-2210 Add annotations endpoint

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -92,7 +92,9 @@ Route::name('v4_bible.all')->get('bibles',                                      
 Route::name('v4_bible.defaults')->get('bibles/defaults/types',                     'Bible\BiblesController@defaults');
 Route::name('v4_bible.copyright')->get('bibles/{bible_id}/copyright',              'Bible\BiblesController@copyright');
 Route::name('v4_bible.chapter')
-        ->middleware('APIToken')->get('bibles/{bible_id}/chapter',                 'Bible\BiblesController@chapter');
+    ->middleware('APIToken')->get('bibles/{bible_id}/chapter',                     'Bible\BiblesController@chapter');
+Route::name('v4_bible.chapter.annotations')
+    ->middleware('APIToken:check')->get('bibles/{bible_id}/chapter/annotations',          'Bible\BiblesController@annotations');
 
 // VERSION 4 | Filesets
 Route::name('v4_filesets.types')->get('bibles/filesets/media/types',               'Bible\BibleFileSetsController@mediaTypes');


### PR DESCRIPTION
# Description
- Created `/bibles/{bible_id}/chapter/annotations` endpoint
- The new enpoint only retrives to a logged user the annotations of a chapter/book/bible

## Issue Link
Original Story: [FCBH-2210](https://fullstacklabs.atlassian.net/browse/FCBH-2210) 
Review Story: [FCBH-2224](https://fullstacklabs.atlassian.net/browse/FCBH-2224) 

## How Do I QA This
- Run `http://dbp.test/api/bibles/{BIBLE_ID}/chapter/annotations?chapter={CHAPTER}&book_id={BOOK_ID}&api_token={API_TOKEN}&key={KEY}&v=4`

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
