### PR TITLE
FCBH-2704 show text of translated playlists

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -764,6 +764,12 @@ class PlaylistsController extends APIController
      *          @OA\Schema(ref="#/components/schemas/Bible/properties/id"),
      *          description="The id of the bible that will be used to translate the playlist"
      *     ),
+     *     @OA\Parameter(
+     *          name="show_details",
+     *          in="query",
+     *          @OA\Schema(type="boolean"),
+     *          description="Give full details of the playlist"
+     *     ),
      *     @OA\Response(response=200, ref="#/components/responses/playlist")
      * )
      *
@@ -782,6 +788,7 @@ class PlaylistsController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
+        $show_details = checkBoolean('show_details');
         $bible_id = checkParam('bible_id', true);
         $bible = cacheRemember('bible_translate', [$bible_id], now()->addDay(), function () use ($bible_id) {
             return Bible::whereId($bible_id)->first();
@@ -858,7 +865,6 @@ class PlaylistsController extends APIController
         $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist->id, 'v' => $this->v, 'key' => $this->key]);
         $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
 
-        $show_details = checkBoolean('show_details');
         if ($show_details) {
             $playlist_text_filesets = $this->getPlaylistTextFilesets($playlist_id);
             foreach ($playlist->items as $item) {

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -858,6 +858,15 @@ class PlaylistsController extends APIController
         $playlist->path = route('v4_playlists.hls', ['playlist_id'  => $playlist->id, 'v' => $this->v, 'key' => $this->key]);
         $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
 
+        $show_details = checkBoolean('show_details');
+        if ($show_details) {
+            $playlist_text_filesets = $this->getPlaylistTextFilesets($playlist_id);
+            foreach ($playlist->items as $item) {
+                $item->verse_text = $item->getVerseText($playlist_text_filesets);
+                $item->item_timestamps = $item->getTimestamps();
+            }
+        }
+
         $playlist->translation_data = $metadata_items;
         $playlist->translated_percentage = $translated_percentage * 100;
 


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
* Check show_details param
* Add verse_text to playlist items
* Add swagger documentation

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-52](https://fullstacklabs.atlassian.net/browse/FCBH-52) -->
[FCBH-2704](https://fullstacklabs.atlassian.net/browse/FCBH-2704)

## How Do I QA This
* Translate a playlist with http://dbp.test/api/playlists/{playlist_id}/translate
* you'll have to use show_details: true, and bible_id as params
* Check that the response gets the verses text 

