### PR TITLE
FCBHDBP-43 use eng as default for hugarian jesus films

### DIFF
--- a/app/Http/Controllers/Bible/VideoStreamController.php
+++ b/app/Http/Controllers/Bible/VideoStreamController.php
@@ -42,6 +42,9 @@ class VideoStreamController extends APIController
     {
         try {
             $iso = checkParam('iso') ?? $iso;
+            $forbidden_isos = explode(',', config('settings.forbiddenArclightIso'));
+            $iso = in_array($iso, $forbidden_isos) ? 'eng' : $iso;
+
             if ($iso) {
                 $languages = cacheRemember('arclight_languages', [$iso], now()->addDay(), function () use ($iso) {
                     $languages = collect($this->fetchArclight('media-languages', false, false, 'iso3=' . $iso)->mediaLanguages);

--- a/config/settings.php
+++ b/config/settings.php
@@ -110,4 +110,9 @@ return [
   'bibleSyncFilePath' => env('BIBLE_SYNC_FILE_PATH', ''),
 
   'apiLatestVersion' => env('API_LATEST_VERSION', '4'),
+
+  /*
+   * Arclight forbiddenn iso list
+   */
+  'forbiddenArclightIso' => env('FORBIDDEN_ARCLIGHT_ISO', 'hun'),
 ];


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* use env variable: FORBIDDEN_ARCLIGHT_ISO=hun (can have a list like: hun,spa)
* default to english if the iso of the call is included in the list FORBIDDEN_ARCLIGHT_ISO
## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBH-3037](https://fullstacklabs.atlassian.net/browse/FCBH-3037) -->
[FCBHDBP-43](https://fullstacklabs.atlassian.net/browse/FCBHDBP-43)

## How to qa this?
* go to {base_api}/arclight/jesus-film/chapters?asset_id=dbp-prod&iso=hun&arclight_id=1107&key=52e62d4c-f7c8-4a8b-9008-8634d0fbddb0&v=4
* text data should be in english, not on hungarian
