### PR TITLE
FCBHDBP-235 v2_compat: text search does not account for seven character DAMID

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -78,14 +78,14 @@ function cacheGet($cache_key)
 
 function createCacheLock($cache_key, $lock_timeout = 10)
 {
-    return Cache::lock($cache_key . '_lock', $lock_timeout); 
+    return Cache::lock($cache_key . '_lock', $lock_timeout);
 }
 
 function cacheRemember($cache_key, $cache_args, $ttl, $callback)
 {
     $key = generateCacheString($cache_key, $cache_args);
-    // if something fails on the callback, release the lock 
-    // 45 seconds was selected to allow for the longest query to complete. 
+    // if something fails on the callback, release the lock
+    // 45 seconds was selected to allow for the longest query to complete.
     // This is not based on any empirical evidence.
     $lock_timeout = 45;
     $value = Cache::get($key);
@@ -105,7 +105,7 @@ function cacheRemember($cache_key, $cache_args, $ttl, $callback)
                 Cache::put($key, $value, $ttl);
             } else {
                 Log::error("CacheRemember. callback returned null for key: " . $key);
-            }        
+            }
             $lock->release();
             return $value;
         } catch (Exception $exception) {
@@ -115,7 +115,7 @@ function cacheRemember($cache_key, $cache_args, $ttl, $callback)
         }
     } else {
         try {
-            // couldn't get the lock, another is executing the callback. block for up to 45 seconds waiting for lock 
+            // couldn't get the lock, another is executing the callback. block for up to 45 seconds waiting for lock
             // or until the lock is released by the lock timeout
             $lock->block($lock_timeout + 1);
             // Lock acquired, which should mean the cache is set

--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -92,4 +92,109 @@ class TextControllerV2 extends APIController
 
         return $this->reply(fractal($verses, new TextTransformer(), $this->serializer));
     }
+
+    /**
+     *
+     * @OA\Get(
+     *     path="/search",
+     *     tags={"Search"},
+     *     summary="Search a bible for a word",
+     *     description="",
+     *     operationId="v2_text_search",
+     *     @OA\Parameter(
+     *          name="query",
+     *          in="query",
+     *          description="The word or phrase being searched", required=true,
+     *          @OA\Schema(type="string"),
+     *          example="Jesus"
+     *     ),
+     *     @OA\Parameter(
+     *          name="fileset_id",
+     *          in="query",
+     *          description="The Bible fileset ID", required=true,
+     *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id")
+     *     ),
+     *     @OA\Parameter(name="limit",  in="query", description="The number of search results to return",
+     *          @OA\Schema(type="integer",default=15)),
+     *     @OA\Parameter(ref="#/components/parameters/page"),
+     *     @OA\Parameter(name="books",  in="query", description="The usfm book ids to search through separated by a comma",
+     *          @OA\Schema(type="string",example="GEN,EXO,MAT")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v2_text_search"))
+     *     )
+     * )
+     *
+     * @return Response
+     *
+     * @OA\Schema(
+     *   schema="v2_text_search",
+     *   type="object",
+     *   @OA\Property(property="verses", ref="#/components/schemas/v4_bible_filesets_chapter"),
+     *   @OA\Property(property="meta",ref="#/components/schemas/pagination")
+     *
+     * )
+     */
+    public function search()
+    {
+        if (!$this->api) {
+            return view('docs.v2.text_search');
+        }
+
+        $query      = checkParam('query', true);
+        $fileset_id = checkParam('fileset_id|dam_id', true);
+        $book_id    = checkParam('book|book_id|books');
+
+        $fileset = BibleFileset::with('bible')
+            ->uniqueFileset(
+                $fileset_id,
+                'text_plain',
+                false,
+                getTestamentString($fileset_id)
+            )
+            ->first();
+        if (!$fileset) {
+            return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+        }
+        $bible = $fileset->bible->first();
+
+        $search_text  = '%' . $query . '%';
+        $select_columns = [
+            'bible_verses.book_id as book_id',
+            'bible_books.bible_id as bible_id',
+            'books.name as book_name',
+            'bible_books.name as book_vernacular_name',
+            'bible_verses.chapter',
+            'bible_verses.verse_start',
+            'bible_verses.verse_end',
+            'bible_verses.verse_text',
+        ];
+        $verses = BibleVerse::where('hash_id', $fileset->hash_id)
+            ->withVernacularMetaData($bible)
+            ->when($book_id, function ($query) use ($book_id) {
+                $books = explode(',', $book_id);
+                $query->whereIn('bible_verses.book_id', $books);
+            })
+            ->where('bible_verses.verse_text', 'like', $search_text);
+
+        if ($bible && $bible->numeral_system_id) {
+            $select_columns_extra = array_merge(
+                $select_columns,
+                [
+                    'glyph_chapter.glyph as chapter_vernacular',
+                    'glyph_start.glyph as verse_start_vernacular',
+                    'glyph_end.glyph as verse_end_vernacular',
+                ]
+            );
+            $verses->select($select_columns_extra);
+        } else {
+            $verses->select($select_columns);
+        }
+
+        return $this->reply([
+            [['total_results' => strval($verses->count())]],
+            fractal($verses->get(), new TextTransformer(), $this->serializer)
+        ]);
+    }
 }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -198,7 +198,7 @@ class BibleFileset extends Model
             });
         })
         ->when($testament_filter, function ($query) use ($testament_filter) {
-            if (is_array($testament_filter)) {
+            if (is_array($testament_filter) && !empty($testament_filter)) {
                 $query->whereIn('bible_filesets.set_size_code', $testament_filter);
             }
         })

--- a/routes/apiV2.php
+++ b/routes/apiV2.php
@@ -33,7 +33,7 @@ Route::name('v2_volume_organization_list')->get('library/volumeorganization',   
 Route::name('v2_text_font')->get('text/font',                                      'Bible\TextController@fonts');
 Route::name('v2_text_verse')->get('text/verse',                                    'Bible\TextControllerV2@index');
 Route::name('v2_verseInfo')->get('text/verseinfo',                                 'Bible\TextController@info'); // I cannot see a difference between library/verseinfo and text/verseinfo
-Route::name('v2_text_search')->get('text/search',                                  'Bible\TextController@search');
+Route::name('v2_text_search')->get('text/search',                                  'Bible\TextControllerV2@search');
 Route::name('v2_text_search_group')->get('text/searchgroup',                       'Bible\TextController@searchGroup');
 Route::name('v2_text_volume')->get('/text/volume',                                 'Bible\BiblesController@show');
 


### PR DESCRIPTION
## v2_compat: text search does not account for seven character DAMID

# Description
It has created the search action to TextControllerV2. Also, It has added the feature to filter by testament according to the dam_id parameter.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-235

## How Do I QA This
- The tests for this postman url should not fail.
[<!--- Explain how a developer would qa out these changes locally -->](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0622b741-a38d-4c9f-814a-0ae2375f1b4e)

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
