### PR TITLE
FCBH-2430 check verseEnd for bible files

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -158,12 +158,17 @@ class StreamController extends APIController
             return BibleFile::with('streamBandwidth')->where('hash_id', $fileset->hash_id)->where('id', $parts[0])->first();
         }
 
+        $where = [
+            'book_id' => $parts[0],
+            'chapter_start' => $parts[1],
+            'verse_start' => $parts[2]
+        ];
+
+        if ($parts[3] !== '') {
+            $where['verse_end'] = $parts[3];
+        }
+
         return BibleFile::with('streamBandwidth')->where('hash_id', $fileset->hash_id)
-            ->where([
-                'book_id' => $parts[0],
-                'chapter_start' => $parts[1],
-                'verse_start' => $parts[2],
-                'verse_end' => $parts[3] ? $parts[3] : null,
-            ])->first();
+            ->where($where)->first();
     }
 }


### PR DESCRIPTION
# Description
- Add check (for null and 0) on streamController for verseEnd in bible files
- there are files with chapter end on 0 (not sure if that's intentional)
- the problem was in the db bible_files table, there are different approaches on the chapter_end sometimes “NULL” is used and sometimes 0, we did an extra check to pass either of those.

## Issue Link
Original Story: [FCBH-2430](https://fullstacklabs.atlassian.net/browse/FCBH-2430) 

## How Do I QA This
- Call `https://dev.dbt.io/api/bible/filesets/ENGKJVP2DV/MAT-1-1-0/playlist.m3u8?v=4&key=52e62d4c-f7c8-4a8b-9008-8634d0fbddb0&api_token=cXxyvWdW1rjzChIjKcaQpdmGmMgMMLnN7OSO2Cv3ifSX1A7HyaaLGIIQA9nS

## Screenshots
![image (3)](https://user-images.githubusercontent.com/14282633/94210975-d546f180-fe95-11ea-837f-1c86462a4bd7.png)

![image (2)](https://user-images.githubusercontent.com/14282633/94210978-d8da7880-fe95-11ea-98ec-9cba202f086f.png)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
