### PR TITLE
FCBH-2425 Properly set filesetId in GOSPEL_FILMS videoStart and videoStop analytics event_types

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -797,7 +797,11 @@ class BiblesController extends APIController
             if ($video_stream) {
                 $fileset_controller = new BibleFileSetsController();
                 $gospel_films = $fileset_controller->show($video_stream->id, $video_stream->asset_id, $video_stream->set_type_code, 'v4_chapter_filesets_show')->original['data'] ?? [];
-                $chapter_filesets->video->gospel_films = $gospel_films;
+                $chapter_filesets->video->gospel_films = array_map(function ($gospel_film) use ($video_stream) {
+                    unset($video_stream->laravel_through_key);
+                    $gospel_film['fileset'] = $video_stream;
+                    return $gospel_film;
+                }, $gospel_films);
             }
 
             $video_stream_controller = new VideoStreamController();


### PR DESCRIPTION
# Description
- Added fileset metadata to the gospel_films object on the CD endpoint in order to notify the client the video's fileset

## Issue Link
Original Story: [FCBH-2425](https://fullstacklabs.atlassian.net/browse/FCBH-2425) 

## How Do I QA This
- Call `http://dbp.test/api/bibles/OZMTBL/chapter?asset_id=dbp-prod&chapter=1&book_id=MRK&key={API_KEY}&v=4` and verify you get the fileset metadata values on the gospel_film section

![image](https://user-images.githubusercontent.com/41348080/94307394-5061e380-ff3a-11ea-9a2f-0ebc1b4038d9.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.

