### PR TITLE
FCBHDBP hotfix safeguarding accessControl AccessGroupKey

### DIFF
--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -44,9 +44,11 @@ trait AccessControlAPI
             ->pluck('access')
             ->where('name', '!=', 'RESTRICTED')
             ->map(function ($access) {
-                return collect($access->toArray())
-                    ->only(['id', 'name'])
-                    ->all();
+                return !is_null($access)
+                    ? collect($access->toArray())
+                        ->only(['id', 'name'])
+                        ->all()
+                    : collect([]);
             });
 
             // Access Control has historically been tied to fileset hashes.


### PR DESCRIPTION
# Description
It has added the feature to do safeguarding when the dbp tries to fetch AccessGroup by key.

## Issue Link


## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->
