### PR TITLE
FCBHDBP-242 v2_backward_compat: text search does not filter on testament

### DIFF
--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -146,12 +146,13 @@ class TextControllerV2 extends APIController
         $fileset_id = checkParam('fileset_id|dam_id', true);
         $book_id    = checkParam('book|book_id|books');
 
+        $testament_filter = getTestamentString($fileset_id);
         $fileset = BibleFileset::with('bible')
             ->uniqueFileset(
                 $fileset_id,
                 'text_plain',
                 false,
-                getTestamentString($fileset_id)
+                $testament_filter
             )
             ->first();
         if (!$fileset) {
@@ -172,7 +173,7 @@ class TextControllerV2 extends APIController
             \DB::raw("'$fileset_id' as dam_id_request"),
         ];
         $verses = BibleVerse::where('hash_id', $fileset->hash_id)
-            ->withVernacularMetaData($bible)
+            ->withVernacularMetaData($bible, $testament_filter)
             ->when($book_id, function ($query) use ($book_id) {
                 $books = explode(',', $book_id);
                 $query->whereIn('bible_verses.book_id', $books);

--- a/app/Models/Bible/BibleVerse.php
+++ b/app/Models/Bible/BibleVerse.php
@@ -72,7 +72,7 @@ class BibleVerse extends Model
         return $this->hasMany(BibleConcordance::class);
     }
 
-    public function scopeWithVernacularMetaData($query, $bible)
+    public function scopeWithVernacularMetaData($query, $bible, $testament_filter = null)
     {
         $numeral_system_id = $bible->numeral_system_id;
         $query->when($numeral_system_id, function ($query) use ($numeral_system_id) {
@@ -92,7 +92,12 @@ class BibleVerse extends Model
                     ->where('glyph_end.numeral_system_id', $numeral_system_id);
             });
         })
-        ->join('books', 'books.id', 'bible_verses.book_id')
+        ->join('books', function ($join) use ($testament_filter) {
+            $join->on('books.id', 'bible_verses.book_id');
+            if (is_array($testament_filter) && !empty($testament_filter)) {
+                $join->whereIn('books.book_testament', $testament_filter);
+            }
+        })
         ->join('bible_books', function ($join) use ($bible) {
             $join->on('bible_verses.book_id', 'bible_books.book_id')->where('bible_books.bible_id', $bible->id);
         });


### PR DESCRIPTION
## v2_backward_compat: text search does not filter on testament

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
It has added the testament filter to `VernacularMetaData` method that belongs to `BibleVerse` model. The goal is to make sure that the books belong to specific testament when the filter is set.

The next is a example about the updated query.

```sql
SELECT count(*) AS aggregate
FROM `bible_verses` INNER JOIN `dbp`.`numeral_system_glyphs` AS `glyph_chapter`
ON `bible_verses`.`chapter` = `glyph_chapter`.`VALUE` and `glyph_chapter`.`numeral_system_id` = 'western-arabic' 
INNER JOIN `dbp`.`numeral_system_glyphs` AS `glyph_start`
ON `bible_verses`.`verse_start` = `glyph_start`.`VALUE` and `glyph_start`.`numeral_system_id` = 'western-arabic'
INNER JOIN `dbp`.`numeral_system_glyphs` AS `glyph_end`
ON `bible_verses`.`verse_end` = `glyph_end`.`VALUE` and `glyph_end`.`numeral_system_id` = 'western-arabic'
INNER JOIN `books` 
ON `books`.`id` = `bible_verses`.`book_id` and `books`.`book_testament` in ('OT', 'C')
INNER JOIN `bible_books`
ON `bible_verses`.`book_id` = `bible_books`.`book_id` and `bible_books`.`bible_id` = 'ENGKJV'
WHERE `hash_id` = 'e22c3e6a0010' and `bible_verses`.`verse_text` like '%Moses%'
```
The above has the new filter `books.book_testament in ('OT', 'C')` to make sure that the verses fetched should belong the testament calculated from DAM_ID.

## NOTE: the current postman url to test it is falling according to total results. I think that we need to update the postman test because it is currently filtering the books by testament.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-242

## How Do I QA This
- The next postman URL should pass all tests.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6ee59ffe-3b37-4cad-811f-e067cf4ea8fd
