### PR TITLE
FCBHDBP-215 v2_compat: library/volume should return everything if language_code is not provided

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 
 use App\Models\Language\Language;
 use App\Models\Bible\BibleFileset;
+use App\Models\Organization\Asset;
 
 use App\Transformers\V2\LibraryVolumeTransformer;
 use App\Transformers\V2\LibraryCatalog\LibraryMetadataTransformer;
@@ -449,9 +450,15 @@ class LibraryController extends APIController
         $cache_params = [$dam_id, $media, $language_name, $iso, $updated, $organization, $version_code];
         $filesets = cacheRemember('v2_library_volume', $cache_params, now()->addDay(), function () use ($dam_id, $media, $language_name, $iso, $updated, $organization, $version_code) {
             $language_id = $iso ? optional(Language::where('iso', $iso)->first())->id : null;
-            if (!$language_id && !$dam_id) {
-                return [];
-            }
+
+            $has_nondrama = BibleFileset::where('set_type_code', 'audio')
+                ->select('id')
+                ->where('set_type_code', 'audio')
+                ->whereHas('permissions', function ($query) {
+                    $query->whereHas('access', function ($query) {
+                        $query->where('name', '!=', 'RESTRICTED');
+                    });
+                });
 
             $filesets = BibleFileset::with('meta')->where('set_type_code', '!=', 'text_format')
                 ->where('bible_filesets.id', 'NOT LIKE', '%16')
@@ -490,9 +497,14 @@ class LibraryController extends APIController
                         languages.name as language_name,
                         language_translations.name as autonym,
                         MIN(bible_files_secondary.file_name) as secondary_file_name,
-                        bible_files_secondary.file_type as secondary_file_type'
+                        bible_files_secondary.file_type as secondary_file_type,
+                        bible_filesets_has_dram.id as bible_filesets_has_dram'
                     )
                 )->groupBy(['bible_filesets.hash_id', 'bible_files_secondary.file_type'])
+                ->leftJoinSub($has_nondrama, 'bible_filesets_has_dram', function ($join) {
+                    $join
+                        ->on('bible_filesets_has_dram.id', '=', 'bible_filesets.id');
+                })
                 ->when($updated, function ($query) use ($updated) {
                     $query->where('bible_filesets.updated_at', '>', $updated);
                 })
@@ -508,28 +520,76 @@ class LibraryController extends APIController
                     return $item->english_name;
                 });
 
-            foreach ($filesets as &$fileset) {
-                if ($fileset->secondary_file_type === 'zip') {
-                    $fileset->audio_zip_path = $fileset->id . '/' . $fileset->secondary_file_name;
+            $asset_ids_array = [];
+            foreach ($filesets as $fileset) {
+                $asset_ids_array[$fileset->asset_id] = true;
+            }
+
+            $assets = Asset::whereIn('id', array_keys($asset_ids_array))->get();
+            $assets_by_id = [];
+
+            foreach ($assets as $asset) {
+                $assets_by_id[$asset->id] = $asset;
+            }
+
+            foreach ($filesets as $key => $fileset) {
+                if ($fileset && $fileset->secondary_file_name) {
+                    $filesets[$key]->secondary_file_path = $this->signedUrl(
+                        storagePath(
+                            $fileset->bible_id,
+                            $fileset,
+                            null,
+                            $fileset->secondary_file_name
+                        ),
+                        $fileset->asset_id,
+                        random_int(0, 10000000),
+                        isset($assets_by_id[$fileset->asset_id]) ? $assets_by_id[$fileset->asset_id] : null
+                    );
                 }
             }
 
             return $this->generateV2StyleId($filesets);
         });
 
-        if ($dam_id) {
-            $filesets = $this->filterById($filesets, $dam_id);
-        }
+        $this->getBiblesByFilesetId($filesets);
 
         $filesets = fractal($filesets, new LibraryVolumeTransformer(), $this->serializer)->toArray();
         if (!empty($filesets) &&
             !isset($version_code) &&
-            (empty($media) || $media === 'video' || $media === 'video_stream')
+            (empty($media) || $media === 'video' || $media === 'video_stream') &&
+            !empty($iso)
         ) {
             $filesets = array_merge($filesets, $arclight->volumes($iso));
         }
 
         return $this->reply($filesets);
+    }
+
+    private function getBiblesByFilesetId($filesets)
+    {
+        $filesets_ids = [];
+        foreach ($filesets as $fileset) {
+            $filesets_ids[] = $fileset->id;
+        }
+
+        $bible_filesets_with_bible_id = BibleFileset::whereIn('id', $filesets_ids)
+            ->whereIn('set_type_code', ['audio_stream', 'audio_drama_stream', 'audio', 'audio_drama'])
+            ->select(
+                \DB::raw(
+                    'bible_filesets.id,
+                    (SELECT bibles.id
+                    FROM bibles
+                    INNER JOIN bible_fileset_connections ON bible_fileset_connections.bible_id = bibles.id
+                    WHERE bible_fileset_connections.hash_id = bible_filesets.hash_id LIMIT 1) as bible_id'
+                )
+            )->get()
+            ->pluck('id', 'bible_id');
+
+        foreach ($filesets as &$fileset) {
+            if (isset($bible_filesets_with_bible_id[$fileset->id])) {
+                $fileset->bible_id = $bible_filesets_with_bible_id[$fileset->id];
+            }
+        }
     }
 
     private function filterById($filesets, $dam_id)
