### PR TITLE
FCBHDBP  [M] v2_compat / Priority Group 1 / library volume - hotfix

### DIFF
--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -160,7 +160,7 @@ class LibraryVolumeTransformer extends BaseTransformer
                     'num_art'                   => '0',
                     'num_sample_audio'          => '0',
                     'sku'                       => $fileset->meta->where('name', 'sku')->first()->description ?? '',
-                    'audio_zip_path'            => $fileset->secondary_file_type === 'zip' ? $fileset->secondary_file_path : null,
+                    'audio_zip_path'            => $fileset->audio_zip_path,
                     'font'                      => null,
                     'arclight_language_id'      => '', // (int) $fileset->arclight_code,
                     'media'                     => Str::contains($fileset->set_type_code, 'audio') ? 'audio' : 'text',


### PR DESCRIPTION
## [M] v2_compat / Priority Group 1 / library volume - hotfix

# Description
It has fixed a issues: I had a rebase conflict and the audio_zip_path had the old pattern. And I had not considered the case for the volume action where the language_id parameter is a value similar to ZZZZ so, it is not a language but the query was returning all records similar when there not filters.

## Issue Link


## How Do I QA This
Run [M] v2_compat / Priority Group 1 / library volume
