### PR TITLE
FCBH-3133 add defensive code on highligh filesets data

### DIFF
--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -173,12 +173,22 @@ class Highlight extends Model
         $verse_start = $highlight['verse_start'];
         $verse_end = $highlight['verse_end'] ?? $verse_start;
         $bible = Bible::where('id', $highlight['bible_id'])->first();
+        if (!$bible) {
+            return [];
+        }
         $filesets = $bible->filesets;
+        if (!$filesets) {
+            return [];
+        }
         $text_fileset = $filesets->firstWhere('set_type_code', 'text_plain');
 
         $bibles_controller = new BiblesController();
         $fileset_types = collect(['audio_stream_drama', 'audio_drama', 'audio_stream', 'audio']);
-        $testament = $this->book->book->book_testament;
+        if (!$this->book || !$this->book->book) {
+            $testament = '';
+        } else {
+            $testament = $this->book->book->book_testament;
+        }
 
         $audio_filesets = $filesets->filter(function ($fs) {
             return Str::contains($fs->set_type_code, 'audio');


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Check if the bible was returned before calling its properties
* Check fileset exist before calling properties
* If data was not set correctly, return empty testament book

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3132](https://fullstacklabs.atlassian.net/browse/FCBH-3132) -->
[FCBH-3133](https://fullstacklabs.atlassian.net/browse/FCBH-3133)

## How Do I QA This
* basePath/users/1314767/highlights?asset_id=dbp-prod&prefer_color=hex&sort_by=id&sort_dir=desc&page=1&query=&color=fd2e2e%2C%23fd2e2e
* set v = 4 and key = 52e62d4c-f7c8-4a8b-9008-8634d0fbddb0 params
* call should not return a 500 error, but a 200 with data 

**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
