### PR TITLE
FCBHDBP-196 It has removed the filter by vernacular=1 from the bible search endpoint

### DIFF
--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -370,7 +370,6 @@ class Bible extends Model
                 'bible_translations as ver_title',
                 function ($join) use ($formatted_search) {
                     $join->on('ver_title.bible_id', '=', 'bibles.id')
-                    ->where('ver_title.vernacular', 1)
                     ->whereRaw(
                         'match (ver_title.name) against (? IN BOOLEAN MODE)',
                         [$formatted_search]


### PR DESCRIPTION
## It has removed the filter by vernacular=1 from the bible search endpoint

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
It has removed the filter by vernacular=1 from the bible search endpoint. For now on, it will search in all bible records.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-196

## How Do I QA This

Execute the next postman endpoints:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-610cc1be-f389-47ab-8ad2-48fd978e1817

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b80a2569-5bcb-455d-8731-a53b1dd18b06
