### PR TITLE
[Gideons branch] Add verse_count parameter to books endpoint

### DIFF
--- a/app/Transformers/BooksTransformer.php
+++ b/app/Transformers/BooksTransformer.php
@@ -148,6 +148,9 @@ class BooksTransformer extends BaseTransformer
                 if ($book->content_types) {
                     $result['content_types'] = $book->content_types;
                 }
+                if ($book->verses_count) {
+                    $result['verses_count'] = $book->verses_count;
+                }
                 return $result;
 
             case 'v4_bible_filesets.books':


### PR DESCRIPTION
# Description
- Added `verse_count` parameter to the bible->book endpoint in order to have the verse_count of the chapters
- If there are no verses the object won't be retrieved

# Test steps
- Run the following query and verify that you get now the verse count of the chapters
- `http://dbp.test/api/bibles/{BIBLE_ID}/book?asset_id=dbp-prod,dbp-vid&verify_content=true&key={KEY}&v=4&verse_count=true`

# Screenshots
![image](https://user-images.githubusercontent.com/41348080/102392426-091d4900-3fa5-11eb-9547-dfefec570a68.png)