@@ -550,16 +610,7 @@ class LibraryController extends APIController
     {
         $output = [];
         foreach ($filesets as $fileset) {
-            $has_nondrama = $fileset->where('id', 'LIKE', substr($fileset->id, 0, 6) . '%')
-                ->where('set_type_code', 'audio')
-                ->whereHas('permissions', function ($query) {
-                    $query->whereHas('access', function ($query) {
-                        $query->where('name', '!=', 'RESTRICTED');
-                    });
-                })
-                ->get();
-
-            $type_codes = $this->getV2TypeCode($fileset, !$has_nondrama->isEmpty());
+            $type_codes = $this->getV2TypeCode($fileset, !empty($fileset->bible_filesets_has_dram));
 
             foreach ($type_codes as $type_code) {
                 $ot_fileset_id = substr($fileset->id, 0, 6) . 'O' . $type_code;
@@ -591,6 +642,8 @@ class LibraryController extends APIController
                     case 'OTP':
                         $output[$ot_fileset_id] = clone $fileset;
                         $output[$ot_fileset_id]->generated_id = $pt_fileset_id;
+                        break;
+                    default:
                         break;
                 }
             }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -239,13 +239,15 @@ class BibleFileset extends Model
         return $url;
     }
 
-    public function getArtworkUrlFromBibleId($bible_id)
+    public function getArtworkUrlFromBibleId($bible_id, $isSigned = false)
     {
         $url = '';
         $fileset_id = $this->id ?: $this->generated_id;
 
         if ($bible_id && $fileset_id) {
-            $url = $this->getUriFromStorage($bible_id, $fileset_id);
+            $url = $isSigned === true
+                ? $this->getUriFromStorage($bible_id, $fileset_id)
+                : "audio/{$bible_id}/{$fileset_id}/Art/300x300/{$fileset_id}.jpg";
         }
 
         return $url;

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -239,6 +239,32 @@ class BibleFileset extends Model
         return $url;
     }
 
+    public function getArtworkUrlFromBibleId($bible_id)
+    {
+        $url = '';
+        $fileset_id = $this->id ?: $this->generated_id;
+
+        if ($bible_id && $fileset_id) {
+            $url = $this->getUriFromStorage($bible_id, $fileset_id);
+        }
+
+        return $url;
+    }
+
+    private function getUriFromStorage($bible_id, $fileset_id)
+    {
+        $storage = \Storage::disk('dbp-web');
+        $client = $storage->getDriver()->getAdapter()->getClient();
+        $expiry = '+10 minutes';
+
+        $command = $client->getCommand('GetObject', [
+            'Bucket' => config('filesystems.disks.dbp-web.bucket'),
+            'Key'    => "audio/{$bible_id}/{$fileset_id}/Art/300x300/{$fileset_id}.jpg"
+        ]);
+
+        return (string) $client->createPresignedRequest($command, $expiry)->getUri();
+    }
+
     public function scopeIsContentAvailable($query, $key)
     {
         $dbp_users = config('database.connections.dbp_users.database');

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -161,9 +161,6 @@ class LibraryVolumeTransformer extends BaseTransformer
                     'num_sample_audio'          => '0',
                     'sku'                       => $fileset->meta->where('name', 'sku')->first()->description ?? '',
                     'audio_zip_path'            => $fileset->secondary_file_type === 'zip' ? $fileset->secondary_file_path : null,
-                    // 'artwork_url'               => $fileset->bible_id
-                    //                                     ? $fileset->getArtworkUrlFromBibleId($fileset->bible_id)
-                    //                                     : null,
                     'font'                      => null,
                     'arclight_language_id'      => '', // (int) $fileset->arclight_code,
                     'media'                     => Str::contains($fileset->set_type_code, 'audio') ? 'audio' : 'text',

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -160,8 +160,10 @@ class LibraryVolumeTransformer extends BaseTransformer
                     'num_art'                   => '0',
                     'num_sample_audio'          => '0',
                     'sku'                       => $fileset->meta->where('name', 'sku')->first()->description ?? '',
-                    'audio_zip_path'            => $fileset->audio_zip_path,
-                    // 'artwork_url'               => $fileset->artwork_url,
+                    'audio_zip_path'            => $fileset->secondary_file_type === 'zip' ? $fileset->secondary_file_path : null,
+                    // 'artwork_url'               => $fileset->bible_id
+                    //                                     ? $fileset->getArtworkUrlFromBibleId($fileset->bible_id)
+                    //                                     : null,
                     'font'                      => null,
                     'arclight_language_id'      => '', // (int) $fileset->arclight_code,
                     'media'                     => Str::contains($fileset->set_type_code, 'audio') ? 'audio' : 'text',


### PR DESCRIPTION
# v2_compat: library/volume should return everything if language_code is not provided

# Description
The volume action was updated to support to fetch all records for the dbp version 2. The main goal was to increase the queries to improve the action.

This PR also included the solution for the ticket FCBHDBP-218.

## Issue Link
- FCBHDBP-215
https://fullstacklabs.atlassian.net/browse/FCBHDBP-215

- FCBHDBP-218
https://fullstacklabs.atlassian.net/browse/FCBHDBP-218

## How Do I QA This
- Postman endpoint to test to fetch all records
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a456764c-7135-4405-bba8-ac5d3e7d6908
- Postman endpoint to test to fetch a only record by dam_id
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-cf5eea29-4a3f-423d-9148-bc172079d86d

- Postman endpoint to test to fetch a only record by dam_id `ENGKJV`
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e3716dfc-85f3-474f-b789-7ea40c50d306

## Screenshots 
- The request takes around 30 seconds when it should fetch all records. But the main query takes around 2 seconds, the most of the time is related to sign the  audio_zip_path for each record.
![screenshot-localhost_8080-2021 10 26-08_28_09](https://user-images.githubusercontent.com/73488660/138890255-cf7f007a-b219-4fd2-b84a-d999d7d39e3f.png)


