### PR TITLE
FCBH-2135 Text not showing up for several languages

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -822,7 +822,7 @@ class BiblesController extends APIController
         }
 
         $size_partial_filesets = $filesets->filter(function ($fileset) use ($type, $testament) {
-            return $fileset->set_type_code === $type && strpos($fileset->set_size_code, $testament . 'P') !== false;
+            return $fileset->set_type_code === $type && strpos($fileset->set_size_code, $testament) !== false;
         })->toArray();
 
         if (!empty($size_partial_filesets)) {


### PR DESCRIPTION
# Description
- Fixed wrong query when looking for a size of testament that is complete with another that is partial
- We now look for the presence of the size of the testament on the set_size_code of the fileset. For example for this size code `NTOTP` we look if `NT` is present, we were looking for `NTP`. 

## Issue Link
Original Story: [FCBH-2135](https://fullstacklabs.atlassian.net/browse/FCBH-2135) 

## How Do I QA This
- Navigate to `http://dbp.test/api/bibles/HATBIV/chapter?asset_id=dbp-prod&chapter=8&book_id=2CO&key={KEY}&v=4` and verify the text content is displayed
