### PR TITLE
FCBH-3126 avoid checking null email on social providers

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -269,8 +269,15 @@ class UsersController extends APIController
             return User::with('accounts', 'profile')->whereId($account->user_id)->first();
         }
 
+        $no_match_log = 'social provider login with no matching DBP info. request:' . json_encode($request->all())
+                        . ', provider_id: ' . $provider_id . ', provider_user_id: ' . $provider_user_id;
+        Log::error($no_match_log);
         // Verify a user with the email exist
-        $user = User::with('accounts', 'profile')->where('email', $request->email)->first();
+        if (!$request->email) {
+            $user = null;
+        } else {
+            $user = User::with('accounts', 'profile')->where('email', $request->email)->first();
+        }
         // Create user if not exists
         if (!$user) {
             $user = User::create([
@@ -281,6 +288,8 @@ class UsersController extends APIController
                 'activated'     => 0,
                 'password'      => \Hash::make(Str::random(10)),
             ]);
+            $user_created_log = 'new user created with userid:' . $user->id . ', request: ' . json_encode($request->all());
+            Log::error($user_created_log);
 
             Profile::create([
                 'user_id' => $user->id
@@ -298,7 +307,9 @@ class UsersController extends APIController
                 'provider_user_id' => $provider_user_id
             ]
         );
-        
+        $account_log = 'social provider login, User Account after linking User and Account:' . json_encode($account);
+        Log::error($account_log);
+
         // if exists update the provider_user_id (For now throw error to newrelic)
         if ($existing_account && ($provider_user_id !== $existing_account->provider_user_id)) {
             $provider_error_message = 'Login error on request' . json_encode($request->all()) . ' with different provider_user_id ' . $provider_user_id .


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Find account with primary keys, if no account exists with those, create one.
* If the account exists update the existing with the given provider_user_id

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3037](https://fullstacklabs.atlassian.net/browse/FCBH-3037) -->
[FCBH-3126](https://fullstacklabs.atlassian.net/browse/FCBH-3126)

## How Do I QA This
* identify a test userid and provider_id
* add a new row that has the same user_id, the same provider_id, and a bogus provider_user_id. 
* attempt to login with that userid / provider_id and the real provider_user_id. This will fail currently, and will pass when the fix is in

**Note:** To run the test suite refer to the Readme.md
<!--- Explain how a developer would qa out these changes locally -->
