### PR TITLE
FCBHDBP-166 v2 backward compatibility - text verse with verse start should return one verse

### DIFF
--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -70,7 +70,7 @@ class TextController extends APIController
         $book_id     = checkParam('book_id', false, $book_url_param);
         $chapter     = checkParam('chapter_id', false, $chapter_url_param);
         $verse_start = checkParam('verse_start') ?? 1;
-        $verse_end   = checkParam('verse_end');
+        $verse_end   = checkParam('verse_end') ?? $verse_start;
 
         $book = Book::where('id', $book_id)->orWhere('id_osis', $book_id)->first();
 


### PR DESCRIPTION
## v2 backward compatibility - text verse with verse start should return one verse

# Description
It has fixed the text verse endpoint. For now on, DBP4 returns only one verse if verse_end parameter is not provided and verse_end will be equal to verse_start if verse_end is empty.

I have tested for the version 2 and 3.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-166

## How Do I QA This
You can test it with postman using the next URL:
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1459d5d9-a970-4bc8-9dd6-d1af9007e75d

And used the value `ENGESV` for the `dam_id` parameter

## Screenshots (if appropriate)
![Screenshot from 2021-09-07 18-19-59](https://user-images.githubusercontent.com/73488660/132422975-02af371b-bbf7-4f13-b339-19c89561597d.png)

