### PR TITLE
FCBHDBP-220 500 error on bible filesets - updated again method to process the cache keys

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -392,7 +392,9 @@ class APIController extends Controller
     {
         return array_map(
             function ($param) {
-                return is_string($param) ? str_replace(' ', '', $param) : $param;
+                return is_string($param)
+                    ? preg_replace('/[[:cntrl:]]/', '', str_replace(' ', '', $param))
+                    : $param;
             },
             $cache_params
         );


### PR DESCRIPTION
## 500 error on bible filesets

# Description
It has updated the method to process the cache keys to remove from the key string the control characters. Because the next postman URL is using  a control characters (tab) into the `chapter_id` parameter so, we need to remove the character to use the chapter_id value as cache key. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-220

## How Do I QA This
- The next postman URL should return the 200 code.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-5f1a7af9-e048-4534-969d-721f6ffbbc8a

