### PR TITLE
FCBHDBP-214 v2_compat: don't modify the book_id in Audio Transformer

### DIFF
--- a/app/Transformers/AudioTransformer.php
+++ b/app/Transformers/AudioTransformer.php
@@ -62,7 +62,7 @@ class AudioTransformer extends BaseTransformer
                  */
             case 'v2_audio_path':
                 return [
-                    'book_id'    => $audio->book ? ucfirst(strtolower($audio->book->id_osis)) : $audio->book_id,
+                    'book_id'    => $audio->book ? $audio->book->id_osis : $audio->book_id,
                     'chapter_id' => (string) $audio->chapter_start,
                     'path'       => preg_replace("/https:\/\/.*?\/.*?\//", '', $audio->file_name)
                 ];


### PR DESCRIPTION
# v2_compat: don't modify the book_id in Audio Transformer

# Description
It has removed from AudioTransformer the feature to convert to lower and then Uppers the first character for the v2_audio_path endpoint.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-214

## How Do I QA This
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1acd4220-1a45-412d-bd4a-65bd1538f426
