### PR TITLE
FCBHDBP-164 implement mapping between DBP API keys and Cloudfront access

### DIFF
--- a/app/Console/Commands/S3LogBackup.php
+++ b/app/Console/Commands/S3LogBackup.php
@@ -118,4 +118,9 @@ class S3LogBackup extends Command
             $this->log_string = implode(':::', array_merge($log_array, $geo_array));
         }
     }
+
+    protected function getKey()
+    {
+        return false;
+    }
 }

--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -368,4 +368,14 @@ class APIController extends Controller
 
         return rtrim($output, $newline);
     }
+
+    /**
+     * Get the key value
+     *
+     * @return string $key
+     */
+    protected function getKey()
+    {
+        return $this->key;
+    }
 }

--- a/app/Http/Controllers/Bible/AudioControllerV2.php
+++ b/app/Http/Controllers/Bible/AudioControllerV2.php
@@ -104,7 +104,12 @@ class AudioControllerV2 extends APIController
         // Transaction id to be passed to signedUrl
         $transaction_id = random_int(0, 10000000);
         foreach ($audioChapters as $key => $audio_chapter) {
-            $audioChapters[$key]->file_name = $this->signedUrl('audio/' . $audio_chapter->bible->first()->id . '/' . $fileset_id . '/' . $audio_chapter->file_name, 'dbp-prod', $transaction_id);
+            $audioChapters[$key]->file_name = $this->signedUrl(
+                'audio/' . $audio_chapter->bible->first()->id . '/' . $fileset_id . '/' . $audio_chapter->file_name,
+                'dbp-prod',
+                $transaction_id,
+                $key
+            );
         }
 
         return $this->reply(fractal($audioChapters, new AudioTransformer(), $this->serializer), [], $transaction_id);

--- a/app/Jobs/SendApiLogs.php
+++ b/app/Jobs/SendApiLogs.php
@@ -115,4 +115,9 @@ class SendApiLogs implements ShouldQueue
             \Log::error('unable to push logs to s3');
         }
     }
+
+    protected function getKey()
+    {
+        return false;
+    }
 }

--- a/app/Logs/CloudfrontApiKeyFormatter.php
+++ b/app/Logs/CloudfrontApiKeyFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Logs;
+
+use Monolog\Formatter\LineFormatter;
+
+class CloudfrontApiKeyFormatter
+{
+    /**
+     * Customize the given logger instance.
+     *
+     * @param  \Illuminate\Log\Logger  $logger
+     * @return void
+     */
+    public function __invoke($logger)
+    {
+        $format = "%datetime% %message% %context% %extra%\n";
+        $date_format = 'Y-m-d H:m:s';
+
+        foreach ($logger->getHandlers() as $handler) {
+            $handler->setFormatter(new LineFormatter(
+                $format,
+                $date_format,
+                false,
+                true
+            ));
+        }
+    }
+}

--- a/app/Logs/EmptyLineFormatter.php
+++ b/app/Logs/EmptyLineFormatter.php
@@ -12,6 +12,7 @@
 namespace App\Logs;
 
 use Monolog\Formatter\NormalizerFormatter;
+use Throwable;
 
 /**
  * Formats incoming records into a one-line string
@@ -86,7 +87,7 @@ class EmptyLineFormatter extends NormalizerFormatter
         return $this->replaceNewlines($this->convertToString($value));
     }
 
-    protected function normalizeException($e)
+    protected function normalizeException(Throwable $e, int $depth = 0)
     {
         if (!$e instanceof \Exception && !$e instanceof \Throwable) {
             throw new \InvalidArgumentException('Exception/Throwable expected, got '.gettype($e).' / '.get_class($e));

--- a/config/logging.php
+++ b/config/logging.php
@@ -82,6 +82,12 @@ return [
             'driver' => 'errorlog',
             'level'  => 'debug',
         ],
+
+        'cloudfront_api_key' => [
+            'driver' => 'single',
+            'tap'    => [App\Logs\CloudfrontApiKeyFormatter::class],
+            'path'   => storage_path('logs/cloudfront_api_key.log'),
+        ],
     ],
 
 ];


### PR DESCRIPTION
## implement mapping between DBP API keys and Cloudfront access

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
it has created a feature to store into new file log a relationship between a `Cloudfront signed url` and the `API key`. Then, it has created a new log channel to handle the entries into the new log file. The new log file is called: `cloudfront_api_key.log` and it is located into the floder `storate/logs`.

The entries stored into the `cloudfront_api_key.log` has the pattern `{time} {key} {signature}` e.g.

```log
2021-09-16 17:09:28 API_KEY_XXXX-YYYY SIGNATURE_HhiS9lUT1ohR11
```

`Signature` value is extract from the query parameters from signed URL, if the Signature doesn't exist, the entire signed URL will be stored. The `Key` is the API Key that user uses to do the request.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-164

## How Do I QA This
1. Execute e.g. /library/volume
2. You should see into the file: ROOT_PATH/storage/logs/cloudfront_api_key.log the new entries with the pattern:` {time} {key} {signature}`

