### PR TITLE
FCBHDBP-235 v2_compat: text search does not account for seven character DAMID

### DIFF
--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -234,19 +234,12 @@ class TextController extends APIController
             $verses->select($select_columns);
         }
 
-        if ($this->v === 2 || $this->v === 3) {
-            return $this->reply([
-                [['total_results' => strval($verses->count())]],
-                fractal($verses->get(), new TextTransformer(), $this->serializer)
-            ]);
-        } else {
-            if ($page) {
-                $verses  = $verses->paginate($limit);
-                return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses->getCollection(), TextTransformer::class)->paginateWith(new IlluminatePaginatorAdapter($verses))]);
-            }
-            $verses  = $verses->limit($limit)->get();
-            return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses, new TextTransformer(), $this->serializer)]);
+        if ($page) {
+            $verses  = $verses->paginate($limit);
+            return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses->getCollection(), TextTransformer::class)->paginateWith(new IlluminatePaginatorAdapter($verses))]);
         }
+        $verses  = $verses->limit($limit)->get();
+        return $this->reply(['audio_filesets' => $audio_filesets, 'verses' => fractal($verses, new TextTransformer(), $this->serializer)]);
     }
     /**
      *

--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -169,6 +169,7 @@ class TextControllerV2 extends APIController
             'bible_verses.verse_start',
             'bible_verses.verse_end',
             'bible_verses.verse_text',
+            \DB::raw("'$fileset_id' as dam_id_request"),
         ];
         $verses = BibleVerse::where('hash_id', $fileset->hash_id)
             ->withVernacularMetaData($bible)

--- a/app/Transformers/TextTransformer.php
+++ b/app/Transformers/TextTransformer.php
@@ -41,6 +41,8 @@ class TextTransformer extends BaseTransformer
              */
             case 'v2_text_search':
                 return [
+                    // It must return a damid longer than six characters, then it is using the request DAMID
+                    // to accomplish this goal
                     'dam_id' => (string) $text->dam_id_request ?? $text->bible_id,
                     'book_name' => (string) $text->book_name,
                     'book_id' => (string) $text->book_id,

--- a/app/Transformers/TextTransformer.php
+++ b/app/Transformers/TextTransformer.php
@@ -41,7 +41,7 @@ class TextTransformer extends BaseTransformer
              */
             case 'v2_text_search':
                 return [
-                    'dam_id' => (string) $text->bible_id,
+                    'dam_id' => (string) $text->dam_id_request ?? $text->bible_id,
                     'book_name' => (string) $text->book_name,
                     'book_id' => (string) $text->book_id,
                     'chapter_id' => (string) $text->chapter,


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
- damid match to the request param.
- Added comment to explain about the dam_id value for the text transformForV2 method.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-235

## How Do I QA This
- The tests for this postman url should not fail.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0622b741-a38d-4c9f-814a-0ae2375f1b4e

- The postman URL for the search text v4 should not return error.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-505f93c5-4abf-4acb-9d50-c8992d135590
