### PR TITLE
FCBH-2311 Create script for plan translation

### DIFF
--- a/app/Console/Commands/translatePlan.php
+++ b/app/Console/Commands/translatePlan.php
@@ -72,7 +72,7 @@ class translatePlan extends Command
         } else {
             $bible_ids = explode(',', $bible_ids);
             $user = User::with('projects')->whereId($plan->user_id)->first();
-            $plan_controller = new PlansController();
+            $plan_controller = new MessagedPlansController();
             foreach ($bible_ids as $key => $bible_id) {
                 $request = new Request();
                 request()->merge(['bible_id' => $bible_id]);
@@ -108,5 +108,14 @@ class translatePlan extends Command
 
         $this->line('');
         $this->alert('Translating plan end: ' . Carbon::now());
+    }
+}
+
+
+class MessagedPlansController extends PlansController
+{
+    public function replyWithError($message, $action = null)
+    {
+        throw (new Exception($message));
     }
 }

--- a/app/Console/Commands/translatePlan.php
+++ b/app/Console/Commands/translatePlan.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\Plan\PlansController;
+use App\Models\Language\Language;
+use App\Models\Plan\Plan;
+use App\Models\Playlist\PlaylistItems;
+use App\Models\User\User;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Http\Request;
+
+class translatePlan extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'translate:plan {plan_id} {bible_ids}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command to translate a plan to a list of bibles';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $plan_id = $this->argument('plan_id');
+        $bible_ids = $this->argument('bible_ids');
+
+
+
+        // i18n
+
+        $cache_params = ['eng'];
+        $current_language = cacheRemember('selected_api_language', $cache_params, now()->addDay(), function () {
+            $language = Language::where('iso', 'eng')->select(['iso', 'id'])->first();
+            return [
+                'i18n_iso' => $language->iso,
+                'i18n_id'  => $language->id
+            ];
+        });
+        $GLOBALS['i18n_iso'] = $current_language['i18n_iso'];
+        $GLOBALS['i18n_id']  = $current_language['i18n_id'];
+
+
+        $plan = Plan::where('id', $plan_id)->first();
+
+        $this->alert('Translating plan ' . $plan->name . ' starting: ' . Carbon::now());
+        if (!$plan) {
+            $this->error('Plan with ID:' . $plan_id . ' do not exist');
+        } else {
+            $bible_ids = explode(',', $bible_ids);
+            $user = User::with('projects')->whereId($plan->user_id)->first();
+            $plan_controller = new PlansController();
+            foreach ($bible_ids as $key => $bible_id) {
+                $request = new Request();
+                request()->merge(['bible_id' => $bible_id]);
+                try {
+                    $this->line('Translating plan to bible ' . $bible_id . ' started ' . Carbon::now());
+                    $new_plan = $plan_controller->translate($request, $plan_id, $user, false, false);
+                    $days = $new_plan['days'];
+                    $this->line('Calculating duration and verses ' . Carbon::now());
+                    foreach ($days as $day) {
+                        $playlist_items = PlaylistItems::where('playlist_id', $day['playlist_id'])->get();
+                        foreach ($playlist_items as $playlist_item) {
+                            $playlist_item->calculateDuration()->save();
+                            $playlist_item->calculateVerses()->save();
+                        }
+                    }
+
+                    $this->info('Translating plan to bible ' . $bible_id . ' finalized ' . Carbon::now());
+                    $this->line('');
+                } catch (Exception $e) {
+                    $this->error('Error translating plan to bible ' . $bible_id . ' ');
+                    $this->error('Error message: ' . $e->getMessage() . ' ');
+                    $this->error('Error timestamp: ' . Carbon::now() . ' ');
+                    $this->line('');
+                    $this->question('Please fix the issue translating the plan to ' . $bible_id . ' ');
+                    $this->question('To continue the process please run the following command: ');
+                    $this->line('');
+
+                    $this->comment("\t<fg=green>php artisan translate:plan " . $plan_id . ' ' . implode(',', array_splice($bible_ids, $key)));
+                    break;
+                }
+            }
+        }
+
+        $this->line('');
+        $this->alert('Translating plan end: ' . Carbon::now());
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -44,6 +44,7 @@ class Kernel extends ConsoleKernel
         Commands\syncV2Highlights::class,
         Commands\syncV2Notes::class,
         Commands\reSyncV2Notes::class,
+        Commands\translatePlan::class,
         Commands\encryptNote::class,
 
         Commands\syncPlaylistDuration::class,

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -900,12 +900,12 @@ class PlansController extends APIController
      *
      *
      */
-    public function translate(Request $request, $plan_id)
+    public function translate(Request $request, $plan_id, $user = null, $compare_projects = true, $draft = true)
     {
-        $user = $request->user();
+        $user = $user ? $user : $request->user();
 
         // Validate Project / User Connection
-        if (!empty($user) && !$this->compareProjects($user->id, $this->key)) {
+        if ($compare_projects && !empty($user) && !$this->compareProjects($user->id, $this->key)) {
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
@@ -928,7 +928,7 @@ class PlansController extends APIController
             'user_id'               => $user->id,
             'name'                  => $plan->name . ': ' . $bible->language->name . ' ' . substr($bible->id, -3),
             'featured'              => false,
-            'draft'                 => true,
+            'draft'                 => $draft,
             'suggested_start_date'  => $plan->suggested_start_date
         ];
 
@@ -939,7 +939,7 @@ class PlansController extends APIController
         $playlists_data = [];
         $order = 1;
         foreach ($plan->days as $day) {
-            $playlist = (object) $playlist_controller->translate($request, $day->playlist_id, $user)->original;
+            $playlist = (object) $playlist_controller->translate($request, $day->playlist_id, $user, $compare_projects)->original;
             $playlists_data[] = [
                 'plan_id'               => $new_plan->id,
                 'playlist_id'           => $playlist->id,

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -770,12 +770,12 @@ class PlaylistsController extends APIController
      *
      *
      */
-    public function translate(Request $request, $playlist_id, $user = false)
+    public function translate(Request $request, $playlist_id, $user = false, $compare_projects = true)
     {
         $user = $user ? $user : $request->user();
 
         // Validate Project / User Connection
-        if (!empty($user) && !$this->compareProjects($user->id, $this->key)) {
+        if ($compare_projects && !empty($user) && !$this->compareProjects($user->id, $this->key)) {
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 


### PR DESCRIPTION
# Description
- Added an artisan php command to translate a plan to multiple bibles

## Issue Link
Original Story: [FCBH-2311](https://fullstacklabs.atlassian.net/browse/FCBH-2311) 

## How Do I QA This
- On your local environment run `php artisan translate:plan {PLAN_ID} {COMMA_SEPARATED_BIBLES_IDS}` to run the translation
- Verify that the plans are being translated 

## Screenshots 
### Translation with error example
![image](https://user-images.githubusercontent.com/41348080/94854504-9c0d0500-03f2-11eb-8e17-aeeccd31201b.png)
### Translation without error example
![image](https://user-images.githubusercontent.com/41348080/94854521-a4fdd680-03f2-11eb-9071-f28689c47f8e.png)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed locally.
