### PR TITLE
FCBHDBP-218 v2_backward_compat: library/volume should process dam_id as input and return only that damid

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -445,7 +445,7 @@ class LibraryController extends APIController
         $cache_params = [$dam_id, $media, $language_name, $iso, $updated, $organization, $version_code];
         $filesets = cacheRemember('v2_library_volume', $cache_params, now()->addDay(), function () use ($dam_id, $media, $language_name, $iso, $updated, $organization, $version_code) {
             $language_id = $iso ? optional(Language::where('iso', $iso)->first())->id : null;
-            if (!$language_id) {
+            if (!$language_id && !$dam_id) {
                 return [];
             }
 
@@ -503,20 +503,7 @@ class LibraryController extends APIController
                 ->filter(function ($item) {
                     return $item->english_name;
                 });
-            foreach ($filesets as $key => $fileset) {
-                if ($fileset && $fileset->secondary_file_name) {
-                    $filesets[$key]->secondary_file_path = $this->signedUrl(
-                        storagePath(
-                            $fileset->bible_id,
-                            $fileset,
-                            null,
-                            $fileset->secondary_file_name
-                        ),
-                        $fileset->asset_id,
-                        random_int(0, 10000000)
-                    );
-                }
-            }
+
             return $this->generateV2StyleId($filesets);
         });
 

--- a/app/Traits/CallsBucketsTrait.php
+++ b/app/Traits/CallsBucketsTrait.php
@@ -60,7 +60,7 @@ trait CallsBucketsTrait
             $key = $this->getKey();
 
             if (!empty($key)) {
-                $signature = isset($query_parameters['Signature']) ? $query_parameters['Signature'] : $signedUrl;
+                $signature = isset($query_parameters['Signature']) ? $query_parameters['Signature'] : $signed_url;
                 \Log::channel('cloudfront_api_key')->notice($key . ' ' . $signature);
             }
 

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -161,7 +161,7 @@ class LibraryVolumeTransformer extends BaseTransformer
                     'num_sample_audio'          => '0',
                     'sku'                       => $fileset->meta->where('name', 'sku')->first()->description ?? '',
                     'audio_zip_path'            => $fileset->secondary_file_type === 'zip' ? $fileset->secondary_file_path : null,
-                    'artwork_url'               => $fileset->artwork_url,
+                    // 'artwork_url'               => $fileset->artwork_url,
                     'font'                      => null,
                     'arclight_language_id'      => '', // (int) $fileset->arclight_code,
                     'media'                     => Str::contains($fileset->set_type_code, 'audio') ? 'audio' : 'text',


### PR DESCRIPTION
# v2_backward_compat: library/volume should process dam_id as input and return only that damid

# Description
It has added the feature to fetch a library/volume by dam_id without the language_code filter.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-218

## How Do I QA This
- The next postman url should return the fileset according to given dam_id
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a456764c-7135-4405-bba8-ac5d3e7d6908
