### PR TITLE
FCBHDBP-165 v2 backward compatibility - library volume does not respect media = audio

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -399,7 +399,10 @@ class LibraryController extends APIController
         }
 
         $filesets = fractal($filesets, new LibraryVolumeTransformer(), $this->serializer)->toArray();
-        if (!empty($filesets) && !isset($version_code)) {
+        if (!empty($filesets) &&
+            !isset($version_code) &&
+            (empty($media) || $media === 'video' || $media === 'video_stream')
+        ) {
             $filesets = array_merge($filesets, $arclight->volumes($iso));
         }
 


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
 It added the feature to respect the media filter.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-165

## How Do I QA This
You can use the next test and you should filter by media=audio and it should return only media results.

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-c37a4e7b-4c0c-4fea-8360-1f8a3007195d

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
