### PR TITLE
FCBHDBP Defect on the bible ordering when key is not bibleis or gideon

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -147,7 +147,7 @@ function generateCacheString($key, $args = [])
     return $cache_string;
 }
 
-function isBibleisOrGideon($key)
+function getBackwardCompatibilityInfo($key)
 {
     $bibleis_compat_keys = config('auth.compat_users.api_keys.bibleis');
     $bibleis_compat_keys = explode(',', $bibleis_compat_keys);
@@ -165,10 +165,9 @@ function isBibleisOrGideon($key)
     return $compat_keys_response;
 }
 
-function isKeyBelongBibleisOrGideon($key)
+function isBackwardCompatible($key)
 {
-    $app_compat_keys = isBibleisOrGideon($key);
-
+    $app_compat_keys = getBackwardCompatibilityInfo($key);
     return $app_compat_keys['isBibleis'] === true || $app_compat_keys['isGideons'] === true;
 }
 
@@ -258,7 +257,7 @@ function shouldUseBibleisBackwardCompat($key)
     $should_use_backward_compat = false;
     $app_name = '';
     $app_version = '';
-    $app_compat_keys = isBibleisOrGideon($key);
+    $app_compat_keys = getBackwardCompatibilityInfo($key);
     $deprecation_version = null;
 
     if ($app_compat_keys['isBibleis']) {

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -102,7 +102,7 @@ class BiblesController extends APIController
             $tag_exclude = 'opus';
         }
 
-        if (isKeyBelongBibleisOrGideon($this->key)) {
+        if (isBackwardCompatible($this->key)) {
             $order_by = 'bibles.priority DESC';
         }
 


### PR DESCRIPTION
# Defect on the bible ordering when key is not bibleis or gideon

# Description
When the key is not `bibleis` or `gideon` the bibles list must be sorted by id. It has added a new method to eval the isBibleis and isGideons flags

## Issue Link


## How Do I QA This
- The next postman url should pass all tests.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-90a0e9db-7dd8-4539-8792-d7fc651a8f50