### PR TITLE
FCBHDBP-247 v2_compat: library book should return testament in damid when input damid is six characters

### DIFF
--- a/app/Http/Controllers/Bible/BooksControllerV2.php
+++ b/app/Http/Controllers/Bible/BooksControllerV2.php
@@ -97,7 +97,10 @@ class BooksControllerV2 extends APIController
                     ->where('bible_id', $bible_id)
                     ->pluck('name', 'book_id');
                 foreach ($books as $key => $book) {
-                    $books[$key]->source_id       = $id;
+                    $testament_first_letter = $book->getTestamentFirstLetter($book->book_testament);
+                    $books[$key]->source_id       = $testament_first_letter && empty($testament)
+                        ? $id.$testament_first_letter
+                        : $id;
                     $books[$key]->bible_id        = $bible_id;
                     $books[$key]->number_chapters = $current_chapters[$key]->count();
                     $books[$key]->chapters        = $current_chapters[$key]->implode(',');

--- a/app/Models/Bible/Book.php
+++ b/app/Models/Bible/Book.php
@@ -410,6 +410,19 @@ class Book extends Model
         });
     }
 
+    public function getTestamentFirstLetter($book_testament = null)
+    {
+        if (is_null($book_testament)) {
+            $book_testament = $this->book_testament;
+        }
+
+        if (!empty($book_testament)) {
+            return substr($book_testament, 0, 1);
+        }
+
+        return null;
+    }
+
     public function translations()
     {
         return $this->hasMany(BookTranslation::class, 'book_id');


### PR DESCRIPTION
## v2_compat: library book should return testament in damid when input damid is six characters

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
It has updated the book action and added the testament to the damid parameter when it is only a six characters.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-247

## How Do I QA This
- The postman test for this endpoint should not return error
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-44183544-5641-4252-ae54-1d89b3343d21
