### PR TITLE
FCBHDBP-199 Removed the hook to generate a new APP_KEY when the deplo…

### DIFF
--- a/.platform/confighooks/predeploy/artisan.sh
+++ b/.platform/confighooks/predeploy/artisan.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-php artisan key:generate 

--- a/.platform/hooks/predeploy/artisan.sh
+++ b/.platform/hooks/predeploy/artisan.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-php artisan key:generate 


### PR DESCRIPTION
## The stored notes is not being returned from dev environment

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
Removed the hook to generate a new APP_KEY when the deploy process is done.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-199

## How Do I QA This
The notes created before 2021-09-17 should be pulled.
