### PR TITLE
Modify DBP Rate Limit to match WAF

### DIFF
--- a/.ebextensions/artisan.config
+++ b/.ebextensions/artisan.config
@@ -11,5 +11,6 @@ files:
       sudo -E -u webapp php artisan opcache:optimize
       sudo -E -u webapp php artisan optimize:clear
       sudo -E -u webapp php artisan optimize
-      sudo -E -u webapp php artisan geoip:update
+      # 9/26/2020 https://geolite.maxmind.com/ website down, so removing geoip update
+      #sudo -E -u webapp php artisan geoip:update
       sudo -E -u webapp php artisan config:clear

--- a/.ebextensions/artisan.config
+++ b/.ebextensions/artisan.config
@@ -11,6 +11,5 @@ files:
       sudo -E -u webapp php artisan opcache:optimize
       sudo -E -u webapp php artisan optimize:clear
       sudo -E -u webapp php artisan optimize
-      # 9/26/2020 https://geolite.maxmind.com/ website down, so removing geoip update
-      #sudo -E -u webapp php artisan geoip:update
+      sudo -E -u webapp php artisan geoip:update
       sudo -E -u webapp php artisan config:clear

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,7 +54,7 @@ class Kernel extends HttpKernel
             LocalizationHandler::class
         ],
         'api' => [
-            'throttle:2000,1',
+            'throttle:150,5',
             'bindings'
         ],
         //'activated' => [CheckIsUserActivated::class,],


### PR DESCRIPTION
The intent is to configure DBP Rate limiting to match AWS WAF, so that clients can get better feedback when being rate-limited. With this change, the WAF and DBP will both Rate Limit to 150 requests in 5 minutes. We can adjust the rates once we confirm the client is responding to DBP response headers