### PR TITLE
FCBHDBP-187 hardening: optimize slow query bible_file_timestamps

### DIFF
--- a/app/Models/Bible/BibleFile.php
+++ b/app/Models/Bible/BibleFile.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Bible;
 
+use DB;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Language\Language;
 
@@ -222,5 +223,21 @@ class BibleFile extends Model
     public function streamBandwidth()
     {
         return $this->hasMany(StreamBandwidth::class);
+    }
+
+    public function scopeJoinBibleFileTimestamps($query)
+    {
+        return $query->join(
+            DB::raw(
+                '(  SELECT distint_timestamps.bible_file_id
+                    FROM (  SELECT DISTINCT bible_file_timestamps.bible_file_id
+                            FROM bible_file_timestamps ) AS distint_timestamps
+                    GROUP BY distint_timestamps.bible_file_id
+                ) AS timestamps_counts'
+            ),
+            function ($join) {
+                $join->on('timestamps_counts.bible_file_id', '=', 'bible_files.id');
+            }
+        );
     }
 }


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
It has improved the query to pull the bible files that have a `bible_file_timestamps` record attached. The query to fetch the has_id from bible_files entities has been refactored.

The next query was taking into a local environment around 3 seconds:

```sql
select distinct `hash_id`
from `bible_files` 
where exists (
    select * from `bible_file_timestamps` where `bible_files`.`id` = `bible_file_timestamps`.`bible_file_id`
);
```

The above sql query was replaced by the next query and it takes around 600ms to fetch the hash_ids bible_files entities into a local environment.

```sql
SELECT `bible_files`.`hash_id` FROM `bible_files`
INNER JOIN (
    SELECT distint_timestamps.bible_file_id
    FROM (
        SELECT DISTINCT bible_file_timestamps.bible_file_id
        FROM bible_file_timestamps
    ) AS distint_timestamps
    GROUP BY distint_timestamps.bible_file_id
) AS timestamps_counts ON `timestamps_counts`.`bible_file_id` = `bible_files`.`id`
GROUP BY `bible_files`.`hash_id`
```

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-187

## How Do I QA This
- Execute the `/api/timestamps` endpoint and it should return the same results but less time (around 600ms)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6f3c5408-d3af-4d52-a3a0-c9e0e1babd80
