### PR TITLE
FCBHDBP-183 error on v2 backward compat - v=2.12.1

### DIFF
--- a/app/Http/Middleware/APIVersion.php
+++ b/app/Http/Middleware/APIVersion.php
@@ -35,7 +35,15 @@ class APIVersion
             return $next($request);
         }
         
-        if ($routeV != $requestV) {     
+        // for the version 2, it will strip everything after the first digit,
+        // so that a request submitted with v=2.12.1 will be processed as v=2
+        $request_v_array = explode('.', $requestV);
+
+        if (\sizeof($request_v_array) > 1 && (int) $request_v_array[0] === 2) {
+            $requestV = $request_v_array[0];
+        }
+
+        if ($routeV != $requestV) {
             $route_name = $requestV === '3' && $routeV === '2' ? $route : null;
 
             if (!\Route::has($route_name)) {


### PR DESCRIPTION
## error on v2 backward compat - v=2.12.1

# Description
for the version 2, if the version query parameter has more than 1 digit it will strip everything after the first digit.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-183

## How Do I QA This
You can execute the next endpoint and you should not see any error:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a9ea88da-b047-4c66-85f8-990ec3677a02

