### PR TITLE
FCBHDBP-235 add support for text search on 6 char dam id

### DIFF
--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -170,6 +170,7 @@ class TextControllerV2 extends APIController
             'bible_verses.verse_start',
             'bible_verses.verse_end',
             'bible_verses.verse_text',
+            'book_testament',
             \DB::raw("'$fileset_id' as dam_id_request"),
         ];
         $verses = BibleVerse::where('hash_id', $fileset->hash_id)

--- a/app/Transformers/TextTransformer.php
+++ b/app/Transformers/TextTransformer.php
@@ -40,10 +40,21 @@ class TextTransformer extends BaseTransformer
              * )
              */
             case 'v2_text_search':
+                // This is a temporal fix while v2 transitions to v4
+                // It must return a damid longer than six characters, then it is using the request DAMID
+                $partial_testament_type = 'P';
+                $generalized_testament_types = ['NT', 'OT', 'C'];
+                $damid_with_testament = $text->dam_id_request;
+
+                if (strlen($text->dam_id_request) === 6 && in_array($text->book_testament, $generalized_testament_types)) {
+                    $testament_initial = substr($text->book_testament, 0, 1);
+                    $damid_with_testament = $text->dam_id_request . $testament_initial;
+                } else if (strlen($text->dam_id_request) === 6) {
+                    $damid_with_testament = $text->dam_id_request . $partial_testament_type;
+                }
+                
                 return [
-                    // It must return a damid longer than six characters, then it is using the request DAMID
-                    // to accomplish this goal
-                    'dam_id' => (string) $text->dam_id_request ?? $text->bible_id,
+                    'dam_id' => (string) $damid_with_testament ?? $text->bible_id,
                     'book_name' => (string) $text->book_name,
                     'book_id' => (string) $text->book_id,
                     'chapter_id' => (string) $text->chapter,


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
* Add validation needed for testament in text transformer v2
* All the data was already getting collected by the sql query, but the dam_id was incorrect

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-235) -->
[FCBHDBP-235](https://fullstacklabs.atlassian.net/browse/FCBHDBP-235) 

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-61308e9a-4854-4178-b991-89a1b62433ba

## Screenshots (if appropriate)
<!--- Add screenshots or delete this section -->
