### PR TITLE
FCBHDBP-234 v2_compat: library book does not account for seven character DAMID

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -510,3 +510,30 @@ if (!function_exists('formatFilesetMeta')) {
         return $fileset;
     }
 }
+if (!function_exists('getTestamentString')) {
+    function getTestamentString($id)
+    {
+        $testament_pivot_word = 6;
+
+        $substring = '';
+        if (strlen($id) > $testament_pivot_word) {
+            $substring = $id[$testament_pivot_word];
+        }
+        switch ($substring) {
+            case 'O':
+                $testament = ['OT', 'C'];
+                break;
+
+            case 'N':
+                $testament = ['NT', 'C'];
+                break;
+
+            case 'P':
+                $testament = ['NTOTP', 'NTP', 'NTPOTP', 'OTNTP', 'OTP', 'P'];
+                break;
+            default:
+                $testament = [];
+        }
+        return $testament;
+    }
+}

--- a/app/Http/Controllers/Bible/BooksControllerV2.php
+++ b/app/Http/Controllers/Bible/BooksControllerV2.php
@@ -411,26 +411,6 @@ class BooksControllerV2 extends APIController
 
     private function getTestamentString($id)
     {
-        $testament = [];
-
-        $len = strlen($id);
-        $substring = '';
-        if ($len === 10) {
-            $substring = $id[$len - 4];
-        }
-        switch ($substring) {
-            case 'O':
-                $testament = ['OT', 'C'];
-                break;
-
-            case 'N':
-                $testament = ['NT', 'C'];
-                break;
-
-            case 'P':
-                $testament = ['NTOTP', 'NTP', 'NTPOTP', 'OTNTP', 'OTP', 'P'];
-                break;
-        }
-        return $testament;
+        return getTestamentString($id);
     }
 }


### PR DESCRIPTION
## v2_compat: library book does not account for seven character DAMID

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
It has refactored the getTestamentString method to extract the correct pivot word from the Testament id.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-234

## How Do I QA This
- Test the next postman URL and the tests should not fail
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-45091908-694d-4e1e-8404-b5233e6964c8
