### PR TITLE
FCBHDBP-202 optimize bulk access control

### DIFF
--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -124,6 +124,7 @@ trait AccessControlAPI
                 ->where(function ($query) use ($continent) {
                     $query->where('continent_id', $continent);
                 })
+                ->select('id', 'name')
                 ->first();
 
             if (!$access_type) {
@@ -132,16 +133,16 @@ trait AccessControlAPI
 
             $dbp_database = config('database.connections.dbp.database');
 
-            return AccessGroupKey::join(
+            return AccessGroupKey::join('user_keys', function ($join) use ($api_key) {
+                $join->on('user_keys.id', '=', 'access_group_api_keys.key_id')
+                    ->where('user_keys.key', $api_key);
+            })->join(
                 $dbp_database . '.access_group_filesets as acc_filesets',
                 function ($join) use ($fileset_hash) {
                     $join->on('access_group_api_keys.access_group_id', '=', 'acc_filesets.access_group_id')
                         ->where('hash_id', $fileset_hash);
                 }
-            )->join('user_keys', function ($join) use ($api_key) {
-                    $join->on('user_keys.id', '=', 'access_group_api_keys.key_id')
-                        ->where('user_keys.key', $api_key);
-            })->get();
+            )->select('user_keys.id')->get();
         });
     }
 


### PR DESCRIPTION
## Optimize bulk access control

# Description
the `bulkAccessControl` method has been updated to improve the AccessGroupKey query. It has switched join order and it has set the `access_group_api_keys` as first join and after it has added the join that to `access_group_filesets`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-202

## How Do I QA This
Run the group: [M] Bulk requests
