### PR TITLE
FCBH-3131 add defensive code on playlists not found or without items

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -315,14 +315,13 @@ class PlaylistsController extends APIController
 
         $playlist = $this->getPlaylist($user, $playlist_id);
 
-        if (!$playlist) {
+        if (!$playlist || (isset($playlist->original) && $playlist->original['error'])) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
         }
 
         foreach ($playlist->items as $item) {
             $item->verse_text = $item->getVerseText();
         }
-
 
         return $this->reply($playlist->items->pluck('verse_text', 'id'));
     }
@@ -368,11 +367,11 @@ class PlaylistsController extends APIController
 
         $playlist = $this->getPlaylist($user, $playlist_id);
 
-        if (!$playlist) {
+        if (!$playlist || (isset($playlist->original) && $playlist->original['error'])) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
         }
-
-        if ($show_text) {
+        
+        if ($show_text && isset($playlist->items)) {
             $playlist_text_filesets = $this->getPlaylistTextFilesets($playlist_id);
             foreach ($playlist->items as $item) {
                 $item->verse_text = $item->getVerseText($playlist_text_filesets);
@@ -458,7 +457,6 @@ class PlaylistsController extends APIController
         }
 
         $playlist = $this->getPlaylist($user, $playlist_id);
-
         return $this->reply($playlist);
     }
 
@@ -828,10 +826,9 @@ class PlaylistsController extends APIController
         }
 
         $playlist = $this->getPlaylist(false, $playlist_id);
-        if (!$playlist) {
+        if (!$playlist || (isset($playlist->original) && $playlist->original['error'])) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
         }
-
 
         $audio_fileset_types = collect(['audio_stream', 'audio_drama_stream', 'audio', 'audio_drama']);
         $bible_audio_filesets = $bible->filesets->whereIn('set_type_code', $audio_fileset_types);
@@ -895,7 +892,7 @@ class PlaylistsController extends APIController
         $playlist->path = route('v4_internal_playlists.hls', ['playlist_id'  => $playlist->id, 'v' => $this->v, 'key' => $this->key]);
         $playlist->total_duration = PlaylistItems::where('playlist_id', $playlist->id)->sum('duration');
 
-        if ($show_details) {
+        if ($show_details && isset($playlist->items)) {
             $playlist_text_filesets = $this->getPlaylistTextFilesets($playlist->id);
             foreach ($playlist->items as $item) {
                 $item->verse_text = $item->getVerseText($playlist_text_filesets);
@@ -1254,14 +1251,16 @@ class PlaylistsController extends APIController
             return $this->setStatusCode(404)->replyWithError('No playlist could be found for: ' . $playlist_id);
         }
 
-        $playlist->items = $playlist->items->map(function ($item) {
-            $bible = $item->fileset->bible->first();
-            if ($bible) {
-                $item->bible_id = $bible->id;
-            }
-            unset($item->fileset);
-            return $item;
-        });
+        if (isset($playlist->items)) {
+            $playlist->items = $playlist->items->map(function ($item) {
+                $bible = $item->fileset->bible->first();
+                if ($bible) {
+                    $item->bible_id = $bible->id;
+                }
+                unset($item->fileset);
+                return $item;
+            });
+        }
 
         return $playlist;
     }


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Check if the getPlaylist does not return an error or a null
* Check the playlist->items exists before running an action on them

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3132](https://fullstacklabs.atlassian.net/browse/FCBH-3132) -->
[FCBH-3131](https://fullstacklabs.atlassian.net/browse/FCBH-3131)

## How Do I QA This
* Go to basePath/playlists/3640818?asset_id=dbp-prod&api_token=EtoLIhKGzm9cdAObDpSYVzvLCDC1lqumXPbLx4RfKLvNIMPsZZy6EWLqmtZP&show_text=true
* set v = 4 and key = 52e62d4c-f7c8-4a8b-9008-8634d0fbddb0 params
* call should not return a 500 error, but a 200 with data or a 404 “playlist not found“ 
**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
