### PR TITLE
FCBHDBP-237 Avoid that languages search endpoint run query if search text is only + character

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -241,11 +241,11 @@ class BiblesController extends APIController
         $limit          = min($limit, 50);
         $page           = checkParam('page') ?? 1;
         $formatted_search_cache = str_replace(' ', '', $search_text);
-        if ($formatted_search_cache === '' || !$formatted_search_cache) {
+        $formatted_search = $this->transformQuerySearchText($search_text);
+
+        if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
         }
-
-        $formatted_search = $this->transformQuerySearchText($search_text);
 
         $key = $this->key;
         $cache_params = $this->removeSpaceFromCacheParameters(

--- a/app/Http/Controllers/Wiki/CountriesController.php
+++ b/app/Http/Controllers/Wiki/CountriesController.php
@@ -121,12 +121,11 @@ class CountriesController extends APIController
         $limit     = min($limit, 50);
         $page      = checkParam('page') ?? 1;
         $formatted_search_cache = str_replace(' ', '', $search_text);
+        $formatted_search = $this->transformQuerySearchText($search_text);
 
-        if ($formatted_search_cache === '' || !$formatted_search_cache) {
+        if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
         }
-
-        $formatted_search = $this->transformQuerySearchText($search_text);
 
         $cache_params = $this->removeSpaceFromCacheParameters(
             [$GLOBALS['i18n_iso'], $limit, $page, $formatted_search_cache]

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -187,11 +187,11 @@ class LanguagesController extends APIController
         $limit = (int) (checkParam('limit') ?? 15);
         $limit = min($limit, 50);
         $formatted_search_cache = str_replace(' ', '', $search_text);
-        if ($formatted_search_cache === '' || !$formatted_search_cache) {
+        $formatted_search = $this->transformQuerySearchText($search_text);
+
+        if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
         }
-
-        $formatted_search = $this->transformQuerySearchText($search_text);
 
         $key = $this->key;
         $cache_params = $this->removeSpaceFromCacheParameters(


### PR DESCRIPTION
## Avoid that languages search endpoint run query if search text is only + character

# Description
Hotfix to avoid that the fulltext searching run the query with an empty text because the search text is a special character e.g. '+'.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-237

## How Do I QA This

- Language search
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-8286dc90-99b6-4710-b3d3-c36b5fd97331

- Bibles search
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-018294a1-9804-4d1d-bcd7-4eb2db8e76f8

- Country search
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6b8d827d-3bf3-48ee-a2eb-e027ab0b9218

