### PR TITLE
FCBHDBP-219 hotfix - hardening: shave response time off the tests in Example Workflow that occasionally fail due to excessive response time

### DIFF
--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -209,9 +209,7 @@ class LanguagesController extends APIController
             $cache_params,
             now()->addDay(),
             function () use ($formatted_search, $limit, $key) {
-                $languages = Language::includeAutonymTranslation()
-                    ->includeCurrentTranslation()
-                    ->filterableByNameAndKey($formatted_search, $key)
+                $languages = Language::filterableByNameAndKey($formatted_search, $key)
                     ->select([
                         'languages.id',
                         'languages.glotto_id',


### PR DESCRIPTION
hardening: shave response time off the tests in Example Workflow that occasionally fail due to excessive response time

# Description
It has updated a fix because the language_translations is not filtering the records according to the  highest priority so, it was searching by language_translations records with low priority and high priority. I have tested it with the language endpoint for one letter and for each page.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-219

## How Do I QA This
- Language search (one letter)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-323c258d-e452-4737-a05e-98dd3940b6ea
