### PR TITLE
FCBHDBP-161 configure renovate to update minor versions PHP7.4

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "ignorePaths": [
+    "docker-compose.yml",
+    "package.json"
+  ],
+  "docker": {
+    "enabled": false
+  },
+  "docker-compose": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    }
+  ]
+}


### PR DESCRIPTION
## configure renovate to update minor versions for PHP7.4

# Description
It has added the renovatebot file config. It will only keep the composer.json as dependency source and the minors upgrading will be group into a only PR by dependency.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-161

## How Do I QA This
When we enable the renovatebot we should see a PR from renovate similar to the next screenshot:

## Screenshots (if appropriate)
![screenshot-github com-2021 08 31-18_53_04](https://user-images.githubusercontent.com/73488660/131757073-be0200d6-0a1b-4036-8b5b-75c55f77547e.png)

