### PR TITLE
FCBH-2213 Provide Verse Text for Playlists & Plans

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -265,6 +265,11 @@ class PlansController extends APIController
             foreach ($plan->days as $day) {
                 $day_playlist = $playlist_controller->getPlaylist($user, $day->playlist_id);
                 $day_playlist->path = route('v4_playlists.hls', ['playlist_id'  => $day_playlist->id, 'v' => $this->v, 'key' => $this->key]);
+                if ($show_text) {
+                    foreach ($day_playlist->items as $item) {
+                        $item->verse_text = $item->getVerseText();
+                    }
+                }
                 $day->playlist = $day_playlist;
             }
         }

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -229,10 +229,10 @@ class PlaylistsController extends APIController
     /**
      *
      * @OA\Get(
-     *     path="/playlists/{playlist_id}",
+     *     path="/playlists/{playlist_id}/text",
      *     tags={"Playlists"},
-     *     summary="A user's playlist",
-     *     operationId="v4_playlists.show",
+     *     summary="A user's playlist text",
+     *     operationId="v4_playlists.show_text",
      *     security={{"api_token":{}}},
      *     @OA\Parameter(
      *          name="playlist_id",
@@ -250,7 +250,7 @@ class PlaylistsController extends APIController
      *
      *
      */
-    public function show(Request $request, $playlist_id)
+    public function showText(Request $request, $playlist_id)
     {
         $user = $request->user();
 
@@ -263,6 +263,65 @@ class PlaylistsController extends APIController
 
         if (!$playlist) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+        }
+
+        foreach ($playlist->items as $item) {
+            $item->verse_text = $item->getVerseText();
+        }
+        
+
+        return $this->reply($playlist->items->pluck('verse_text', 'id'));
+    }
+    /**
+     *
+     * @OA\Get(
+     *     path="/playlists/{playlist_id}",
+     *     tags={"Playlists"},
+     *     summary="A user's playlist",
+     *     operationId="v4_playlists.show",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(
+     *          name="playlist_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Playlist/properties/id"),
+     *          description="The playlist id"
+     *     ),
+     *     @OA\Parameter(
+     *          name="show_text",
+     *          in="query",
+     *          @OA\Schema(type="boolean"),
+     *          description="Enable the full details of the playlist and retrieve the text of the items"
+     *     ),
+     *     @OA\Response(response=200, ref="#/components/responses/playlist")
+     * )
+     *
+     * @param $playlist_id
+     *
+     * @return mixed
+     *
+     *
+     */
+    public function show(Request $request, $playlist_id)
+    {
+        $user = $request->user();
+        $show_text = checkBoolean('show_text');
+
+        // Validate Project / User Connection
+        if (!empty($user) && !$this->compareProjects($user->id, $this->key)) {
+            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $playlist = $this->getPlaylist($user, $playlist_id);
+
+        if (!$playlist) {
+            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+        }
+
+        if ($show_text) {
+            foreach ($playlist->items as $item) {
+                $item->verse_text = $item->getVerseText();
+            }
         }
 
         $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist_id, 'v' => $this->v, 'key' => $this->key]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -237,6 +237,8 @@ Route::name('v4_playlists.store')
     ->middleware('APIToken:check')->post('playlists',                               'Playlist\PlaylistsController@store');
 Route::name('v4_playlists.show')
     ->middleware('APIToken')->get('playlists/{playlist_id}',                        'Playlist\PlaylistsController@show');
+Route::name('v4_playlists.show_text')
+    ->middleware('APIToken')->get('playlists/{playlist_id}/text',                   'Playlist\PlaylistsController@showText');
 Route::name('v4_playlists.update')
     ->middleware('APIToken:check')->put('playlists/{playlist_id}',                  'Playlist\PlaylistsController@update');
 Route::name('v4_playlists.destroy')


### PR DESCRIPTION
# Description
- Added SHOW_TEXT flag to `playlist/{playlist_id}` endpoint
- Fixed SHOW_TEXT flag on `plans/{plan_id}` endpoint
- Created `playlist/{playlist_id}/text` endpoint that retrieves the text from the playlists items

## Issue Link
Original Story: [FCBH-2213](https://fullstacklabs.atlassian.net/browse/FCBH-2213) 

## How Do I QA This
- Navigate to `http://dbp.test/api/playlists/{PLAYLIST_ID}/text?key={KEY}&v=4` and verify you get only the text of the playlist items

- Navigate to `http://dbp.test/api/playlists/{PLAYLIST_ID}?key={KEY}&v=4&show_text=true` and verify you get the playlist items text
- Navigate to `http://dbp.test/api/playlists?key={KEY}&v=4&show_text=true` and verify you get the playlist items text
- Navigate to `http://dbp.test/api/playlists/{PLAN_ID}?key={KEY}&v=4&show_text=true` and verify you get the playlist items text

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
