### PR TITLE
FCBHDBP-166 v2 backward compatibility - text verse with verse start should return one verse

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -961,8 +961,12 @@ class BiblesController extends APIController
         return isset($fileset->set_type_code) && isset($fileset->set_size_code);
     }
 
-    private function getAudioFilesetData($results, $bible, $book, $chapter, $type, $name, $download = false, $secondary_type, $secondary_name, $get_secondary = false)
+    private function getAudioFilesetData($results, $bible, $book, $chapter, $type, $name, $download, $secondary_type, $secondary_name, $get_secondary = false)
     {
+        if (!$download) {
+            $download = false;
+        }
+
         $fileset_controller = new BibleFileSetsController();
         $fileset = $this->getStreamNonStreamFileset($download, $bible, $type, $book);
 

--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -47,8 +47,8 @@ class TextController extends APIController
      *     path="/text/verse",
      *     tags={"Library Text"},
      *     summary="Returns Signed URLs or Text",
-     *     description="V2's base fileset route",
-     *     operationId="v2_text_verse",
+     *     description="V4's base fileset route",
+     *     operationId="v4_bible.verseinfo",
      *     @OA\Parameter(name="fileset_id", in="query", description="The Bible fileset ID", required=true, @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")),
      *     @OA\Parameter(name="book", in="query", description="The Book ID. For a complete list see the `book_id` field in the `/bibles/books` route.", required=true, @OA\Schema(ref="#/components/schemas/Book/properties/id")),
      *     @OA\Parameter(name="chapter", in="query", description="The chapter number", required=true, @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")),
@@ -70,7 +70,7 @@ class TextController extends APIController
         $book_id     = checkParam('book_id', false, $book_url_param);
         $chapter     = checkParam('chapter_id', false, $chapter_url_param);
         $verse_start = checkParam('verse_start') ?? 1;
-        $verse_end   = checkParam('verse_end') ?? $verse_start;
+        $verse_end   = checkParam('verse_end');
 
         $book = Book::where('id', $book_id)->orWhere('id_osis', $book_id)->first();
 

--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Bible;
+
+use App\Models\Bible\BibleVerse;
+use DB;
+
+use Illuminate\Http\Response;
+use App\Models\Bible\BibleFileset;
+use App\Models\Bible\Book;
+use App\Models\Language\AlphabetFont;
+use App\Traits\AccessControlAPI;
+use App\Traits\CheckProjectMembership;
+use App\Traits\CallsBucketsTrait;
+use App\Transformers\FontsTransformer;
+use App\Transformers\TextTransformer;
+use App\Http\Controllers\APIController;
+use App\Http\Controllers\Bible\Traits\TextControllerTrait;
+
+class TextControllerV2 extends APIController
+{
+    use CallsBucketsTrait;
+    use AccessControlAPI;
+    use CheckProjectMembership;
+    use TextControllerTrait;
+
+    /**
+     * Display a listing of the Verses
+     * Will either parse the path or query params to get data before passing it to the bible_equivalents table
+     *
+     * @param string|null $bible_url_param
+     * @param string|null $book_url_param
+     * @param string|null $chapter_url_param
+     *
+     * API Note: I removed the v4 openapi docs. Returning text for a fileset/book/chapter is now handled in BibleFileSetsController:showChapter, along with all other filesets
+     *
+     * @OA\Get(
+     *     path="/text/verse",
+     *     tags={"Library Text"},
+     *     summary="Returns Signed URLs or Text",
+     *     description="V2's base fileset route",
+     *     operationId="v2_text_verse",
+     *     @OA\Parameter(name="fileset_id", in="query", description="The Bible fileset ID", required=true, @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")),
+     *     @OA\Parameter(name="book", in="query", description="The Book ID. For a complete list see the `book_id` field in the `/bibles/books` route.", required=true, @OA\Schema(ref="#/components/schemas/Book/properties/id")),
+     *     @OA\Parameter(name="chapter", in="query", description="The chapter number", required=true, @OA\Schema(ref="#/components/schemas/BibleFile/properties/chapter_start")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_text_verse")),
+     *         @OA\MediaType(mediaType="application/xml",  @OA\Schema(ref="#/components/schemas/v2_text_verse")),
+     *         @OA\MediaType(mediaType="text/x-yaml",      @OA\Schema(ref="#/components/schemas/v2_text_verse"))
+     *     )
+     * )
+     *
+     * @return Response
+     */
+    public function index($bible_url_param = null, $book_url_param = null, $chapter_url_param = null)
+    {
+        // Fetch and Assign $_GET params
+        $fileset_id  = checkParam('dam_id|fileset_id', true, $bible_url_param);
+        $book_id     = checkParam('book_id', false, $book_url_param);
+        $chapter     = checkParam('chapter_id', false, $chapter_url_param);
+        $verse_start = checkParam('verse_start') ?? 1;
+        $verse_end   = checkParam('verse_end') ?? $verse_start;
+
+        $book = Book::where('id', $book_id)->orWhere('id_osis', $book_id)->first();
+
+        $fileset = BibleFileset::with('bible')->uniqueFileset($fileset_id, 'text_plain')->first();
+        if (!$fileset) {
+            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+        }
+        $bible = optional($fileset->bible)->first();
+
+        $access_blocked = $this->blockedByAccessControl($fileset);
+        if ($access_blocked) {
+            return $access_blocked;
+        }
+        $asset_id = $fileset->asset_id;
+        $cache_params = [$asset_id, $fileset_id, $book_id, $chapter, $verse_start, $verse_end];
+        $verses = $this->getVerses(
+            $cache_params,
+            $fileset,
+            $bible,
+            $book,
+            $chapter,
+            $verse_start,
+            $verse_end,
+        );
+
+        return $this->reply(fractal($verses, new TextTransformer(), $this->serializer));
+    }
+}

--- a/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
+++ b/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Bible\Traits;
+
+use App\Models\Bible\BibleVerse;
+
+trait TextControllerTrait
+{
+    public function getVerses($cache_params, $fileset, $bible, $book, $chapter, $verse_start, $verse_end)
+    {
+        return cacheRemember(
+            'bible_text',
+            $cache_params,
+            now()->addDay(),
+            function () use ($fileset, $bible, $book, $chapter, $verse_start, $verse_end) {
+                return BibleVerse::withVernacularMetaData($bible)
+                    ->where('hash_id', $fileset->hash_id)
+                    ->when($book, function ($query) use ($book) {
+                        return $query->where('bible_verses.book_id', $book->id);
+                    })
+                    ->when($verse_start, function ($query) use ($verse_start) {
+                        return $query->where('verse_end', '>=', $verse_start);
+                    })
+                    ->when($chapter, function ($query) use ($chapter) {
+                        return $query->where('chapter', $chapter);
+                    })
+                    ->when($verse_end, function ($query) use ($verse_end) {
+                        return $query->where('verse_end', '<=', $verse_end);
+                    })
+                    ->orderBy('verse_start')
+                    ->select([
+                        'bible_verses.book_id as book_id',
+                        'books.name as book_name',
+                        'books.protestant_order as book_order',
+                        'bible_books.name as book_vernacular_name',
+                        'bible_verses.chapter',
+                        'bible_verses.verse_start',
+                        'bible_verses.verse_end',
+                        'bible_verses.verse_text',
+                        'glyph_chapter.glyph as chapter_vernacular',
+                        'glyph_start.glyph as verse_start_vernacular',
+                        'glyph_end.glyph as verse_end_vernacular',
+                    ])->get();
+            }
+        );
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,8 +24,8 @@ Route::name('v4_languages.one')->get(
     'Wiki\LanguagesController@show'
 );
 Route::name('v4_languages.search')->get(
-  'languages/search/{search_text}',
-  'Wiki\LanguagesController@search'
+    'languages/search/{search_text}',
+    'Wiki\LanguagesController@search'
 );
 
 // VERSION 4 | Alphabets and Numbers
@@ -50,8 +50,6 @@ Route::name('v4_numbers.one')->get(
 // VERSION 4 | Search
 // Even though TextController fields the search, it returns content from text, audio and video. Rename to SearchController?
 Route::name('v4_text_search')->get('search', 'Bible\TextController@search');
-
-
 
 // VERSION 4 | Bibles
 Route::name('v4_bible.defaults')->get(

--- a/routes/apiV2.php
+++ b/routes/apiV2.php
@@ -22,7 +22,7 @@ Route::name('v2_country_lang')->get('country/countrylang',                      
 Route::name('v2_library_version')->get('library/version',                          'Bible\LibraryController@version');
 Route::name('v2_library_metadata')->get('library/metadata',                        'Bible\LibraryController@metadata');
 Route::name('v2_library_volume')->get('library/volume',                            'Bible\LibraryController@volume');
-Route::name('v2_library_verse')->get('library/verse',                              'Bible\TextController@index');
+Route::name('v2_library_verse')->get('library/verse',                              'Bible\TextControllerV2@index');
 Route::name('v2_library_verseInfo')->get('library/verseinfo',                      'Bible\TextController@info');
 Route::name('v2_library_numbers')->get('library/numbers',                          'Wiki\NumbersController@customRange');
 Route::name('v2_library_organization')->get('library/organization',                'Organization\OrganizationsController@index');
@@ -31,7 +31,7 @@ Route::name('v2_volume_organization_list')->get('library/volumeorganization',   
 
 // VERSION 2 | Text
 Route::name('v2_text_font')->get('text/font',                                      'Bible\TextController@fonts');
-Route::name('v2_text_verse')->get('text/verse',                                    'Bible\TextController@index');
+Route::name('v2_text_verse')->get('text/verse',                                    'Bible\TextControllerV2@index');
 Route::name('v2_verseInfo')->get('text/verseinfo',                                 'Bible\TextController@info'); // I cannot see a difference between library/verseinfo and text/verseinfo
 Route::name('v2_text_search')->get('text/search',                                  'Bible\TextController@search');
 Route::name('v2_text_search_group')->get('text/searchgroup',                       'Bible\TextController@searchGroup');


### PR DESCRIPTION
##  v2 backward compatibility - text verse with verse start should return one verse

# Description
It has separated the `textController` into two controllers to support the different API versions. It has created a controller for the version 4 and other controller for the version 2.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-166

## How Do I QA This
You can test it with postman using the next URL:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1459d5d9-a970-4bc8-9dd6-d1af9007e75d


## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
