### PR TITLE
FCBHDBP-213 v2_compat: library/metadata should not require a damid

### DIFF
--- a/app/Transformers/V2/LibraryCatalog/LibraryMetadataTransformer.php
+++ b/app/Transformers/V2/LibraryCatalog/LibraryMetadataTransformer.php
@@ -54,34 +54,57 @@ class LibraryMetadataTransformer extends TransformerAbstract
      * @return array
      */
     public function transform($bible_fileset)
-    {   
-        $copyright = optional($bible_fileset->copyright)->copyright;
+    {
+        $copyright = $bible_fileset->copyright;
         $mark = $this->formatCopyrightMark($copyright);
 
         $output = [
             'dam_id'         => isset($bible_fileset->dam_id) ? $bible_fileset->dam_id : $bible_fileset->id,
             'mark'           => $mark,
-            'volume_summary' => optional($bible_fileset->copyright)->copyright_description,
+            'volume_summary' => $bible_fileset->copyright_description,
             'font_copyright' => null,
             'font_url'       => null
         ];
 
-        $organization = optional(optional($bible_fileset->copyright)->organizations)->first();
-        if ($organization) {
+        if ($bible_fileset->organization) {
             $output['organization'][] = [
-                'organization_id'       => (string) $organization->id,
-                'organization'          => (string) optional($organization->translations->where('vernacular', 1)->first())->name,
-                'organization_english'  => optional($organization->translations->where('language_id', $GLOBALS['i18n_id'])->first())->name ?? $organization->slug,
-                'organization_role'     => optional($bible_fileset->copyright)->role->roleTitle->name,
-                'organization_url'      => $organization->url_website,
-                'organization_donation' => $organization->url_donate,
-                'organization_address'  => $organization->address,
-                'organization_address2' => $organization->address2,
-                'organization_city'     => $organization->city,
-                'organization_state'    => $organization->state,
-                'organization_country'  => $organization->country,
-                'organization_zip'      => $organization->zip,
-                'organization_phone'    => $organization->phone,
+                'organization_id'       => (string) $bible_fileset->organization->id,
+                'organization'          => isset($bible_fileset->organization->name)
+                    ? $bible_fileset->organization->name
+                    : '',
+                'organization_english'  => isset($bible_fileset->organization->slug)
+                    ? $bible_fileset->organization->slug
+                    : '',
+                'organization_role'     => isset($bible_fileset->organization->role_name)
+                    ? $bible_fileset->organization->role_name
+                    : '',
+                'organization_url'      => isset($bible_fileset->organization->url_website)
+                    ? $bible_fileset->organization->url_website
+                    : '',
+                'organization_donation' => isset($bible_fileset->organization->url_donate)
+                    ? $bible_fileset->organization->url_donate
+                    : '',
+                'organization_address'  => isset($bible_fileset->organization->address)
+                    ? $bible_fileset->organization->address
+                    : '',
+                'organization_address2' => isset($bible_fileset->organization->address2)
+                    ? $bible_fileset->organization->address2
+                    : '',
+                'organization_city'     => isset($bible_fileset->organization->city)
+                    ? $bible_fileset->organization->city
+                    : '',
+                'organization_state'    => isset($bible_fileset->organization->state)
+                    ? $bible_fileset->organization->state
+                    : '',
+                'organization_country'  => isset($bible_fileset->organization->country)
+                    ? $bible_fileset->organization->country
+                    : '',
+                'organization_zip'      => isset($bible_fileset->organization->zip)
+                    ? $bible_fileset->organization->zip
+                    : '',
+                'organization_phone'    => isset($bible_fileset->organization->phone)
+                    ? $bible_fileset->organization->phone
+                    : '',
             ];
         }
         return $output;
@@ -93,9 +116,9 @@ class LibraryMetadataTransformer extends TransformerAbstract
         $mark_types = ['Audio', 'Text', 'Video'];
         foreach ($mark_types as $type) {
             if (!$mark) {
-                $mark = optional(explode('Audio:', $copyright))[1];
+                $mark = optional(explode($type.':', $copyright))[1];
             }
-        }     
+        }
         return $mark ? $mark : $copyright;
     }
 }


### PR DESCRIPTION
# v2_compat: library/metadata should not require a damid

# Description
The way to fetch the metadata has been changed. It was using the Eager Loading way to fetch the records but when we need to fetch all records the process to index the relationships was taking long time. So, we have change the above and it will do a only query with multiple joins. This new query will have duplicate filesets but we will process to result to keep an unique record by fileset using the hash_id to index the final array.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-213

## How Do I QA This
- Execute the postman endpoint without dam_id
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-bc43548c-73f3-433f-a7f5-20b56accff4e

## Screenshots
### Before, the endpoint was taking around 10mins to respond as you can see in the next screenshot
![screenshot-localhost_8080-2021 10 22-16_59_52](https://user-images.githubusercontent.com/73488660/138529580-26d0679d-23b8-4d05-9567-c0b4f7426d84.png)

### Now, the endpoint is taking around max 2mins to respond (see the next screenshot)
![screenshot-localhost_8080-2021 10 22-17_00_38](https://user-images.githubusercontent.com/73488660/138529658-5c4a71b7-859c-465d-bd9d-83f717514f90.png)
