### PR TITLE
FCBHDBP-245 v2_compat: 500 error in countrylang

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -141,12 +141,16 @@ class LanguageControllerV2 extends APIController
         $additional         = checkParam('additional');
 
         $key = $this->key;
-        $cache_params = [
-            $sort_by, $lang_code,
-            $country_code, $img_size,
-            $img_type, $additional,
+
+        $cache_params = $this->removeSpaceFromCacheParameters([
+            $sort_by,
+            $lang_code,
+            $country_code,
+            $img_size,
+            $img_type,
+            $additional,
             $key
-        ];
+        ]);
 
         if ($sort_by === 'lang_code') {
             $sort_by = 'languages.iso';
@@ -178,7 +182,7 @@ class LanguageControllerV2 extends APIController
                     })
                     ->whereHas('country', function ($query) use ($country_code) {
                         $query->when($country_code, function ($subquery) use ($country_code) {
-                            $subquery->where('country.country_id', $country_code);
+                            $subquery->where('country_language.country_id', $country_code);
                         });
                     })
                     ->orderBy($sort_by, 'desc')->get()->each(function ($item) use ($img_size, $img_type) {


### PR DESCRIPTION
## v2_compat: 500 error in countrylang

# Description
It has fixed the countryLang action for the Language Controller V2. It has added the feature to clean the special characters to set the cache keys

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-245

## How Do I QA This
- The next postman URL should not return error.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-65b6830a-f413-4e57-802e-ff8373a9c4ee
