### PR TITLE
FCBHDBP-197 ARBVDV - 500 error

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -1037,9 +1037,13 @@ class BiblesController extends APIController
             $zip->addFromString('contents.json', json_encode($result));
 
             foreach ($result->filesets->downloads as $download) {
-                $client = new Client();
-                $mp3 = $client->get($download->path);
-                $zip->addFromString($download->file_name, $mp3->getBody());
+                try {
+                    $client = new Client();
+                    $mp3 = $client->get($download->path);
+                    $zip->addFromString($download->file_name, $mp3->getBody());
+                } catch (\Throwable $th) {
+                    \Log::channel('errorlog')->error($th->getMessage());
+                }
             }
             unset($result->filesets->downloads);
             $zip->close();


### PR DESCRIPTION
## ARBVDV - 500 error

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
Avoid that dbp crashes when it tries to download the content from `content.cdn.dbp` and the content does not exist or cdn returns access denied.

The current case is related with the bible ARBVDV and the bible_filesets attached. I saw that on my local database I have two filesets with set_size_code `OT`:

```sql
ARZVDVO1DA	42510b5d7dfe dbp-prod audio	        OT	0	2018-02-13 10:27:06	2018-09-07 17:39:24	ARBVDV
ARZVDVO2DA	6db7b153c52e dbp-prod audio_drama	OT	0	2018-02-13 10:27:03	2018-09-07 17:39:24	ARBVDV
```
So, dbp tries to download the ARZVDVO1DA audios using the next path but it path is not correct.
- `https://content.cdn.dbp-prod.dbp4.org/audio/ARBVDV/ARZVDVO1DA`


## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
You should execute the next postman test - VDV CDN - exact request that causes 500 error:
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-45d17673-da9f-4ad0-a5cb-283737650699

