### PR TITLE
FCBH-3127 fix jesus film error returning 500

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -834,7 +834,7 @@ class BiblesController extends APIController
                     }
                 }
                 $chapter_filesets->video->jesus_films = collect($films)->map(function ($film) use ($metadata) {
-                    $film->meta = $metadata[$film->component_id];
+                    $film->meta = $metadata[$film->component_id] ?? [];
                     return $film;
                 });
             }


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* return empty array on metadata for jesus film if empty

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3037](https://fullstacklabs.atlassian.net/browse/FCBH-3037) -->
[FCBH-3127](https://fullstacklabs.atlassian.net/browse/FCBH-3127)

## How Do I QA This
* Check that calling this endpoints don't return an error
* {dbp_url}/api/bibles/FIN38CB/chapter?asset_id=dbp-prod&chapter=26&book_id=MAT&api_token=LVgoHpP8AEKDVanN4weBvQSndO4YqAuDqlKP0BYQY9GY8KbDco0ZitmQDUFu
and
{dbp_url}/api/bibles/NORNBV/chapter?asset_id=dbp-prod&chapter=6&book_id=MAT&api_token=null

**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
