### PR TITLE
FCBH-2132 Creation note is not returning timestamps

### DIFF
--- a/app/Http/Controllers/User/BookmarksController.php
+++ b/app/Http/Controllers/User/BookmarksController.php
@@ -166,7 +166,8 @@ class BookmarksController extends APIController
             return $this->setStatusCode(422)->replyWithError($invalidBookmark);
         }
 
-        $bookmark = Bookmark::create($request->all());
+        $bookmark_id = Bookmark::create($request->all())->id;
+        $bookmark = Bookmark::where('id', $bookmark_id)->first();
 
         $this->handleTags($bookmark);
 

--- a/app/Http/Controllers/User/NotesController.php
+++ b/app/Http/Controllers/User/NotesController.php
@@ -191,7 +191,7 @@ class NotesController extends APIController
             return $invalidNote;
         }
 
-        $note = Note::create([
+        $note_id = Note::create([
             'user_id'     => $user_id,
             'bible_id'    => $request->bible_id,
             'book_id'     => $request->book_id,
@@ -199,7 +199,8 @@ class NotesController extends APIController
             'verse_start' => $request->verse_start,
             'verse_end'   => $request->verse_end ?? $request->verse_start,
             'notes'       =>  encrypt(isset($request->notes) ? $request->notes : ''),
-        ]);
+        ])->id;
+        $note = Note::where('id', $note_id)->first();
 
         $this->handleTags($note);
 

--- a/app/Transformers/V2/Annotations/BookmarkTransformer.php
+++ b/app/Transformers/V2/Annotations/BookmarkTransformer.php
@@ -24,7 +24,7 @@ class BookmarkTransformer extends TransformerAbstract
             'id'                   => (string) $bookmark->id,
             'user_id'              => (string) $bookmark->user_id,
             'dam_id'               => $bookmark->bible_id.substr($bookmark->book->book_testament, 0, 1).'2ET',
-            'book_id'              => (string) $bookmark->book->id_osis,
+            'book_id'              => (string) $bookmark->book->id_osis ? $bookmark->book->id_osis : $bookmark->book_id,
             'chapter_id'           => (string) $bookmark->chapter,
             'verse_id'             => (string) $bookmark->verse_start,
             'created'              => (string) $bookmark->created_at,


### PR DESCRIPTION
# Description
- Fixed bookmarks and notes creation timestamps response

## Issue Link
Original Story: [FCBH-2132](https://fullstacklabs.atlassian.net/browse/FCBH-2132) 

## How Do I QA This
- Open the app targeting the local API
- Create a note and verify that the response has the `created_at` and `updated_at` fields
- Create a bookmark and verify that the response has the `created_at`, `updated_at` fields and `book_id` fields

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
