### PR TITLE
FCBH-2032 Create script to sync pl/ans verses and duration

### DIFF
--- a/app/Console/Commands/syncPlaylistDuration.php
+++ b/app/Console/Commands/syncPlaylistDuration.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Playlist\PlaylistItems;
+use App\Models\Plan\Plan;
 use Illuminate\Console\Command;
 use Carbon\Carbon;
 
@@ -20,23 +21,53 @@ class syncPlaylistDuration extends Command
      *
      * @var string
      */
-    protected $description = 'Sync the playlist items duration with the database';
+    protected $description = 'Sync the playlist items verses and duration on the database';
 
     /**
      * Execute the console command.
      *
      * @return mixed
      */
+
+    private function playlist_verses_and_duration($playlist_items)
+    {
+        $this->line(Carbon::now() . ' Sync starting for ' . sizeof($playlist_items) . ' items');
+        foreach ($playlist_items as $key => $playlist_item) {
+            $this->line(Carbon::now() . ' Calculating duration and verses of item ' . ($key + 1) . ' started');
+            $playlist_item->calculateDuration()->save();
+            $playlist_item->calculateVerses()->save();
+            $this->info(Carbon::now() . ' Calculating duration and verses of item ' . ($key + 1) . ' finalized');
+            $this->line('');
+        }
+    }
+
     public function handle()
     {
-        echo "\n" . Carbon::now() . ': playlist items sync started.';
+        $sync_type = $this->choice('What do you want to sync?', ['Playlist', 'Plan', 'All plans and playlists'], 0);
+        
+        if ($sync_type !== 'All plans and playlists') {
+            $plan_playlist_id = $this->ask('Enter the ' . $sync_type . ' id:');
+            $this->alert(Carbon::now() . ' ' . $sync_type . ' items sync started ');
 
-        $playlist_items = PlaylistItems::all();
-
-        foreach ($playlist_items as $playlist_item) {
-            $playlist_item->calculateDuration()->save();
+            if ($sync_type === 'Plan') {
+                $plan = Plan::where('id', $plan_playlist_id)->first();
+                foreach ($plan->days as $key => $day) {
+                    $this->line(Carbon::now() . ' Calculating duration and verses for day ' . ($key + 1) . ' of the plan');
+                    $playlist_items = PlaylistItems::where('playlist_id', $day['playlist_id'])->get();
+                    $this->playlist_verses_and_duration($playlist_items);
+                    $this->line('');
+                }
+            } else {
+                $playlist_items = PlaylistItems::when($plan_playlist_id, function ($query, $plan_playlist_id) {
+                    $query->where('playlist_id', $plan_playlist_id);
+                })->get();
+                $this->playlist_verses_and_duration($playlist_items);
+            }
+        } else {
+            $playlist_items = PlaylistItems::all();
+            $this->playlist_verses_and_duration($playlist_items);
         }
 
-        echo "\n" . Carbon::now() . ": playlist items sync finalized.\n";
+        $this->alert(Carbon::now() . ' ' . $sync_type . ' items sync Finalized ');
     }
 }


### PR DESCRIPTION
# Description
- Added get timestamps functionality to the playlists and plans endpoints

## Issue Link
Original Story: [FCBH-2032](https://fullstacklabs.atlassian.net/browse/FCBH-2032) 

## How Do I QA This
- Create playlist or plan and add playlist_items
- run console command: php artisan sync:playlistDuration
- Check that the duration and verses of the related playlist_items is updated on the db

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
