### PR TITLE
FCBHDBP-209 for bible.is and gideon, return bibles in priority order, regardless of backward compat mode

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -100,8 +100,12 @@ class BiblesController extends APIController
         $order_by = 'bibles.id';
         if (shouldUseBibleisBackwardCompat($this->key)) {
             $tag_exclude = 'opus';
+        }
+
+        if (isBibleisOrGideon($this->key)) {
             $order_by = 'bibles.priority DESC';
         }
+
         $order_cache_key = str_replace(['bibles.', ' '], '', $order_by);
 
         if ($media) {


### PR DESCRIPTION
for bible.is and gideon, return bibles in priority order, regardless of backward compat mode

# Description
It will return the bibles but they will be sorted by priority (only for bibleis and gideons), regardless of whether the backward compatibility mode is active.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-209

## How Do I QA This
The tests should passed for the next postman endpoint:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-88f745ac-39bd-4962-adea-4a3439579aa8


