### PR TITLE
FCBHDBP-199 Hotfix Removed the hook to generate a new APP_KEY deploy process

### DIFF
--- a/.platform/confighooks/predeploy/artisan.sh
+++ b/.platform/confighooks/predeploy/artisan.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-php artisan key:generate 

--- a/.platform/hooks/predeploy/artisan.sh
+++ b/.platform/hooks/predeploy/artisan.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-php artisan key:generate 


### PR DESCRIPTION
## The stored notes is not being returned from dev environment

# Description
Hotfix to remove the hook to generate a new APP_KEY when the deploy process is done.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-199

## How Do I QA This
E.g. use the next endpoint to pull the notes for the user id 278. The notes should be pulled.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6ebd415f-3060-422b-8b9a-dcd5ee675028
