### PR TITLE
restore bibles/filesets/books implementation

### DIFF
--- a/app/Http/Controllers/Bible/BooksController.php
+++ b/app/Http/Controllers/Bible/BooksController.php
@@ -80,18 +80,18 @@ class BooksController extends APIController
      * @param $id
      * @return JsonResponse
      */
-    // public function show($id)
-    // {
-    //     $fileset_type = checkParam('fileset_type') ?? 'text_plain';
+    public function show($id)
+    {
+        $fileset_type = checkParam('fileset_type') ?? 'text_plain';
 
-    //     $cache_params = [$id, $fileset_type];
-    //     $books = cacheRemember('v4_books', $cache_params, now()->addDay(), function () use ($fileset_type, $id) {
-    //         $books = $this->getActiveBooksFromFileset($id, $fileset_type);
-    //         return fractal($books, new BooksTransformer(), $this->serializer);
-    //     });
+        $cache_params = [$id, $fileset_type];
+        $books = cacheRemember('v4_books', $cache_params, now()->addDay(), function () use ($fileset_type, $id) {
+            $books = $this->getActiveBooksFromFileset($id, $fileset_type);
+            return fractal($books, new BooksTransformer(), $this->serializer);
+        });
 
-    //     return $this->reply($books);
-    // }
+        return $this->reply($books);
+    }
 
     public function getActiveBooksFromFileset($id, $fileset_type)
     {

--- a/routes/api.php
+++ b/routes/api.php
@@ -93,18 +93,13 @@ Route::name('v4_internal_filesets.show')->get(
     'Bible\BibleFileSetsController@show'
 );
 
-// not used by bible.is
-// is there anything in this that cannot be provided by bibles/books?
-// try to remove it
-// Route::name('v4_filesets.books')->get(
-//     'bibles/filesets/{fileset_id}/books',
-//     'Bible\BooksController@show'
-// );
-
+// not used by bible.is after 3.0.x
+// needs to remain in the API for backward compatibility until 3.0.x and older are gone
 Route::name('v4_filesets.books')->get(
     'bibles/filesets/{fileset_id}/books',
     'Bible\BooksController@show'
 );
+
 // the order of the routes matters, the most general have to go first
 Route::name('v4_filesets.bulk')->get(
   'bibles/filesets/bulk/{fileset_id}/{book?}',


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
Restore implementation of bibles/filesets/<id>/books. This is deprecated, but still used by bible.is 3.0.x and older. This was found from NewRelic analysis

## Issue Link
No Jira ticket created. 

## How Do I QA This
ensure this Postman test produces good results, and not a 500 error
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a16a0c41-1a36-4d2a-a2b7-2f228721b9e6


