### PR TITLE
FCBHDBP-227 500 error - Undefined variable $verse_text'

### DIFF
--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -200,6 +200,7 @@ class Highlight extends Model
         })->toArray();
 
         $verses = '';
+        $verse_text = '';
         if ($text_fileset) {
             $verses = BibleVerse::withVernacularMetaData($bible)
                 ->where('hash_id', $text_fileset->hash_id)

--- a/app/Transformers/UserHighlightsTransformer.php
+++ b/app/Transformers/UserHighlightsTransformer.php
@@ -67,13 +67,13 @@ class UserHighlightsTransformer extends TransformerAbstract
     private function checkColorPreference($highlight)
     {
         $color_preference = checkParam('prefer_color') ?? 'rgba';
-        if ($color_preference === 'hex') {
+        if ($color_preference === 'hex' && $highlight->color) {
             $highlight->color = '#' . $highlight->color->hex;
         }
-        if ($color_preference === 'rgb') {
+        if ($color_preference === 'rgb' && $highlight->color) {
             $highlight->color = 'rgb(' . $highlight->color->red . ',' . $highlight->color->green . ',' . $highlight->color->blue . ')';
         }
-        if ($color_preference === 'rgba') {
+        if ($color_preference === 'rgba' && $highlight->color) {
             $highlight->color = 'rgba(' . $highlight->color->red . ',' . $highlight->color->green . ',' . $highlight->color->blue . ',' . $highlight->color->opacity . ')';
         }
     }


### PR DESCRIPTION
Error - Undefined variable $verse_text'

# Description
It has fixed Highlight model to avoid the 500 error when dbp tries to pull the FilesetInfo property. Overall, the problem is related when dbp is trying to pull a highlights that belongs to a bible and the bible does not have filesets of text_plain type. Then in the Highlight model assumes that the bible has filesets of text_plain type as you can see in the next line:

https://github.com/faithcomesbyhearing/dbp/blob/d54139d8aefb88783c89e009d48f6c698d81682f/app/Models/User/Study/Highlight.php#L183

We can also see the issue when we try to create a Highlight for the bible: ENGNKJV

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-227

## How Do I QA This
Try to create a Highlight for ENGNKJV bible
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-8c66af95-388e-49d0-8932-b0b3363a5523

Try to pull the chapter 1 for the ENGNKJV bible but for a user logged in
1. Log in with a test user using the next postman URL
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-2fce81ce-e5f2-4442-acb9-4d35922893af
2. Pull the hapter 1 for the ENGNKJV bible using the next postman URL
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b99bf13b-8caf-4d71-b97f-3ef9f8f4009d

