### PR TITLE
add dbp_users database to role_user to disambiguate

### DIFF
--- a/app/Models/User/RoleUser.php
+++ b/app/Models/User/RoleUser.php
@@ -20,7 +20,7 @@ use App\Models\Organization\Organization;
 class RoleUser extends Model
 {
     protected $connection = 'dbp_users';
-    protected $table = 'role_user';
+    protected $table = 'dbp_users.role_user';
     public $fillable = ['organization_id','user_id','role_id'];
 
     /**


### PR DESCRIPTION
in FCBH-2781, the database (dbp_users) was removed from the RoleUser Model table. This change only exists in earlyaccess, and apparently causes a failure during user creation. This PR adds the database name back in