### PR TITLE
FCBH-3132 fix error on bible undefined with bookmarks

### DIFF
--- a/app/Models/User/Study/Bookmark.php
+++ b/app/Models/User/Study/Bookmark.php
@@ -147,6 +147,9 @@ class Bookmark extends Model
         $chapter = $bookmark['chapter'];
         $verse_start = $bookmark['verse_start'];
         $bible = Bible::where('id', $bookmark['bible_id'])->first();
+        if (!$bible) {
+            return '';
+        }
         $fileset = BibleFileset::join(
       'bible_fileset_connections as connection',
       'connection.hash_id',


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Check if the bible was returned before calling its properties

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3132](https://fullstacklabs.atlassian.net/browse/FCBH-3132) -->
[FCBH-3132](https://fullstacklabs.atlassian.net/browse/FCBH-3132)

## How Do I QA This
* Go to basePath/users/711732/bookmarks?asset_id=dbp-prod&sort_by=updated_at&sort_dir=desc&page=1
* set v = 4 and key = 52e62d4c-f7c8-4a8b-9008-8634d0fbddb0 params
* call should not return a 500 error, but a 200 with data 

**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
