### PR TITLE
FCBHDBP-161 configure renovate to update minor versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,28 @@
 {
   "extends": [
     "config:base"
+  ],
+  "ignorePaths": [
+    "docker-compose.yml",
+    "package.json"
+  ],
+  "docker": {
+    "enabled": false
+  },
+  "docker-compose": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    }
   ]
 }


### PR DESCRIPTION
### configure renovate to update minor versions

# Description
It has added the renovatebot file config. It will only keep the composer.json as dependency source and the minors upgrading will be group into a only PR by dependency.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-161

## How Do I QA This
When we enable the renovatebot we should see only PRs for composer dependencies.

