### PR TITLE
FCBH-2384 Add user data to downloads

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\APIController;
 use App\Http\Controllers\User\BookmarksController;
 use App\Http\Controllers\User\HighlightsController;
 use App\Http\Controllers\User\NotesController;
+use App\Models\User\UserDownload;
 use App\Models\Bible\BibleDefault;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileset;
@@ -675,6 +676,16 @@ class BiblesController extends APIController
         $chapter = checkParam('chapter', true);
 
         $zip = checkBoolean('zip');
+
+        if (!empty($user) && $zip) {
+            UserDownload::create([
+                'user_id'        => $user->id,
+                'bible_id'        => $bible_id,
+                'book_id'        => $book_id,
+                'chapter'        => $chapter,
+            ]);
+        }
+
         $copyrights = checkBoolean('copyrights');
         $drama = checkParam('drama') ?? 'all';
         if ($drama !== 'all') {

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -761,31 +761,35 @@ class BiblesController extends APIController
             }
 
             $drama_all = $drama === 'all';
-
+            
             if ($drama === 'drama' || $drama_all) {
                 $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio_drama', 'drama', $zip, 'audio', 'non_drama', !$drama_all && $zip);
 
-                if (!empty($user) && $zip && isset($chapter_filesets->audio)) {
-                    UserDownload::create([
-                      'user_id'        => $user->id,
-                      'book_id'        => $book_id,
-                      'chapter'        => $chapter,
-                      'fileset_id'     => $chapter_filesets->audio->drama['fileset']['id'],
+                if (!empty($user) && $zip && isset($chapter_filesets->audio->drama)) {
+                    $fileset_id = $chapter_filesets->audio->drama['fileset']['id'];
+                
+                    cacheRemember('v4_user_download', [$user->id, $fileset_id], now()->addDay(), function () use ($user, $fileset_id) {
+                        UserDownload::create([
+                    'user_id'        => $user->id,
+                    'fileset_id'     => $fileset_id,
                   ]);
+                        return true;
+                    });
                 }
             }
-
+            
             if ($drama === 'non-drama' || $drama_all) {
                 $chapter_filesets = $this->getAudioFilesetData($chapter_filesets, $bible, $book, $chapter, 'audio', 'non_drama', $zip, 'audio_drama', 'drama', !$drama_all && $zip);
-                
+
                 if (!empty($user) && $zip && isset($chapter_filesets->audio->non_drama)) {
-                    UserDownload::create([
-                      'user_id'        => $user->id,
-                      'bible_id'        => $bible_id,
-                      'book_id'        => $book_id,
-                      'chapter'        => $chapter,
-                      'fileset_id'     => $chapter_filesets->audio->non_drama['fileset']['id'],
+                    $fileset_id = $chapter_filesets->audio->non_drama['fileset']['id'];
+                    cacheRemember('v4_user_download', [$user->id, $fileset_id], now()->addDay(), function () use ($user, $fileset_id) {
+                        UserDownload::create([
+                    'user_id'        => $user->id,
+                    'fileset_id'     => $fileset_id,
                   ]);
+                        return true;
+                    });
                 }
             }
 

--- a/app/Models/User/UserDownload.php
+++ b/app/Models/User/UserDownload.php
@@ -8,7 +8,7 @@ class UserDownload extends Model
 {
     protected $connection = 'dbp_users';
     public $table         = 'user_downloads';
-    protected $fillable  = ['id','user_id','fileset_id', 'book_id', 'chapter', 'created_at'];
+    protected $fillable  = ['id','user_id','fileset_id','created_at'];
     const UPDATED_AT = null;
 
     /**
@@ -45,28 +45,6 @@ class UserDownload extends Model
      */
     protected $user_id;
 
-    /**
-     *
-     * @OA\Property(ref="#/components/schemas/Book/properties/id")
-     * @method static UserDownload whereBookId($value)
-     * @property string $book_id
-     *
-     */
-    protected $book_id;
-
-    /**
-     *
-     * @OA\Property(
-     *   title="chapter",
-     *   type="integer",
-     *   description="This field in combination with the book_id and bible_id can be used to store a user's donwload"
-     * )
-     *
-     * @method static UserDownload whereChapter($value)
-     * @property integer $chapter
-     */
-    protected $chapter;
-
     protected $created_at;
 
     public function user()
@@ -77,10 +55,5 @@ class UserDownload extends Model
     public function fileset()
     {
         return $this->belongsTo(BibleFileset::class);
-    }
-
-    public function book()
-    {
-        return $this->belongsTo(Book::class);
     }
 }

--- a/app/Models/User/UserDownload.php
+++ b/app/Models/User/UserDownload.php
@@ -8,7 +8,7 @@ class UserDownload extends Model
 {
     protected $connection = 'dbp_users';
     public $table         = 'user_downloads';
-    protected $fillable  = ['id','user_id','bible_id', 'book_id', 'chapter', 'created_at'];
+    protected $fillable  = ['id','user_id','fileset_id', 'book_id', 'chapter', 'created_at'];
     const UPDATED_AT = null;
 
     /**
@@ -26,19 +26,24 @@ class UserDownload extends Model
 
     /**
      *
+     * @OA\Property(
+     *   title="playlist_id",
+     *   type="integer",
+     *   description="The fileset id"
+     * )
+     *
+     * @property string $fileset_id
+     */
+    
+    protected $fileset_id;
+
+    /**
+     *
      * @OA\Property(ref="#/components/schemas/User/properties/id")
      * @method static UserDownload whereUserId($value)
      * @property string $user_id
      */
     protected $user_id;
-
-    /**
-     *
-     * @OA\Property(ref="#/components/schemas/Bible/properties/id")
-     * @method static UserDownload whereBibleId($value)
-     * @property string $bible_id
-     */
-    protected $bible_id;
 
     /**
      *
@@ -69,9 +74,9 @@ class UserDownload extends Model
         return $this->belongsTo(User::class);
     }
 
-    public function bible()
+    public function fileset()
     {
-        return $this->belongsTo(Bible::class);
+        return $this->belongsTo(BibleFileset::class);
     }
 
     public function book()

--- a/app/Models/User/UserDownload.php
+++ b/app/Models/User/UserDownload.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models\User;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserDownload extends Model
+{
+    protected $connection = 'dbp_users';
+    public $table         = 'user_downloads';
+    protected $fillable  = ['id','user_id','bible_id', 'book_id', 'chapter', 'created_at'];
+    const UPDATED_AT = null;
+
+    /**
+     *
+     * @OA\Property(
+     *   title="id",
+     *   type="integer",
+     *   description="The unique id for the userDownload",
+     *   minimum=1
+     * )
+     *
+     * @method static UserDownload whereId($value)
+     */
+    private $id;
+
+    /**
+     *
+     * @OA\Property(ref="#/components/schemas/User/properties/id")
+     * @method static UserDownload whereUserId($value)
+     * @property string $user_id
+     */
+    protected $user_id;
+
+    /**
+     *
+     * @OA\Property(ref="#/components/schemas/Bible/properties/id")
+     * @method static UserDownload whereBibleId($value)
+     * @property string $bible_id
+     */
+    protected $bible_id;
+
+    /**
+     *
+     * @OA\Property(ref="#/components/schemas/Book/properties/id")
+     * @method static UserDownload whereBookId($value)
+     * @property string $book_id
+     *
+     */
+    protected $book_id;
+
+    /**
+     *
+     * @OA\Property(
+     *   title="chapter",
+     *   type="integer",
+     *   description="This field in combination with the book_id and bible_id can be used to store a user's donwload"
+     * )
+     *
+     * @method static UserDownload whereChapter($value)
+     * @property integer $chapter
+     */
+    protected $chapter;
+
+    protected $created_at;
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function bible()
+    {
+        return $this->belongsTo(Bible::class);
+    }
+
+    public function book()
+    {
+        return $this->belongsTo(Book::class);
+    }
+}

--- a/database/migrations/2020_09_10_215230_add_user_downloads_table.php
+++ b/database/migrations/2020_09_10_215230_add_user_downloads_table.php
@@ -20,9 +20,6 @@ class AddUserDownloadsTable extends Migration
                 $table->foreign('user_id', 'FK_users_user_downloads')->references('id')->on(config('database.connections.dbp_users.database') . '.users')->onUpdate('cascade');
                 $table->string('fileset_id', 16);
                 $table->foreign('fileset_id', 'FK_bible_filesets_user_downloads')->references('id')->on(config('database.connections.dbp.database') . '.bible_filesets')->onUpdate('cascade')->onDelete('cascade');
-                $table->char('book_id', 3);
-                $table->foreign('book_id', 'FK_books_bible_books')->references('id')->on(config('database.connections.dbp.database').'.books');
-                $table->tinyInteger('chapter')->unsigned();
                 $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
             });
         }

--- a/database/migrations/2020_09_10_215230_add_user_downloads_table.php
+++ b/database/migrations/2020_09_10_215230_add_user_downloads_table.php
@@ -18,8 +18,8 @@ class AddUserDownloadsTable extends Migration
                 $table->increments('id');
                 $table->integer('user_id')->unsigned();
                 $table->foreign('user_id', 'FK_users_user_downloads')->references('id')->on(config('database.connections.dbp_users.database') . '.users')->onUpdate('cascade');
-                $table->string('bible_id', 12);
-                $table->foreign('bible_id', 'FK_bibles_user_downloads')->references('id')->on(config('database.connections.dbp.database').'.bibles')->onUpdate('cascade')->onDelete('cascade');
+                $table->string('fileset_id', 16);
+                $table->foreign('fileset_id', 'FK_bible_filesets_user_downloads')->references('id')->on(config('database.connections.dbp.database') . '.bible_filesets')->onUpdate('cascade')->onDelete('cascade');
                 $table->char('book_id', 3);
                 $table->foreign('book_id', 'FK_books_bible_books')->references('id')->on(config('database.connections.dbp.database').'.books');
                 $table->tinyInteger('chapter')->unsigned();

--- a/database/migrations/2020_09_10_215230_add_user_downloads_table.php
+++ b/database/migrations/2020_09_10_215230_add_user_downloads_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUserDownloadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::connection('dbp_users')->hasTable('user_downloads')) {
+            Schema::connection('dbp_users')->create('user_downloads', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id', 'FK_users_user_downloads')->references('id')->on(config('database.connections.dbp_users.database') . '.users')->onUpdate('cascade');
+                $table->string('bible_id', 12);
+                $table->foreign('bible_id', 'FK_bibles_user_downloads')->references('id')->on(config('database.connections.dbp.database').'.bibles')->onUpdate('cascade')->onDelete('cascade');
+                $table->char('book_id', 3);
+                $table->foreign('book_id', 'FK_books_bible_books')->references('id')->on(config('database.connections.dbp.database').'.books');
+                $table->tinyInteger('chapter')->unsigned();
+                $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->dropIfExists('user_downloads');
+    }
+}


### PR DESCRIPTION
# Description
* Create a migration for userDownloads with id, user_id, fileset_id, and created_at 
* Create model for userDownloads with foreign keys for user, fileset and book
* Add userDownloads on bible controller, creating the model when there's a user and there's a drama/non_drama fileset
* use cache to save user  downloads

## Issue Link
[FCBH-2384](https://fullstacklabs.atlassian.net/browse/FCBH-2384) 

## How Do I QA This
- Run migrations and check the user_download table was created
- Test `/bibles/{bible_id}` `GET` endpoint (You must have an api_token, use zip true, add chapter and book id, and assign drama keys)
- Check the if the user_download row was created with the correct data

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
