### PR TITLE
FCBH-2207 Discoverable pl/plans in languages other than English

### DIFF
--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -35,7 +35,7 @@ class Plan extends Model
     protected $connection = 'dbp_users';
     public $table         = 'plans';
     protected $fillable   = ['user_id', 'name', 'suggested_start_date', 'draft'];
-    protected $hidden     = ['user_id', 'deleted_at', 'plan_id'];
+    protected $hidden     = ['user_id', 'deleted_at', 'plan_id', 'language_id'];
     protected $dates      = ['deleted_at'];
 
     /**

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -35,7 +35,7 @@ class Playlist extends Model
     protected $connection = 'dbp_users';
     public $table         = 'user_playlists';
     protected $fillable   = ['user_id', 'name', 'external_content', 'draft'];
-    protected $hidden     = ['user_id', 'deleted_at', 'plan_id'];
+    protected $hidden     = ['user_id', 'deleted_at', 'plan_id', 'language_id'];
     protected $dates      = ['deleted_at'];
     /**
      *

--- a/database/migrations/2020_08_01_020137_add_language_plans_playlists.php
+++ b/database/migrations/2020_08_01_020137_add_language_plans_playlists.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddLanguagePlansPlaylists extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+            $table->integer('language_id')->unsigned()->nullable()->after('draft');
+            $table->foreign('language_id', 'FK_languages_plans')->references('id')->on(config('database.connections.dbp.database') . '.languages')->onUpdate('cascade');
+        });
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->integer('language_id')->unsigned()->nullable()->after('draft');
+            $table->foreign('language_id', 'FK_languages_playlists')->references('id')->on(config('database.connections.dbp.database') . '.languages')->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('plans', function (Blueprint $table) {
+            $table->dropColumn('language_id');
+        });
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->dropColumn('language_id');
+        });
+    }
+}


### PR DESCRIPTION
# Description
- Added `iso` parameter to plans and playlists index endpoints
- Added migration to support language_id column on user_playlists and plans tables
- Updated documentation

## Issue Link
Original Story: [FCBH-2207](https://fullstacklabs.atlassian.net/browse/FCBH-2207) 

## How Do I QA This
- On your local environment run `php artisan migrate --database="dbp_users"` to run the migrations
- Set the language_id code `6414` to the featured plans and playlists you want on `dbp_users` database
- Navigate to `http://dbp.test/api/plans?asset_id=dbp-prod&featured=true&iso=eng&v=4&key={KEY}` and verify that the plans are being filtered by the iso code
- Navigate to `http://dbp.test/api/playlists?asset_id=dbp-prod&featured=true&iso=eng&v=4&key={KEY}` and verify that the playlists are being filtered by the iso code
- Do not send the iso parameter and verify that the pl/ans are not being filtered


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
