### PR TITLE
FCBHDBP-246 Adjust check for backward compatibility mode on chapter detail

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -709,9 +709,9 @@ class BiblesController extends APIController
      */
     public function chapter(Request $request, $bible_id)
     {
-        // deprecate endpoint for bibleis/gideons newest versions (and for other users by deafult)
-        if (!shouldUseBibleisBackwardCompat($this->key)) {
-            return $this->setStatusCode(410)->replyWithError(trans('api.errors_410'));
+        // Make that only bibleis and gideons can access this endpoint
+        if (!isBackwardCompatible($this->key)) {
+            return $this->setStatusCode(404)->replyWithError(trans('api.errors_404'));
         }
 
         $bible = cacheRemember('v4_chapter_bible', [$bible_id], now()->addDay(), function () use ($bible_id) {


### PR DESCRIPTION
## Adjust check for backward compatibility mode on chapter detail

# Description
The method to know if the chapter action should be compatible with bible.is or gideons has changed. For now on, it will validate if the key belongs to bible.is or gideons to have access to this action. If the user key doesn't allow to bible.is or gideons it will return a 404 message.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-246

## How Do I QA This
- The next postman URL should return 404
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-05258ed5-7797-4cea-ad5e-fcfbf77e9147

- Bible.is success endpoint
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-89017364-bf03-4664-a314-a311bad52269

- Gideons success endpoint
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-d5a44215-1259-48c5-9a32-af9b6ca80ba4