### PR TITLE
add Middleware to require version match

### DIFF
--- a/.ebextensions/artisan.config
+++ b/.ebextensions/artisan.config
@@ -11,5 +11,6 @@ files:
       sudo -E -u webapp php artisan opcache:optimize
       sudo -E -u webapp php artisan optimize:clear
       sudo -E -u webapp php artisan optimize
-      sudo -E -u webapp php artisan geoip:update
+      # 9/26/2020 https://geolite.maxmind.com/ website down, so removing geoip update
+      #sudo -E -u webapp php artisan geoip:update
       sudo -E -u webapp php artisan config:clear

--- a/.ebextensions/artisan.config
+++ b/.ebextensions/artisan.config
@@ -11,6 +11,5 @@ files:
       sudo -E -u webapp php artisan opcache:optimize
       sudo -E -u webapp php artisan optimize:clear
       sudo -E -u webapp php artisan optimize
-      # 9/26/2020 https://geolite.maxmind.com/ website down, so removing geoip update
-      #sudo -E -u webapp php artisan geoip:update
+      sudo -E -u webapp php artisan geoip:update
       sudo -E -u webapp php artisan config:clear

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -54,7 +54,7 @@ class Kernel extends HttpKernel
             LocalizationHandler::class
         ],
         'api' => [
-            'throttle:2000,1',
+            'throttle:150,5',
             'bindings'
         ],
         //'activated' => [CheckIsUserActivated::class,],

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -19,6 +19,7 @@ use \Illuminate\View\Middleware\ShareErrorsFromSession;
 use \Illuminate\Routing\Middleware\SubstituteBindings;
 use \App\Http\Middleware\VerifyCsrfToken;
 use \Lunaweb\Localization\Middleware\LocalizationHandler;
+use \App\Http\Middleware\ApiVersion;
 
 class Kernel extends HttpKernel
 {
@@ -54,6 +55,7 @@ class Kernel extends HttpKernel
             LocalizationHandler::class
         ],
         'api' => [
+            ApiVersion::class,
             'throttle:150,5',
             'bindings'
         ],

--- a/app/Http/Middleware/ApiVersion.php
+++ b/app/Http/Middleware/ApiVersion.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Http\JsonResponse ;
+
+
+use Closure;
+
+class APIVersion
+{
+
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $method
+     * @return mixed
+     *
+     */
+    public function handle($request, Closure $next)
+    {
+
+        $version_name = explode('_', $request->route()->getName())[0];
+        if (!($version_name === 'v2' || $version_name === 'v3' ||  $version_name === 'v4')) {
+            return $next($request);
+        }
+        $routeV = substr($version_name, 1,1);
+
+        if ($url_header = $request->header("v")) {
+            $requestV = $url_header;
+         } else if ($queryParam = $request->input("v")) {
+             $requestV = $queryParam;
+         } else {
+            return $next($request); // TODO:
+         }
+         if ($routeV != $requestV) {
+            return response("Not Found", 404);
+         }
+
+         // all good
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ApiVersion.php
+++ b/app/Http/Middleware/ApiVersion.php
@@ -2,9 +2,6 @@
 
 namespace App\Http\Middleware;
 
-use Illuminate\Http\JsonResponse ;
-
-
 use Closure;
 
 class APIVersion
@@ -22,25 +19,23 @@ class APIVersion
      */
     public function handle($request, Closure $next)
     {
-
         $version_name = explode('_', $request->route()->getName())[0];
         if (!($version_name === 'v2' || $version_name === 'v3' ||  $version_name === 'v4')) {
             return $next($request);
         }
-        $routeV = substr($version_name, 1,1);
+        $routeV = substr($version_name, 1, 1);
 
-        if ($url_header = $request->header("v")) {
+        if ($url_header = $request->header('v')) {
             $requestV = $url_header;
-         } else if ($queryParam = $request->input("v")) {
-             $requestV = $queryParam;
-         } else {
-            return $next($request); // TODO:
-         }
-         if ($routeV != $requestV) {
-            return response("Not Found", 404);
-         }
+        } elseif ($queryParam = $request->input('v')) {
+            $requestV = $queryParam;
+        } else {
+            return $next($request);
+        }
+        if ($routeV != $requestV) {
+            return response('Not Found', 404);
+        }
 
-         // all good
         return $next($request);
     }
 }


### PR DESCRIPTION
This PR enforces a sharper distinction between versions. For example, a v2 route will not be found if the request parameter v is not equal to 2