### PR TITLE
FCBH-2535 Update playlist endpoint to retrieve timestamps so Pl/an reader auto-scrolls properly

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -283,7 +283,6 @@ class PlansController extends APIController
                 if ($show_text) {
                     foreach ($day_playlist->items as $item) {
                         $item->verse_text = $item->getVerseText();
-                        $item->item_timestamps = $item->getTimestamps();
                     }
                 }
                 $day->playlist = $day_playlist;

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -283,6 +283,7 @@ class PlansController extends APIController
                 if ($show_text) {
                     foreach ($day_playlist->items as $item) {
                         $item->verse_text = $item->getVerseText();
+                        $item->item_timestamps = $item->getTimestamps();
                     }
                 }
                 $day->playlist = $day_playlist;

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -15,6 +15,7 @@ use App\Traits\CallsBucketsTrait;
 use App\Traits\CheckProjectMembership;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -176,7 +177,6 @@ class PlaylistsController extends APIController
             if ($show_text) {
                 foreach ($playlist->items as $item) {
                     $item->verse_text = $item->getVerseText();
-                    $item->item_timestamps = $item->getTimestamps();
                 }
             }
             $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
@@ -335,8 +335,9 @@ class PlaylistsController extends APIController
         }
 
         if ($show_text) {
+            $playlist_text_filesets = $this->getPlaylistTextFilesets($playlist_id);
             foreach ($playlist->items as $item) {
-                $item->verse_text = $item->getVerseText();
+                $item->verse_text = $item->getVerseText($playlist_text_filesets);
                 $item->item_timestamps = $item->getTimestamps();
             }
         }
@@ -1187,5 +1188,38 @@ class PlaylistsController extends APIController
         });
 
         return $playlist;
+    }
+
+    public function getPlaylistTextFilesets($playlist_id)
+    {
+        $filesets = Arr::pluck(DB::connection('dbp_users')
+            ->select('select DISTINCT(fileset_id) from playlist_items where playlist_id = ?', [$playlist_id]), 'fileset_id');
+
+        $filesets_hashes = DB::connection('dbp')
+            ->table('bible_filesets')
+            ->select(['hash_id', 'id'])
+            ->whereIn('id', $filesets)->get();
+
+        $hashes_bibles = DB::connection('dbp')
+            ->table('bible_fileset_connections')
+            ->select(['hash_id', 'bible_id'])
+            ->whereIn('hash_id', $filesets_hashes->pluck('hash_id'))->get();
+
+        $text_filesets = DB::connection('dbp')
+            ->table('bible_fileset_connections as fc')
+            ->join('bible_filesets as f', 'f.hash_id', '=', 'fc.hash_id')
+            ->select(['f.*', 'fc.bible_id'])
+            ->where('f.set_type_code', 'text_plain')
+            ->whereIn('fc.bible_id', $hashes_bibles->pluck('bible_id'))->get()->groupBy('bible_id');
+
+
+        $fileset_text_info = $filesets_hashes->pluck('hash_id', 'id');
+        $bible_hash = $hashes_bibles->pluck('bible_id', 'hash_id');
+
+        foreach ($filesets as $fileset) {
+            $bible_id = $bible_hash[$fileset_text_info[$fileset]];
+            $fileset_text_info[$fileset] = $text_filesets[$bible_id];
+        }
+        return $fileset_text_info;
     }
 }

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -176,6 +176,7 @@ class PlaylistsController extends APIController
             if ($show_text) {
                 foreach ($playlist->items as $item) {
                     $item->verse_text = $item->getVerseText();
+                    $item->item_timestamps = $item->getTimestamps();
                 }
             }
             $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
@@ -336,6 +337,7 @@ class PlaylistsController extends APIController
         if ($show_text) {
             foreach ($playlist->items as $item) {
                 $item->verse_text = $item->getVerseText();
+                $item->item_timestamps = $item->getTimestamps();
             }
         }
 


### PR DESCRIPTION
# Description
- Added get timestamps functionality to the playlists and plans endpoints

## Issue Link
Original Story: [FCBH-2535](https://fullstacklabs.atlassian.net/browse/FCBH-2535) 

## How Do I QA This
- Call `http://dbp.test/api/playlists/{PLAYLIST_ID}?v=4&key={APP_KEY}show_details=true&show_text=true` and verify you get the texts and the timestamps

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
