### PR TITLE
FCBH-3134 add defensive code on notes model

### DIFF
--- a/app/Models/User/Study/Note.php
+++ b/app/Models/User/Study/Note.php
@@ -211,6 +211,9 @@ class Note extends Model
         $verse_start = $this['verse_start'];
         $verse_end = $this['verse_end'] ? $this['verse_end'] : $verse_start;
         $bible = Bible::where('id', $this['bible_id'])->first();
+        if (!$bible) {
+            return '';
+        }
         $fileset = BibleFileset::join(
       'bible_fileset_connections as connection',
       'connection.hash_id',
@@ -246,6 +249,9 @@ class Note extends Model
     public function getBibleNameAttribute()
     {
         $bible = Bible::whereId($this['bible_id'])->with(['translations', 'books.book'])->first();
+        if (!$bible) {
+            return '';
+        }
         $ctitle = optional($bible->translations->where('language_id', $GLOBALS['i18n_id'])->first())->name;
         $vtitle = optional($bible->vernacularTranslation)->name;
         return ($vtitle ? $vtitle : $ctitle);


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Check if the bible on notes exists before calling the bibles queries on name and verseText

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3132](https://fullstacklabs.atlassian.net/browse/FCBH-3132) -->
[FCBH-3134](https://fullstacklabs.atlassian.net/browse/FCBH-3134)

## How Do I QA This
* Go to /users/923214/notes?asset_id=dbp-prod&sort_by=updated_at&sort_dir=desc&page=1
* set v = 4 and key = 52e62d4c-f7c8-4a8b-9008-8634d0fbddb0 params
* call should not return a 500 error, but a 200 with data, or, if it throws an error it has to be either a 404 or a 401
**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
