### PR TITLE
FCBHDBP-166 v2 backward compatibility - text verse with verse start should return one verse

### DIFF
--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -60,8 +60,12 @@ class TextControllerV2 extends APIController
         $fileset_id  = checkParam('dam_id|fileset_id', true, $bible_url_param);
         $book_id     = checkParam('book_id', false, $book_url_param);
         $chapter     = checkParam('chapter_id', false, $chapter_url_param);
-        $verse_start = checkParam('verse_start') ?? 1;
-        $verse_end   = checkParam('verse_end') ?? $verse_start;
+        $verse_start = checkParam('verse_start');
+        $verse_end   = checkParam('verse_end');
+
+        if (!empty($verse_start) && empty($verse_end)) {
+            $verse_end = $verse_start;
+        }
 
         $book = Book::where('id', $book_id)->orWhere('id_osis', $book_id)->first();
 


### PR DESCRIPTION
## v2 backward compatibility - text verse with verse start should return one verse

# Description
It has updated the flow to pull the verses. For now, If the chapter, verse start and verse end are not provided it will return all verses in  all chapters. If the chapter is provided but the verse start and verse end are not provided it will return all verses for the given chapter. It the chapter and verse start are provided and the verse end does not, it will only return one chapter equals to verse start.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-166

## How Do I QA This
Relevant Postman tests

- v2_backward_compatibility / Priority Group 2 / text_verse (book)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-7332601f-3beb-4a18-a2ca-ea0d9f7f6cfe

- v2_backward_compatibility / Priority Group 2 / text_verse (book/chapter)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-843e8633-85bf-4c2f-b98f-5d9115da634f

- Active Development / v2_backward_compatibility / text_verse (with verse_start should return one verse)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1459d5d9-a970-4bc8-9dd6-d1af9007e75d

