### PR TITLE
FCBHDBP-18 modify search to return audio timing information when available

### DIFF
--- a/app/Models/Bible/BibleVerse.php
+++ b/app/Models/Bible/BibleVerse.php
@@ -92,4 +92,19 @@ class BibleVerse extends Model
             $join->on('bible_verses.book_id', 'bible_books.book_id')->where('bible_books.bible_id', $bible->id);
         });
     }
+
+    public function scopeWithBibleFileTimestamps($query, $audio_fileset_hash_ids)
+    {
+        return $query->when($audio_fileset_hash_ids, function ($query) use ($audio_fileset_hash_ids) {
+            $query->leftJoin('bible_files', function ($join) use ($audio_fileset_hash_ids) {
+                $join->on('bible_files.book_id', 'bible_verses.book_id')
+                    ->whereRaw('bible_files.chapter_start = bible_verses.chapter')
+                    ->whereIn('bible_files.hash_id', $audio_fileset_hash_ids);
+            });
+            $query->leftJoin('bible_file_timestamps', function ($join) {
+                $join->on('bible_file_timestamps.bible_file_id', 'bible_files.id')
+                    ->whereRaw('bible_verses.verse_start = bible_file_timestamps.verse_start');
+            });
+        });
+    }
 }

--- a/app/Transformers/TextTransformer.php
+++ b/app/Transformers/TextTransformer.php
@@ -164,7 +164,8 @@ class TextTransformer extends BaseTransformer
             'verse_start_alt' => (string) $text->verse_start_vernacular,
             'verse_end' => (int) $text->verse_end,
             'verse_end_alt' => (string) $text->verse_end_vernacular,
-            'verse_text' => (string) $text->verse_text
+            'verse_text' => (string) $text->verse_text,
+            'timestamp' => $text->timestamp ?? ''
         ];
     }
 }


### PR DESCRIPTION
## Modify search to return audio timing information when available

# Description
Added the option to attach the bible_file_timestamps for each bible verses. It has added a new parameter: "include audio timings" and it is by default to false. The new parameter will indicate it the verses should have the available timestamp value.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-18

## How Do I QA This
- Execute the next endpoint and you should see the new timestamp value for each verse available.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-505f93c5-4abf-4acb-9d50-c8992d135590


