### PR TITLE
FCBH-2435 Plan translation (ONE>NIV, maybe others)

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -844,7 +844,7 @@ class PlansController extends APIController
      * )
      */
 
-    private function getPlan($plan_id, $user)
+    private function getPlan($plan_id, $user, $with_order = false)
     {
         $select = ['plans.*'];
         if (!empty($user)) {
@@ -937,14 +937,17 @@ class PlansController extends APIController
         $translation_data = [];
         $translated_percentage = 0;
         $playlists_data = [];
+        $order = 1;
         foreach ($plan->days as $day) {
             $playlist = (object) $playlist_controller->translate($request, $day->playlist_id, $user)->original;
             $playlists_data[] = [
                 'plan_id'               => $new_plan->id,
                 'playlist_id'           => $playlist->id,
+                'order_column'          => $order,
             ];
             $translation_data[] = $playlist->translation_data;
             $translated_percentage += $playlist->translated_percentage;
+            $order += 1;
         }
         PlanDay::insert($playlists_data);
         $translated_percentage = sizeof($plan->days) ? $translated_percentage / sizeof($plan->days) : 0;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -632,15 +632,8 @@ class PlaylistsController extends APIController
 
     private function createTranslatedPlaylistItems($playlist, $playlist_items)
     {
-        $current_items_size = sizeof($playlist->items);
-        $new_items_size = sizeof($playlist_items);
-
-        if ($current_items_size + $new_items_size > $this->items_limit) {
-            $allowed_size = $this->items_limit - $current_items_size;
-            $playlist_items = array_slice($playlist_items, 0, $allowed_size);
-        }
-
         $playlist_items_to_create = [];
+        $order = 1;
         foreach ($playlist_items as $playlist_item) {
             $playlist_item = (object) $playlist_item;
             $playlist_item_data = [
@@ -651,13 +644,15 @@ class PlaylistsController extends APIController
                 'chapter_end'       => $playlist_item->chapter_end,
                 'verse_start'       => $playlist_item->verse_start ?? null,
                 'verse_end'         => $playlist_item->verse_end ?? null,
-                'verses'            => $playlist_items->verses ?? 0
+                'verses'            => $playlist_items->verses ?? 0,
+                'order_column'      => $order
             ];
             $playlist_items_to_create[] = $playlist_item_data;
+            $order += 1;
         }
 
         PlaylistItems::insert($playlist_items_to_create);
-        $new_items = PlaylistItems::where('playlist_id', $playlist->id)->get();
+        $new_items = PlaylistItems::where('playlist_id', $playlist->id)->orderBy('order_column')->get();
         $created_playlist_items = [];
         foreach ($new_items as $key => $playlist_item) {
             $playlist_item->translated_id = $playlist_items[$key]->translated_id;

--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -274,20 +274,16 @@ class UsersController extends APIController
 
     private function loginWithSocialProvider($provider_id, $provider_user_id)
     {
-
-
         $user = \DB::table(
-            config('database.connections.dbp_users.database') . '.users' )
+            config('database.connections.dbp_users.database') . '.users')
                 ->join(config('database.connections.dbp_users.database') . '.user_accounts', function ($join) use ($provider_id, $provider_user_id) {
-            $join->on('users.id', 'user_accounts.user_id')
+                    $join->on('users.id', 'user_accounts.user_id')
             ->where('user_accounts.provider_id', $provider_id)
             ->where('user_accounts.provider_user_id', $provider_user_id);
-        })->select(['*'])->first();
+                })->select(['*'])->first();
 
 
         return $user;
-
-
     }
     /**
      *


### PR DESCRIPTION
# Description
- Fix order by adding the 'order_column' while the pl/an is being translated, without this the order of the items is not being inserted correctly causing conflicts on the translated view.

## Issue Link
[FCBH-2435](https://fullstacklabs.atlassian.net/browse/FCBH-2435) 

## How Do I QA This
- Open the app with the FCBH-2435 backend branch seletec.
- Navigate to the ONE 2021 plan
![image](https://user-images.githubusercontent.com/41348080/93816710-8000ab00-fc1d-11ea-8c62-0a3da595517c.png)
- Click on translate -> English -> NIV
- Verify you get the correct conent

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
