### PR TITLE
remove geoip update temporarily

### DIFF
--- a/.ebextensions/artisan.config
+++ b/.ebextensions/artisan.config
@@ -11,5 +11,6 @@ files:
       sudo -E -u webapp php artisan opcache:optimize
       sudo -E -u webapp php artisan optimize:clear
       sudo -E -u webapp php artisan optimize
-      sudo -E -u webapp php artisan geoip:update
+      # 9/26/2020 https://geolite.maxmind.com/ website down, so removing geoip update
+      #sudo -E -u webapp php artisan geoip:update
       sudo -E -u webapp php artisan config:clear


### PR DESCRIPTION
We are unable to deploy to develop due to an artisan update of geoip, which fails when https://geolite.maxmind.com/ is down (as it is now), thus causing the health check to fail