### PR TITLE
FCBHDBP-225 v2_compate: add audio_zip_path property to library/volume

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -505,7 +505,9 @@ class LibraryController extends APIController
                 });
 
             foreach ($filesets as &$fileset) {
-                $fileset->secondary_file_path = $fileset->id . '/' . $fileset->secondary_file_name;
+                if ($fileset->secondary_file_type === 'zip') {
+                    $fileset->audio_zip_path = $fileset->id . '/' . $fileset->secondary_file_name;
+                }
             }
 
             return $this->generateV2StyleId($filesets);

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -504,6 +504,10 @@ class LibraryController extends APIController
                     return $item->english_name;
                 });
 
+            foreach ($filesets as &$fileset) {
+                $fileset->secondary_file_path = $fileset->id . '/' . $fileset->secondary_file_name;
+            }
+
             return $this->generateV2StyleId($filesets);
         });
 

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -160,7 +160,7 @@ class LibraryVolumeTransformer extends BaseTransformer
                     'num_art'                   => '0',
                     'num_sample_audio'          => '0',
                     'sku'                       => $fileset->meta->where('name', 'sku')->first()->description ?? '',
-                    'audio_zip_path'            => $fileset->secondary_file_type === 'zip' ? $fileset->secondary_file_path : null,
+                    'audio_zip_path'            => $fileset->audio_zip_path,
                     // 'artwork_url'               => $fileset->artwork_url,
                     'font'                      => null,
                     'arclight_language_id'      => '', // (int) $fileset->arclight_code,


### PR DESCRIPTION
# v2_compate: add audio_zip_path property to library/volume

# Description
Added the secondary_file_path property again to populate the audio_zip_path property to the final response.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-225

## How Do I QA This
- Use the next postman URL and the audio_zip_path should be populated.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-cf5eea29-4a3f-423d-9148-bc172079d86d
