### PR TITLE
FCBHDBP-137 deprecate endpoints/functionalities

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -124,7 +124,8 @@ function forceBibleisGideonsPagination($key, $limit_param)
     // remove pagination for bibleis and gideons (temporal fix)
     $limit = min($limit_param, 50);
     $is_bibleis_gideons = null;
-    if (isBibleisOrGideon($key)) {
+
+    if (shouldUseBibleisBackwardCompat($key)) {
         $limit = PHP_INT_MAX;
         $is_bibleis_gideons = 'bibleis-gideons';
     } 
@@ -177,6 +178,7 @@ function shouldUseBibleisBackwardCompat($key)
         $user_ag = $_SERVER['HTTP_USER_AGENT'];
         // add logic to get the ios/android version from the user agennt string
         $app_version = (int) 'version';
+
         if (($app_version < $ios_deprecation_version) || ($app_version < $android_deprecation_version)) {
             $should_use_backward_compat = true;
         }

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Cache;
+use Log;
 
 /**
  * Check query parameters for a given parameter name, and check the headers for the same parameter name;

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -173,17 +173,17 @@ function shouldUseBibleisBackwardCompat($key)
     // different from bibleis
     $should_use_backward_compat = false;
     if (isBibleisOrGideon($key)) {
-        $ios_deprecation_version = (int) config('settings.bibleis_deprecate_from_version.ios');
-        $android_deprecation_version = (int) config('settings.bibleis_deprecate_from_version.android');
+        $deprecation_version = config('settings.bibleis_deprecate_from_version.ios');
         $user_ag = $_SERVER['HTTP_USER_AGENT'];
-        // add logic to get the ios/android version from the user agennt string
-        $app_version = (int) 'version';
-
-        if (($app_version < $ios_deprecation_version) || ($app_version < $android_deprecation_version)) {
-            $should_use_backward_compat = true;
-        }
+        if (strpos($user_ag, 'BibleIs/') !== false) {
+            $app_version = explode("BibleIs/", $user_ag)[1];
+            $app_version = explode(" ", $app_version)[0];
+            $formatted_version = preg_split("/( |\-)/", $app_version)[0];
+            if ($formatted_version < $deprecation_version) {
+                $should_use_backward_compat = true;
+            }
+        }  
     }
-    
     return $should_use_backward_compat;
 }
 

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -182,11 +182,13 @@ function shouldUseBibleisBackwardCompat($key)
     // endpoints/functions using this should already be deprecated for all other users
     // different from bibleis
     $should_use_backward_compat = false;
+    $app_name = '';
+    $app_version = '';
+    $deprecation_version = config('settings.deprecate_from_version.bibleis');
+
     if (isBibleisOrGideon($key)) {
-        $deprecation_version = config('settings.deprecate_from_version.bibleis');
         $deprecation_version = formatAppVersion($deprecation_version);
         $user_ag = $_SERVER['HTTP_USER_AGENT'];
-        $app_name = '';
         
         if (strpos($user_ag, 'Bible.is/') !== false) {
             $app_name = 'Bible.is';
@@ -205,6 +207,17 @@ function shouldUseBibleisBackwardCompat($key)
             }
         }
     }
+    // log data to be sure this deprecation method is working correctly
+    $log_data = [
+        "key" => $key,
+        "app_name" => $app_name,
+        "app_version" => $app_version,
+        "deprecation_version" => $deprecation_version,
+        "backward_compatibility_mode_active" => $should_use_backward_compat,
+    ];
+    $backward_compat_message = "shouldUseBibleisBackwardCompat: " . json_encode($log_data);
+    Log::error($backward_compat_message);
+
     return $should_use_backward_compat;
 }
 

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -166,6 +166,25 @@ function storagePath(
       ($secondary_file_name ?? $fileset_chapter['file_name']);
 }
 
+function shouldUseBibleisBackwardCompat($key)
+{
+    // endpoints/functions using this should already be deprecated for all other users
+    // different from bibleis
+    $should_use_backward_compat = false;
+    if (isBibleisOrGideon($key)) {
+        $ios_deprecation_version = (int) config('settings.bibleis_deprecate_from_version.ios');
+        $android_deprecation_version = (int) config('settings.bibleis_deprecate_from_version.android');
+        $user_ag = $_SERVER['HTTP_USER_AGENT'];
+        // add logic to get the ios/android version from the user agennt string
+        $app_version = (int) 'version';
+        if (($app_version < $ios_deprecation_version) || ($app_version < $android_deprecation_version)) {
+            $should_use_backward_compat = true;
+        }
+    }
+    
+    return $should_use_backward_compat;
+}
+
 if (!function_exists('csvToArray')) {
     function csvToArray($csvfile)
     {

--- a/config/settings.php
+++ b/config/settings.php
@@ -115,8 +115,8 @@ return [
    */
   'forbiddenArclightIso' => env('FORBIDDEN_ARCLIGHT_ISO', 'hun'),
 
-  'bibleis_deprecate_from_version' => [
-      'ios' => env('BIBLEIS_DEPRECATE_FROM_IOS_VERSION', '900'),
-      'android' => env('BIBLEIS_DEPRECATE_FROM_ANDROID_VERSION', '5000'),
-  ],
+  /*
+   * Version to start bibleis/gid deprecation
+   */
+  'bibleis_deprecate_from_version' => env('BIBLEIS_DEPRECATE_FROM_VERSION', '3.0.10'),
 ];

--- a/config/settings.php
+++ b/config/settings.php
@@ -114,4 +114,9 @@ return [
    * Arclight forbiddenn iso list
    */
   'forbiddenArclightIso' => env('FORBIDDEN_ARCLIGHT_ISO', 'hun'),
+
+  'bibleis_deprecate_from_version' => [
+      'ios' => env('BIBLEIS_DEPRECATE_FROM_IOS_VERSION', '900'),
+      'android' => env('BIBLEIS_DEPRECATE_FROM_ANDROID_VERSION', '5000'),
+  ],
 ];

--- a/config/settings.php
+++ b/config/settings.php
@@ -118,5 +118,8 @@ return [
   /*
    * Version to start bibleis/gid deprecation
    */
-  'bibleis_deprecate_from_version' => env('BIBLEIS_DEPRECATE_FROM_VERSION', '3.0.10'),
+  'deprecate_from_version' => [
+      'bibleis' => env('BIBLEIS_DEPRECATE_FROM_VERSION', '3.3.10'),
+      'gideons' => env('GIDEONS_DEPRECATE_FROM_VERSION', '2.1.3'),
+  ],
 ];


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->
This will need a bit of discussion, it. does nont look like user agent is retrieving the data we want, this is easily achievable on bibleis side headers.
# Description
<!--- Describe your changes in detail -->
* add helper to deprecate endpoints/functions for all users, except old bibleis/gid app users
* Deprecate chapter endpoint 
* Deprecate non-pagination for bibleis/gideons newest
* format app version from user agent and compare with formatted deprecation version

MISSING:
* confirm ios and android versions (configurable on .env)
* Get correct data from user agent
## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->
[FCBHDBP-133](https://fullstacklabs.atlassian.net/browse/FCBHDBP-133)
[FCBHDBP-137](https://fullstacklabs.atlassian.net/browse/FCBHDBP-137)
[FCBHDBP-139](https://fullstacklabs.atlassian.net/browse/FCBHDBP-139)

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
