### PR TITLE
FCBHDBP-220 500 error on bible filesets

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -382,7 +382,7 @@ class APIController extends Controller
     }
 
     /**
-     * Remove space for each value that belongs to cache params array
+     * Remove space and control characters for each value that belongs to cache params array
      *
      * @param array $cache_params
      *
@@ -392,7 +392,9 @@ class APIController extends Controller
     {
         return array_map(
             function ($param) {
-                return is_string($param) ? str_replace(' ', '', $param) : $param;
+                return is_string($param)
+                    ? preg_replace('/[\x00-\x1F\x7F]/', '', str_replace(' ', '', $param))
+                    : $param;
             },
             $cache_params
         );

--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -172,15 +172,17 @@ class BibleFileSetsController extends APIController
         $verse_end    = checkParam('verse_end');
         $type         = checkParam('type') ?? '';
 
-        $cache_params = [
-            $this->v,
-            $fileset_id,
-            $book_id,
-            $chapter_id,
-            $verse_start,
-            $verse_end,
-            $type
-        ];
+        $cache_params = $this->removeSpaceFromCacheParameters(
+            [
+                $this->v,
+                $fileset_id,
+                $book_id,
+                $chapter_id,
+                $verse_start,
+                $verse_end,
+                $type
+            ]
+        );
 
         $fileset_chapters = cacheRemember(
             $cache_key,


### PR DESCRIPTION
## 500 error on bible filesets

# Description
It has updated the method to process the cache keys to remove from the key string the control characters. Because the next postman URL is using  a control characters (tab) into the `chapter_id` parameter so, we need to remove the character to use the chapter_id value as cache key. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-220

## How Do I QA This
- The next postman URL should return the 200 code.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-95db873f-2b31-45c2-9ca7-36f93bf4e00f

