### PR TITLE
FCBHDBP-248 v2_compat: library version and library volume do not recognize all versions

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -271,14 +271,14 @@ class LibraryController extends APIController
 
             $versions = BibleFileset::where('asset_id', config('filesystems.disks.s3_fcbh.bucket'))
                 ->rightJoin('bible_fileset_connections as bibles', 'bibles.hash_id', 'bible_filesets.hash_id')
-                ->join('bible_translations as ver_title', function ($join) use ($name) {
+                ->join('bible_translations as ver_title', function ($join) {
                     $join->on('ver_title.bible_id', 'bibles.bible_id')->where('ver_title.vernacular', 1);
                 })
-                ->join('bible_translations as eng_title', function ($join) use ($english_id, $name) {
+                ->join('bible_translations as eng_title', function ($join) use ($english_id) {
                     $join->on('eng_title.bible_id', 'bibles.bible_id')->where('eng_title.language_id', $english_id);
                 })
                 ->when($code, function ($q) use ($code) {
-                    $q->where('bible_filesets.id', 'LIKE', '%' . $code)->get();
+                    $q->where('bible_filesets.id', 'LIKE', '%' . $code .'%')->get();
                 })->when($sort, function ($q) use ($sort) {
                     $q->orderBy($sort, 'asc');
                 })->select([
@@ -497,7 +497,7 @@ class LibraryController extends APIController
                     $query->where('bible_filesets.updated_at', '>', $updated);
                 })
                 ->when($version_code, function ($query) use ($version_code) {
-                    $query->whereRaw('SUBSTRING(bibles.id,4) = ?', [$version_code]);
+                    $query->where('bible_filesets.id', 'LIKE', '%' . $version_code .'%')->get();
                 })
                 ->when($organization, function ($query) use ($organization) {
                     $query->where('bible_organizations.organization_id', $organization);


### PR DESCRIPTION
## v2_compat: library version and library volume do not recognize all versions

# Description
It has modified the `volume` and `version` actions for the `LibraryController`. The goal is to update the filter by code and version_code to make sure that it includes the '%' wildcards on each side of the given code value.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-248

## How Do I QA This
- library version doesn't recognize version code
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0a80fa31-6342-401e-bcf2-b0d50c78f6bc

- library volume doesn't recognize version code
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-acae1b0b-9acc-484e-bab5-2cac5b4553b4
