### PR TITLE
FCBHDBP-168 php8 upgrade - bibles-filesets-id-id-id fails on php8, php74, but works on current php72

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -801,13 +801,19 @@ class BibleFileSetsController extends APIController
 
         if ($is_stream) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
-                $fileset_chapters[$key]->file_name = route('v4_media_stream', [
+                $routeParameters = [
                     'fileset_id' => $fileset->id,
                     'book_id' => $fileset_chapter->book_id,
                     'chapter' => $fileset_chapter->chapter_start,
                     'verse_start' => $fileset_chapter->verse_start,
                     'verse_end' => $fileset_chapter->verse_end
-                ]);
+                ];
+                $fileset_chapters[$key]->file_name = route('v4_media_stream', array_filter(
+                    $routeParameters,
+                    function ($filesetProperty) {
+                        return !is_null($filesetProperty) && $filesetProperty !== '';
+                    }
+                ));
             }
         } else {
             // Multiple files per chapter
@@ -819,8 +825,6 @@ class BibleFileSetsController extends APIController
                         'fileset_id' => $fileset->id,
                         'book_id' => $fileset_chapters[0]->book_id,
                         'chapter' => $fileset_chapters[0]->chapter_start,
-                        'verse_start' => null,
-                        'verse_end' => null,
                     ]
                 );
                 $collection = collect($fileset_chapters);

--- a/routes/api.php
+++ b/routes/api.php
@@ -156,7 +156,7 @@ Route::name('v4_media_stream_ts')->get(
 );
 ## this is no good. StreamController::index does not process book_id/chapter/verse_start/verse_end
 Route::name('v4_media_stream')->get(
-    'bible/filesets/{fileset_id}/{book_id}-{chapter}-{verse_start}-{verse_end}/playlist.m3u8',
+    'bible/filesets/{fileset_id}/{book_id}-{chapter}-{verse_start?}-{verse_end?}/playlist.m3u8',
     'Bible\StreamController@index'
 );
 Route::name('v4_media_stream_ts')->get(


### PR DESCRIPTION
## php8 upgrade - bibles-filesets-id-id-id fails on php8, php74, but works on current php72

# Description
 It has update the v4_media_stream route to allow verse_end and verse_start as optional parameters.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-168

## How Do I QA This
Use the next endpoint ->
- Active Development / new in php upgrade / bibles-filesets-id-id-id (SA)
- basePath/bibles/filesets/:filesetid/:bookid/:chapterid?v=4

## Screenshots

## Call route with option parameter
![Screenshot from 2021-09-03 16-59-02](https://user-images.githubusercontent.com/73488660/132069183-c91c9502-9d1b-437e-b6cc-d4fa4df7cb5b.png)
