### PR TITLE
FCBHDBP-203 Evaluate whether to remove fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,10 +49,11 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "3.6.2",
         "barryvdh/laravel-ide-helper": "2.10.0",
+        "fakerphp/faker": "^1.16",
         "filp/whoops": "2.14.4",
         "friendsofphp/php-cs-fixer": "3.2.1",
-        "fzaninotto/faker": "1.5.0",
         "itsgoingd/clockwork": "5.1.0",
+        "laravel/legacy-factories": "^1.1",
         "mockery/mockery": "1.4.4",
         "nunomaduro/collision": "5.10.0",
         "phpunit/phpunit": "9.5.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5a20c5fab2774d4778140b512129dbc",
+    "content-hash": "ccb174f3c7194b5a11ef3deee92d2692",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -10438,6 +10438,71 @@
             "time": "2020-10-16T08:27:54+00:00"
         },
         {
+            "name": "fakerphp/faker",
+            "version": "v1.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "271d384d216e5e5c468a6b28feedf95d49f83b35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/271d384d216e5e5c468a6b28feedf95d49f83b35",
+                "reference": "271d384d216e5e5c468a6b28feedf95d49f83b35",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-intl": "*",
+                "symfony/phpunit-bridge": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.16-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.16.0"
+            },
+            "time": "2021-09-06T14:53:37+00:00"
+        },
+        {
             "name": "filp/whoops",
             "version": "2.14.4",
             "source": {
@@ -10599,63 +10664,6 @@
             "time": "2021-10-05T08:12:17+00:00"
         },
         {
-            "name": "fzaninotto/faker",
-            "version": "v1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d0190b156bcca848d401fb80f31f504f37141c8d",
-                "reference": "d0190b156bcca848d401fb80f31f504f37141c8d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
-            },
-            "suggest": {
-                "ext-intl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Faker\\": "src/Faker/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "François Zaninotto"
-                }
-            ],
-            "description": "Faker is a PHP library that generates fake data for you.",
-            "keywords": [
-                "data",
-                "faker",
-                "fixtures"
-            ],
-            "support": {
-                "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/master"
-            },
-            "abandoned": true,
-            "time": "2015-05-29T06:29:14+00:00"
-        },
-        {
             "name": "itsgoingd/clockwork",
             "version": "v5.1.0",
             "source": {
@@ -10793,6 +10801,62 @@
                 "source": "https://github.com/justinrainbow/json-schema/tree/5.2.11"
             },
             "time": "2021-07-22T09:24:00+00:00"
+        },
+        {
+            "name": "laravel/legacy-factories",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/legacy-factories.git",
+                "reference": "5e3fe2fd5fda64e20ea5c74c831a7346294e902a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/legacy-factories/zipball/5e3fe2fd5fda64e20ea5c74c831a7346294e902a",
+                "reference": "5e3fe2fd5fda64e20ea5c74c831a7346294e902a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/macroable": "^8.0",
+                "php": "^7.3|^8.0",
+                "symfony/finder": "^3.4|^4.0|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Illuminate\\Database\\Eloquent\\LegacyFactoryServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Illuminate\\Database\\Eloquent\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The legacy version of the Laravel Eloquent factories.",
+            "homepage": "http://laravel.com",
+            "support": {
+                "issues": "https://github.com/laravel/framework/issues",
+                "source": "https://github.com/laravel/framework"
+            },
+            "time": "2020-10-27T14:25:32+00:00"
         },
         {
             "name": "maximebf/debugbar",

--- a/database/seeds/ProjectsSeeder.php
+++ b/database/seeds/ProjectsSeeder.php
@@ -1,4 +1,5 @@
 <?php
+namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 
@@ -17,8 +18,9 @@ class ProjectsSeeder extends Seeder
      */
     public function run(Faker $faker)
     {
+        $dbp_users = config('database.connections.dbp_users.database');
         Project::create([
-            'id'              => unique_random('projects', 'id'),
+            'id'              => unique_random($dbp_users.'.projects', 'id'),
             'name'            => 'Digital Bible Platform',
             'url_avatar'      => $faker->url,
             'url_avatar_icon' => $faker->url,
@@ -30,7 +32,7 @@ class ProjectsSeeder extends Seeder
         $project_count = random_int(3, 5);
         while ($project_count > 0) {
             Project::create([
-                'id'              => $project_count,
+                'id'              => unique_random($dbp_users.'.projects', 'id'),
                 'name'            => $faker->company,
                 'url_avatar'      => $faker->url,
                 'url_avatar_icon' => $faker->url,
@@ -40,19 +42,21 @@ class ProjectsSeeder extends Seeder
             ]);
 
             ProjectOauthProvider::create([
+                'id'            => unique_random($dbp_users.'.project_oauth_providers', 'id'),
                 'name'          => 'facebook',
                 'project_id'    => $project_count,
-                'client_id'     => unique_random('project_oauth_providers', 'client_id'),
-                'client_secret' => unique_random('project_oauth_providers', 'client_secret'),
+                'client_id'     => unique_random($dbp_users.'.project_oauth_providers', 'client_id'),
+                'client_secret' => unique_random($dbp_users.'.project_oauth_providers', 'client_secret'),
                 'callback_url'  => 'https://dbp4.org/login/callback/facebook',
                 'description'   => (string) $faker->paragraph(),
             ]);
 
             ProjectOauthProvider::create([
+                'id'            => unique_random($dbp_users.'.project_oauth_providers', 'id'),
                 'name'          => 'google',
                 'project_id'    => $project_count,
-                'client_id'     => unique_random('project_oauth_providers', 'client_id'),
-                'client_secret' => unique_random('project_oauth_providers', 'client_secret'),
+                'client_id'     => unique_random($dbp_users.'.project_oauth_providers', 'client_id'),
+                'client_secret' => unique_random($dbp_users.'.project_oauth_providers', 'client_secret'),
                 'callback_url'  => 'https://dbp4.org/login/callback/google',
                 'description'   => (string) $faker->paragraph(),
             ]);


### PR DESCRIPTION
## Evaluate whether to remove fzaninotto/faker

# Description
It has replaced the `fzaninotto/faker` package by the new package: fakerphp/faker. Fixed the ProjectsSeeder file.
The other package: `laravel/legacy-factories` is to support the legacy factories that we have into the project and can execute the unit test.

## NOTE.

We need to create other ticket to update all seeder and unit test files according to the new recommendations. For example each seeder should have a namespace.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-203

## How Do I QA This
From the local environment you can execute the next seeder to test that the new Faker package is working:

```bash
php artisan db:seed --class=ProjectsSeeder
```