### PR TITLE
FCBHDBP-191-v2 Add download endpoint for access to 18x and 19x content

### DIFF
--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -61,8 +61,9 @@ class BibleFilesetsDownloadController extends APIController
         $type  = checkParam('type') ?? '';
         $limit = (int) (checkParam('limit') ?? 5000);
         $limit = max($limit, 5000);
+        $key = $this->getKey();
 
-        $cache_params = $this->removeSpaceFromCacheParameters([$fileset_id, $book_id, $chapter]);
+        $cache_params = $this->removeSpaceFromCacheParameters([$fileset_id, $book_id, $chapter, $key]);
 
         $fileset_chapters = cacheRemember(
             $cache_key,

--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -6,6 +6,7 @@ use App\Models\User\AccessGroupKey;
 use App\Models\User\AccessGroupFileset;
 use App\Models\User\AccessType;
 use App\Models\User\Key;
+use App\Exceptions\ResponseException as Response;
 use DB;
 
 trait AccessControlAPI
@@ -186,7 +187,9 @@ trait AccessControlAPI
         );
 
         if (sizeof($allowed_fileset_for_download) === 0) {
-            return $this->setStatusCode(404)->replyWithError('Not found');
+            return $this
+                ->setStatusCode(Response::HTTP_FORBIDDEN)
+                ->replyWithError(Response::getStatusTextByCode(Response::HTTP_FORBIDDEN));
         }
     }
 }

--- a/app/Transformers/BibleFileSetsDownloadTransFormer.php
+++ b/app/Transformers/BibleFileSetsDownloadTransFormer.php
@@ -17,10 +17,10 @@ class BibleFileSetsDownloadTransFormer extends BaseTransformer
         switch ($this->route) {
             case 'v4_bible_filesets_download.list':
                 return [
-                    'type'      => (string) $fileset->type,
-                    'language'  => (string) $fileset->language,
-                    'licensor'  => (string) $fileset->licensor,
-                    'filesetid' => (string) $fileset->filesetid,
+                    'type'       => (string) $fileset->type,
+                    'language'   => (string) $fileset->language,
+                    'licensor'   => (string) $fileset->licensor,
+                    'fileset_id' => (string) $fileset->filesetid,
                 ];
             default:
                 return [];


### PR DESCRIPTION

# Description
It has change the index action response and It has renamed the filesetid column to fileset_id. It has included the key into the cache parameters for the index action.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-191

## How Do I QA This
- Execute download endpoint using runner
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-b17ae5d8-bb92-471c-8f72-9dabc5896fad
