### PR TITLE
don't store null in cache

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -100,7 +100,12 @@ function cacheRemember($cache_key, $cache_args, $ttl, $callback)
     if ($lock->acquire()) {
         try {
             // lock acquired. access resource via callback
-            Cache::put($key, $value = $callback(), $ttl);
+            $value = $callback();
+            if (!is_null($value)) {
+                Cache::put($key, $value, $ttl);
+            } else {
+                Log::error("CacheRemember. callback returned null for key: " . $key);
+            }        
             $lock->release();
             return $value;
         } catch (Exception $exception) {


### PR DESCRIPTION
Storing null in the cache is probably a sign of some upstream problem. Check the callback value, and don't store value in cache if it is null. Log the key which is associated with the null callback value