### PR TITLE
FCBHDBP-181 500 error in v2 backward compat - volumelanguagefamily with media=audio

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -369,17 +369,11 @@ class LanguageControllerV2 extends APIController
             $languages = Language::with('bibles')->with('dialects')
                 ->includeAutonymTranslation()
                 ->includeCurrentTranslation()
-                ->whereHas('filesets', function ($query) use ($hashes, $organization_id, $media) {
-                    $query->whereIn('hash_id', $hashes);
-                    if ($organization_id) {
-                        $query->whereHas('copyright', function ($query) use ($organization_id) {
-                            $query->where('organization_id', $organization_id);
-                        });
-                    }
-                    if ($media) {
-                        $query->where('set_type_code', 'LIKE', $media . '%');
-                    }
-                })
+                ->withRequiredFilesets([
+                    'hashes'          => $hashes,
+                    'media'           => $media,
+                    'organization_id' => $organization_id
+                ])
                 ->with(['dialects.childLanguage' => function ($query) {
                     $query->select(['id', 'iso']);
                 }])

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -371,7 +371,7 @@ class Language extends Model
     }
 
     public function scopeIncludeExtraLanguages($query, $access_control_identifiers)
-    {  
+    {
         return $query->whereRaw('languages.id in (' . $access_control_identifiers . ')');
     }
 
@@ -410,11 +410,31 @@ class Language extends Model
     }
 
     public function scopeFilterableByNameOrAutonym($query, $name)
-    {   
+    {
         $formatted_name = str_replace(' ', '', $name);
         return $query->when($name, function ($query) use ($formatted_name) {
             $query->where('languages.name', 'like', $formatted_name.'%')
                 ->orWhere('autonym.name', 'like', $formatted_name.'%');
+        });
+    }
+
+    public function scopeWithRequiredFilesets($query, $type_filters)
+    {
+        $hashes = $type_filters['hashes'];
+        $organization_id = $type_filters['organization_id'];
+        $media = $type_filters['media'];
+
+        return $query->whereHas('filesets', function ($query) use ($hashes, $organization_id, $media) {
+            if ($organization_id) {
+                $query->whereHas('copyright', function ($query) use ($organization_id) {
+                    $query->where('organization_id', $organization_id);
+                });
+            }
+            if ($media) {
+                $query->join('bible_filesets', 'bible_filesets.hash_id', 'bible_fileset_connections.hash_id');
+                $query->where('bible_filesets.set_type_code', 'LIKE', $media . '%');
+            }
+            $query->whereIn('bible_fileset_connections.hash_id', $hashes);
         });
     }
     


### PR DESCRIPTION
## 500 error in v2 backward compat - volumelanguagefamily with media=audio

# Description
it has fixed the `library/volumelanguagefamily` endpoint. It has added the join related with `bible_filesets` because Language entity has only registered the relation with `bible_fileset_connections` entity.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-181

## How Do I QA This
You should execute the next endpoint it should return error:
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f527e2af-aee7-47e5-93ae-e626f895b305
