### PR TITLE
Fix languageController filters by languages instead of filesets

### DIFF
--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -370,14 +370,9 @@ class Language extends Model
         });
     }
 
-    public function scopeIncludeExtraLanguages($query, $access_control_identifiers, $asset_id)
-    {   
-        return $query->whereRaw('languages.id in (' . $access_control_identifiers . ')')
-            ->when($asset_id, function ($query) use ($asset_id) {
-                $query->whereHas('fileset', function ($query) use ($asset_id) {
-                    $query->where('asset_id', $asset_id);
-                });
-            });
+    public function scopeIncludeExtraLanguages($query, $access_control_identifiers)
+    {  
+        return $query->whereRaw('languages.id in (' . $access_control_identifiers . ')');
     }
 
     public function scopeIncludeCountryPopulation($query, $country)
@@ -411,6 +406,14 @@ class Language extends Model
         $name_expression = $full_word ? $name : '%'.$name.'%';
         return $query->when($name, function ($query) use ($name, $name_expression) {
             $query->where('languages.name', 'like', $name_expression);
+        });
+    }
+
+    public function scopeFilterBySearch($query, $search_text)
+    {
+        $name_expression = $full_word ? $name : '%'.$name.'%';
+        return $query->when($name, function ($query) use ($name, $name_expression) {
+            $query->where('languages.name', 'like', $search_text)->orWhere();
         });
     }
 


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
Remove filter by fileset asset id on languages controllers due to new access control returning languages ids
## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
