### PR TITLE
FCBHDBP-212 value retrieved from cache is empty for bible

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -291,11 +291,12 @@ class BiblesController extends APIController
         if ($this->v === 2 || $this->v === 3) {
             $id = substr($id, 0, 6);
         }
+        $key_error_404 = 'api.bibles_errors_404';
         $key = $this->key;
-
         $bible = Bible::whereId($id)->isContentAvailable($key)->count();
+
         if (!$bible) {
-            return $this->setStatusCode(404)->replyWithError(trans('api.bibles_errors_404', ['bible_id' => $id]));
+            return $this->setStatusCode(404)->replyWithError(trans($key_error_404, ['bible_id' => $id]));
         }
 
         $cache_params = [$id, $key];
@@ -309,7 +310,7 @@ class BiblesController extends APIController
         });
 
         if (!$bible || !sizeof($bible->filesets)) {
-            return $this->setStatusCode(404)->replyWithError(trans('api.bibles_errors_404', ['bible_id' => $id]));
+            return $this->setStatusCode(404)->replyWithError(trans($key_error_404, ['bible_id' => $id]));
         }
 
         return $this->reply(fractal($bible, new BibleTransformer(), $this->serializer));


### PR DESCRIPTION
# value retrieved from cache is empty for bible

# Description
the bible show endpoint has been updated to validate if the bible exist before to try to put the result in cache.

I was trying to set the response for this endpoint to false if the query responds null but I think that is not necessary to store a false value and the query to know if the bible exists takes max 2.5ms on my local environment.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-212

## How Do I QA This
Execute the next URL and validate that it only execute the query to know if a bible exists when the bible does not exist in the database.
http://localhost:8080/api/bibles/EN1WEB?key=52e62d4c-f7c8-4a8b-9008-8634d0fbddb0&v=4&asset_id=dbp-prod,dbp-vid

