### PR TITLE
FCBHDBP-173 Fix the endpoint library-volume Copy for php74 env

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -7,6 +7,7 @@ use App\Models\Organization\Organization;
 use App\Models\User\AccessGroupFileset;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 /**
  * App\Models\Bible\BibleFileset
@@ -221,7 +222,7 @@ class BibleFileset extends Model
         $fileset = $this->toArray();
         $url = '';
 
-        if (starts_with($fileset['set_type_code'], 'audio')) {
+        if (Str::startsWith($fileset['set_type_code'], 'audio')) {
             $bible_id = optional(BibleFileset::find($fileset['id'])->bible()->first())->id;
             if ($bible_id) {
                 $command = $client->getCommand('GetObject', [


### PR DESCRIPTION
### Fix the endpoint library-volume Copy for php8 env

# Description
The `starts_with` method has been replaced by `Illuminate\Support\Str::startsWith()`

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-173

## How Do I QA This
You can test the endpoint (library-volume Copy) on postman:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-19e5ad74-c223-4959-b781-13cf6778c35b

## Screenshots (if appropriate)
![Screenshot from 2021-09-07 11-29-13](https://user-images.githubusercontent.com/73488660/132379754-9389c50f-93b4-4b9c-8fac-0dcacb768d25.png)

