### PR TITLE
FCBHDBP-170 Incompatible method signature - UserPlan::setKeysForSaveQuery

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -689,6 +689,7 @@ class BibleFileSetsController extends APIController
                         ->flatten();
                     $video_filesets_hashes = $filesets
                         ->where('set_type_code', 'video_stream')
+                        ->pluck('hash_id')
                         ->flatten();
                     return [
                         'audio' => $audio_filesets_hashes,

--- a/app/Models/Plan/PlanDayComplete.php
+++ b/app/Models/Plan/PlanDayComplete.php
@@ -4,9 +4,12 @@ namespace App\Models\Plan;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\Traits\ModelBase;
 
 class PlanDayComplete extends Model
 {
+    use ModelBase;
+
     protected $connection = 'dbp_users';
     public $table         = 'plan_days_completed';
     protected $primaryKey = ['user_id', 'plan_day_id'];
@@ -20,7 +23,7 @@ class PlanDayComplete extends Model
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $keys = $this->getKeyName();
         if (!is_array($keys)) {

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -4,6 +4,7 @@ namespace App\Models\Plan;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\Traits\ModelBase;
 
 /**
  * @OA\Schema (
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class UserPlan extends Model
 {
+    use ModelBase;
+
     protected $connection = 'dbp_users';
     protected $primaryKey = ['user_id', 'plan_id'];
     public $incrementing = false;
@@ -50,7 +53,7 @@ class UserPlan extends Model
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $keys = $this->getKeyName();
         if (!is_array($keys)) {

--- a/app/Models/Playlist/PlaylistFollower.php
+++ b/app/Models/Playlist/PlaylistFollower.php
@@ -4,9 +4,12 @@ namespace App\Models\Playlist;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\Traits\ModelBase;
 
 class PlaylistFollower extends Model
 {
+    use ModelBase;
+
     protected $connection = 'dbp_users';
     protected $primaryKey = ['user_id', 'playlist_id'];
     public $incrementing  = false;
@@ -20,7 +23,7 @@ class PlaylistFollower extends Model
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $keys = $this->getKeyName();
         if (!is_array($keys)) {

--- a/app/Models/Playlist/PlaylistItemsComplete.php
+++ b/app/Models/Playlist/PlaylistItemsComplete.php
@@ -4,9 +4,12 @@ namespace App\Models\Playlist;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use App\Models\Traits\ModelBase;
 
 class PlaylistItemsComplete extends Model
 {
+    use ModelBase;
+
     protected $connection = 'dbp_users';
     public $table         = 'playlist_items_completed';
     protected $primaryKey = ['user_id', 'playlist_item_id'];
@@ -20,7 +23,7 @@ class PlaylistItemsComplete extends Model
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    protected function setKeysForSaveQuery(Builder $query)
+    protected function setKeysForSaveQuery($query)
     {
         $keys = $this->getKeyName();
         if (!is_array($keys)) {

--- a/app/Models/Traits/ModelBase.php
+++ b/app/Models/Traits/ModelBase.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models\Traits;
+
+trait ModelBase
+{
+    /**
+     * Get the value of the model's primary key.
+     *
+     * @return mixed
+     */
+    public function getKey()
+    {
+        $key = $this->getKeyName();
+
+        if (is_array($key)) {
+            return $this->getKeyName();
+        }
+
+        return parent::getKey();
+    }
+}


### PR DESCRIPTION
## Incompatible method signature - UserPlan::setKeysForSaveQuery

# Description
- it has added a trait to support composite primary keys for the model class.
- It has added a fix to the `checkTypes` endpoint. We need to add the pluck method because the `video_filesets_hashes` parameter was storing the query instance before and the results was not being fetching.
- Removed the type constraint for the method `setKeysForSaveQuery` for the query input parameter. The above because the last version of laravel has also removed it.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-170

## How Do I QA This
 I can run the bible.is mobile request on postman for the current branch.

## Screenshots (if appropriate)
![Screenshot from 2021-09-03 10-30-44](https://user-images.githubusercontent.com/73488660/132039233-21e6f376-7598-4e0b-8561-13476652345b.png)

