### PR TITLE
FCBH-2106 Improve chapter detail API endpoint

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -60,7 +60,7 @@ class BibleFileSetsController extends APIController
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
      * @throws \Exception
      */
-    public function show($id = null, $asset_id = null, $set_type_code = null)
+    public function show($id = null, $asset_id = null, $set_type_code = null, $cache_key = 'bible_filesets_show')
     {
         $fileset_id    = checkParam('dam_id|fileset_id', true, $id);
         $book_id       = checkParam('book_id');
@@ -69,7 +69,8 @@ class BibleFileSetsController extends APIController
         $type          = checkParam('type', $set_type_code !== null, $set_type_code);
 
         $cache_params = [$this->v, $fileset_id, $book_id, $type, $chapter_id, $asset_id];
-        $fileset_chapters = cacheRemember('bible_filesets_show', $cache_params, now()->addHours(12), function () use ($fileset_id, $book_id, $type, $chapter_id, $asset_id) {
+
+        $fileset_chapters = cacheRemember($cache_key, $cache_params, now()->addHours(12), function () use ($fileset_id, $book_id, $type, $chapter_id, $asset_id) {
             $book = Book::where('id', $book_id)->orWhere('id_osis', $book_id)->orWhere('id_usfx', $book_id)->first();
             $fileset = BibleFileset::with('bible')->uniqueFileset($fileset_id, $asset_id, $type)->first();
             if (!$fileset) {


### PR DESCRIPTION
# Description
- Improved chapter detail endpoint by adding cache where is possible
   - Added 24 hours cache to the bible, book and copyrights queries
   - Added 12 hours cache to chapter filesets content

## Issue Link
Original Story: [FCBH-2106](https://fullstacklabs.atlassian.net/browse/FCBH-2106) 

## How Do I QA This
- Navigate to `http://dbp.test/api/bibles/{BIBLE_ID}/chapter?v=4&key={KEY}&book_id={BOOK_ID}&chapter={CHAPTER}&copyrights=true` and verify you get the same content that the `develop` branch but faster after the endpoint is memcached

## Before
![image](https://user-images.githubusercontent.com/41348080/89858962-7a676e00-db65-11ea-95ea-7b69415d14d8.png)
## After
![image](https://user-images.githubusercontent.com/41348080/89859086-c7e3db00-db65-11ea-83f1-245facc64de2.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

