### PR TITLE
FCBHDBP-243 v2_compat: 500 error on v2_library_version

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -265,7 +265,7 @@ class LibraryController extends APIController
         $name = checkParam('name');
         $sort = checkParam('sort_by');
 
-        $cache_params = [$code, $name, $sort];
+        $cache_params = $this->removeSpaceFromCacheParameters([$code, $name, $sort]);
         $versions = cacheRemember('v2_library_version', $cache_params, now()->addDay(), function () use ($code, $sort, $name) {
             $english_id = Language::where('iso', 'eng')->first()->id ?? '6414';
 
@@ -298,7 +298,11 @@ class LibraryController extends APIController
             return $versions;
         });
 
-        return $this->reply(fractal($versions[0], new LibraryVolumeTransformer(), $this->serializer));
+        return $this->reply(fractal(
+            isset($versions[0]) ? $versions[0] : [],
+            new LibraryVolumeTransformer(),
+            $this->serializer
+        ));
     }
 
     /**


### PR DESCRIPTION
## v2_compat: 500 error on v2_library_version

# Description
It has fixed the version action for the Library Controller. It has added the feature to clean the special character to set the cache keys.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-243

## How Do I QA This
- The next postman URL should not return error.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-546d2f44-9c45-4a8b-8ef1-327578b79302
