### PR TITLE
FCBHDBP-174 Hardening - Example Workflow endpoints should return in less than one second (for non-cached requests)

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -108,12 +108,18 @@ class BiblesController extends APIController
             $media_types = BibleFilesetType::select('set_type_code')->get();
             $media_type_exists = $media_types->where('set_type_code', $media);
             if ($media_type_exists->isEmpty()) {
-                return $this->setStatusCode(404)->replyWithError('media type not found. must be one of ' . $media_types->pluck('set_type_code')->implode(','));
+                return $this
+                    ->setStatusCode(404)
+                    ->replyWithError(
+                        'media type not found. must be one of ' . $media_types->pluck('set_type_code')->implode(',')
+                    );
             }
         }
 
         $access_control = $this->accessControl($this->key);
-        $organization = $organization_id ? Organization::where('id', $organization_id)->orWhere('slug', $organization_id)->first() : null;
+        $organization = $organization_id
+            ? Organization::where('id', $organization_id)->orWhere('slug', $organization_id)->first()
+            : null;
         $cache_params = [
             $language_code,
             $organization,
@@ -196,9 +202,7 @@ class BiblesController extends APIController
                 BibleTransformer::class,
                 new DataArraySerializer()
             );
-            $result =  $bibles_return->paginateWith(new IlluminatePaginatorAdapter($bibles));
-            // Log::error('Size of the response body in Bytes:' . strlen(json_encode($result)));
-            return $result;
+            return $bibles_return->paginateWith(new IlluminatePaginatorAdapter($bibles));
         });
 
         return $this->reply($bibles);


### PR DESCRIPTION
## Hardening - Example Workflow endpoints should return in less than one second (for non-cached requests)

# Description
It has improved the endpoint to pull the bibles with the `filesets` relationship. It has update the query to pull the `filesets` and it has used the operator EXISTS to improve the performance.

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
We should execute the next endpoint just after when the cache has been cleaned.

- List All Bibles/Filesets in a language
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1bd358a1-24c0-4a7a-b1dd-0a835862b2f9

- List All Bibles/Filesets in a language that have Dramatized Audio
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-394cf2be-8e03-466a-a8b4-fab1a88960c2

- List All Bibles/Filesets in a language that have Streaming
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-7684183f-13bf-49c4-9ba3-22cf478afe9c

- List All Bibles/Filesets in a language that have Gospel Films
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f2f5a018-cbcf-4804-b90f-ea6d51edab68

## Screenshots
![Screenshot from 2021-09-20 19-23-12](https://user-images.githubusercontent.com/73488660/134094170-80288bcb-c990-4528-9e45-6aa1df4c2c52.png)


