### PR TITLE
FCBHDBP it has added the FULLTEXT index bibles languages and countries

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -237,7 +237,7 @@ class BiblesController extends APIController
         $page           = checkParam('page') ?? 1;
         $formatted_search = str_replace(' ', '', $search_text);
         if ($formatted_search === '' || !$formatted_search) {
-          return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
+            return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
         }
 
         // instead of returning hashes, accessControl will return bible ids associated with the hashes
@@ -248,7 +248,10 @@ class BiblesController extends APIController
             ->leftJoin('bible_translations as ver_title', function ($join) {
                 $join->on('ver_title.bible_id', 'bibles.id')->where('ver_title.vernacular', 1);
             })
-            ->where('ver_title.name', 'LIKE' , '%'.$formatted_search.'%')
+            ->whereRaw(
+                'match (ver_title.name) against (? IN BOOLEAN MODE)',
+                ['*'.$formatted_search.'*']
+            )
             ->paginate($limit);
 
             $bibles_return = fractal(

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -206,6 +206,7 @@ class LanguagesController extends APIController
             $languages = Language::includeCurrentTranslation()
                 ->includeAutonymTranslation()
                 ->includeExtraLanguages(arrayToCommaSeparatedValues($access_control->identifiers), false)
+                ->includeExtraLanguageTranslations(true)
                 ->filterableByNameOrAutonym($formatted_search)
                 ->select([
                     'languages.id',

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -410,11 +410,11 @@ class Language extends Model
     }
 
     public function scopeFilterableByNameOrAutonym($query, $name)
-    {   
+    {
         $formatted_name = str_replace(' ', '', $name);
         return $query->when($name, function ($query) use ($formatted_name) {
-            $query->where('languages.name', 'like', $formatted_name.'%')
-                ->orWhere('autonym.name', 'like', $formatted_name.'%');
+            $query->whereRaw('match (languages.name) against (? IN BOOLEAN MODE)', ['*'.$formatted_name.'*']);
+            $query->orWhereRaw('match (autonym.name) against (? IN BOOLEAN MODE)', ['*'.$formatted_name.'*']);
         });
     }
     

--- a/database/migrations/2021_09_22_173446_add_fulltext_index_countries_languages_bibles.php
+++ b/database/migrations/2021_09_22_173446_add_fulltext_index_countries_languages_bibles.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddFulltextIndexCountriesLanguagesBibles extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::connection('dbp')
+            ->statement('ALTER TABLE countries ADD FULLTEXT ft_index_countries_name_iso_a3(name, iso_a3)');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE languages ADD FULLTEXT ft_index_languages_name(name)');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE language_translations ADD FULLTEXT ft_index_language_translations_name(name)');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE bible_translations ADD FULLTEXT ft_index_bible_translations_name(name)');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::connection('dbp')
+            ->statement('ALTER TABLE countries DROP INDEX ft_index_countries_name_iso_a3');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE languages DROP INDEX ft_index_languages_name');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE language_translations DROP INDEX ft_index_language_translations_name');
+        DB::connection('dbp')
+            ->statement('ALTER TABLE bible_translations DROP INDEX ft_index_bible_translations_name');
+    }
+}


### PR DESCRIPTION
##  it has added the FULLTEXT index bibles languages and countries

# Description
it has added the `FULLTEXT` index for the entities: languages, countries, language_translations and bible_translations. The goal is to expand the searching related with the above entities.

## Note
We must run the migration before to call the endpoints:

```bash
php artisan migrate --path=/database/migrations/2021_09_22_173446_add_fulltext_index_countries_languages_bibles.php
```

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
- Contries: you can test with `faso` word. It should return a record about Burkina Faso country
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1c473cb7-c83a-425c-81ee-fb53045ca27f

- Bibles: It should continue working correclty.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-46fe99f1-5201-4e76-bfff-408f56309b84

- Languages: you can test with `hind` word. It should return 3 records about `hindi` Languages
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9d2ff0d8-2582-4945-a408-1755c0a09e94
## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
