### PR TITLE
FCBHDBP-229 languages / search doesn't decode encoded characters, resulting in lock timeout

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -248,7 +248,9 @@ class BiblesController extends APIController
         $formatted_search = $this->transformQuerySearchText($search_text);
 
         $key = $this->key;
-        $cache_params = [$limit, $page, $formatted_search_cache, $key];
+        $cache_params = $this->removeSpaceFromCacheParameters(
+            [$limit, $page, $formatted_search_cache, $key]
+        );
         $bibles = cacheRemember('bibles_search', $cache_params, now()->addDay(), function () use ($key, $limit, $formatted_search) {
             $bibles = Bible::isContentAvailable($key)
             ->matchByFulltextSearch($formatted_search)

--- a/app/Http/Controllers/Wiki/CountriesController.php
+++ b/app/Http/Controllers/Wiki/CountriesController.php
@@ -128,7 +128,9 @@ class CountriesController extends APIController
 
         $formatted_search = $this->transformQuerySearchText($search_text);
 
-        $cache_params = [$GLOBALS['i18n_iso'], $limit, $page, $formatted_search_cache];
+        $cache_params = $this->removeSpaceFromCacheParameters(
+            [$GLOBALS['i18n_iso'], $limit, $page, $formatted_search_cache]
+        );
         $countries = cacheRemember('countries', $cache_params, now()->addDay(), function () use ($limit, $page, $formatted_search) {
             $countries = Country::with('currentTranslation')
                 ->filterableByNameOrIso($formatted_search)

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -194,15 +194,16 @@ class LanguagesController extends APIController
         $formatted_search = $this->transformQuerySearchText($search_text);
 
         $key = $this->key;
-
-        $cache_params = [
-            $this->v,
-            $formatted_search_cache,
-            $limit,
-            $page,
-            $GLOBALS['i18n_id'],
-            $key
-        ];
+        $cache_params = $this->removeSpaceFromCacheParameters(
+            [
+                $this->v,
+                $formatted_search_cache,
+                $limit,
+                $page,
+                $GLOBALS['i18n_id'],
+                $key
+            ]
+        );
         $languages = cacheRemember(
             'languages_search',
             $cache_params,


### PR DESCRIPTION
Languages / search doesn't decode encoded characters, resulting in lock timeout

# Description
It has added the feature to remove the control characters for the languages, bibles and countries search endpoint when they set the cache parameters.

It also fixed the ticket 230:

- https://fullstacklabs.atlassian.net/browse/FCBHDBP-230

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-229

## How Do I QA This
- Languages search with encoded characters
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ba22c1e3-162c-4ad5-b06e-cd0bb279bd11

- Bibles search with encoded characters
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-79e19524-4896-4922-8dc8-6b68a88e5c47

- Countries search with encoded characters
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-c3c679d0-e0ec-42a9-8911-72e9e8143429
