### PR TITLE
FCBHDBP-204 Gideons Bibles are seen in the List

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -173,7 +173,7 @@ class LanguageControllerV2 extends APIController
                         }
                     })
                     ->whereHas('language', function ($query) use ($key) {
-                        $query->isContentAvailable($key);
+                        $query->isContentAvailable($key, true);
                     })
                     ->whereHas('country', function ($query) use ($country_code) {
                         $query->when($country_code, function ($subquery) use ($country_code) {

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -246,10 +246,13 @@ class BibleFileset extends Model
             'EXISTS (select 1
                     from ' . $dbp_users . '.user_keys uk
                     join ' . $dbp_users . '.access_group_api_keys agak on agak.key_id = uk.id
+                    join ' . $dbp_prod . '.access_groups acg on agak.access_group_id = acg.id
                     join ' . $dbp_prod . '.access_group_filesets agf on agf.access_group_id = agak.access_group_id
-                    where uk.key = ? and agf.hash_id = bible_filesets.hash_id
+                    WHERE uk.key = ?
+                    AND acg.name != ?
+                    AND agf.hash_id = bible_filesets.hash_id
             )',
-            [$key]
+            [$key, 'RESTRICTED']
         );
     }
 }


### PR DESCRIPTION

## Gideons Bibles are seen in the List

# Description
It has added the filter to avoid to get the bibles from gideons. Currently, the access group with id 7 and name: RESTRICTED are not being filter from the the method that validate if the bible has one or more `bible_fileset` attached to the user api key.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-204

## How Do I QA This
I have create the next postman endpoint to validate the fix. e.g. The English Standard Version (Gideons) bible should not be pulled.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-88c9b3e6-a965-4e65-b8a6-ebc5dff21ae0

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
