### PR TITLE
FCBHDBP-232 Improve performance for endpoints that use signedUrl method

### DIFF
--- a/app/Traits/CallsBucketsTrait.php
+++ b/app/Traits/CallsBucketsTrait.php
@@ -83,42 +83,7 @@ trait CallsBucketsTrait
         });
         $client = $this->authorizeAWS($asset->asset_type);
 
-        // Return Either CloudFront Signed Urls
-        if ($asset->asset_type === 'cloudfront') {
-            $request_array = [
-                'url'         => 'https://content.cdn.' . $asset_id . '.dbp4.org/' . $file_path . '?x-amz-transaction=' . $transaction,
-                'key_pair_id' => config('filesystems.disks.cloudfront.key'),
-                'private_key' => storage_path('app/' . config('filesystems.disks.cloudfront.secret')),
-                'expires'     => Carbon::now()->addDay()->timestamp,
-            ];
-
-            $signed_url = $client->getSignedUrl($request_array);
-            $query_parameters_string = parse_url($signed_url, PHP_URL_QUERY);
-            $query_parameters = [];
-            parse_str($query_parameters_string, $query_parameters);
-            $key = $this->getKey();
-
-            if (!empty($key)) {
-                $signature = isset($query_parameters['Signature']) ? $query_parameters['Signature'] : $signed_url;
-                \Log::channel('cloudfront_api_key')->notice($key . ' ' . $signature);
-            }
-
-            return $signed_url;
-        }
-
-        // Or return S3 Urls
-        if ($asset->asset_type === 's3') {
-            $temp_session_token = $client->AssumeRoleResult->Credentials->SessionToken;
-            $temp_secret_key    = $client->AssumeRoleResult->Credentials->SecretAccessKey;
-            $temp_access_key    = $client->AssumeRoleResult->Credentials->AccessKeyId;
-
-            $bucket = $asset->id;
-
-            $timestamp = Carbon::now()->addDay()->timestamp;
-            $data = "GET\n\n\n$timestamp\nx-amz-security-token:$temp_session_token\nx-amz-transaction:$transaction\n/$bucket" . '/' . $file_path;
-            $signature = base64_encode(hash_hmac('sha1', $data, $temp_secret_key, true));
-            return "https://$bucket.s3.amazonaws.com/$file_path?AWSAccessKeyId=$temp_access_key&Signature=" . urlencode($signature) . '&x-amz-security-token=' . urlencode($temp_session_token) . "&x-amz-transaction=$transaction&Expires=$timestamp";
-        }
+        return $this->signedUrlUsingClient($client, $file_path, $transaction);
     }
 
     private function assumeRole()

--- a/app/Traits/CallsBucketsTrait.php
+++ b/app/Traits/CallsBucketsTrait.php
@@ -38,6 +38,43 @@ trait CallsBucketsTrait
             return $security_token;
         }
     }
+    /**
+     * Method to sign a URL but the CloudFrontClient object should be passed by parameter
+     * to do an only one call to AWS
+     *
+     * @param CloudFrontClient $client
+     * @param string $file_path
+     * @param int $transaction
+     *
+     * @return string signed url
+     */
+    public function signedUrlUsingClient(CloudFrontClient $client, string $file_path, int $transaction): string
+    {
+        if (!$client) {
+            return null;
+        }
+
+        $cdn_server_url = config('services.cdn.server');
+        $request_array = [
+            'url'         => 'https://'. $cdn_server_url . '/' . $file_path . '?x-amz-transaction=' . $transaction,
+            'key_pair_id' => config('filesystems.disks.cloudfront.key'),
+            'private_key' => storage_path('app/' . config('filesystems.disks.cloudfront.secret')),
+            'expires'     => Carbon::now()->addDay()->timestamp,
+        ];
+
+        $signed_url = $client->getSignedUrl($request_array);
+        $query_parameters_string = parse_url($signed_url, PHP_URL_QUERY);
+        $query_parameters = [];
+        parse_str($query_parameters_string, $query_parameters);
+        $key = $this->getKey();
+
+        if (!empty($key)) {
+            $signature = isset($query_parameters['Signature']) ? $query_parameters['Signature'] : $signed_url;
+            \Log::channel('cloudfront_api_key')->notice($key . ' ' . $signature);
+        }
+
+        return $signed_url;
+    }
 
     public function signedUrl(string $file_path, $asset_id, int $transaction)
     {


### PR DESCRIPTION
Improve performance for endpoints that use signedUrl method

# Description
It is a child of the ticket FCBHDBP-219 and it has been created to improve the performance for the signedUrl method because the AWS authorization is likely the bottleneck. It has created a new method to sign an url but the cloudFrontClient is passed by parameter to avoid the external call to AWS for each signing request.

@bradflood Check this PR to validate if it is ok related with the last email that you sent me.

### NOTE: If it is ok, I think that we can replace every call to the current method `singUrl` with the new method: `signedUrlUsingClient`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-219

https://fullstacklabs.atlassian.net/browse/FCBHDBP-232

## How Do I QA This
- I have tested the change with the next endpoint and the response time is around 1.3 seg as you can see in the next screenshot.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9c2df2d6-85cf-46e9-bda9-4bb6d65810f9

## Screenshots (if appropriate)
![Screenshot from 2021-11-09 22-53-10](https://user-images.githubusercontent.com/73488660/141047868-c82a1955-7175-4995-9b61-de97163e9a23.png)

