### PR TITLE
FCBHDBP-238 Solve two error that newrelic is displaying

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -203,7 +203,7 @@ class UsersController extends APIController
             $user = $this->loginWithEmail($email, $password);
         }
 
-        if (!$user) {
+        if (!isset($user) || !$user) {
             return $this->setStatusCode(401)->replyWithError(
                 trans('auth.failed')
             );

--- a/app/Transformers/BibleTransformer.php
+++ b/app/Transformers/BibleTransformer.php
@@ -251,7 +251,9 @@ class BibleTransformer extends BaseTransformer
                             $chapters[$key] = intval($chapter);
                         }
                         $book->chapters = $chapters;
-                        $book->testament = $book->book['book_testament'];
+                        $book->testament = isset($book->book) && isset($book->book['book_testament'])
+                            ? $book->book['book_testament']
+                            : null;
                         unset($book->book);
                         return $book;
                     })->values(),


### PR DESCRIPTION
## Solve two error that newrelic is displaying

# Description
It has fixed two error displayed in NewRelic. The first is related with the endpoint to log in and the second is defensive code for the BibleTransformer class.

- First error
```bash
/v4_bible.one
ErrorExceptionException 'ErrorException' with message 'Trying to access array offset on value of type null' in /var/app/current/app/Transformers/BibleTransformer.php:254
```

- Second error
```bash
/v4_internal_user.login
ErrorExceptionException 'ErrorException' with message 'Undefined variable $user' in /var/app/current/app/Http/Controllers/User/UsersController.php:206
```
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-238

## How Do I QA This
- The next postman should render the testament parameter for each book.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f0144522-8f09-4a97-908a-779d8d08f8fc
