### PR TITLE
FCBHDBP-233-257-261 v2_compat: library issues

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -287,7 +287,9 @@ class LibraryController extends APIController
                     'eng_title.name as eng_title',
                     'ver_title.name as ver_title',
                     'bible_filesets.id'
-                ])->get();
+                ])
+                ->distinct()
+                ->get();
             
             if ($name) {
                 $subsetVersions = $versions->where('eng_title', $name)->first();
@@ -301,7 +303,7 @@ class LibraryController extends APIController
         });
 
         return $this->reply(fractal(
-            isset($versions[0]) ? $versions[0] : [],
+            $versions,
             new LibraryVolumeTransformer(),
             $this->serializer
         ));

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -144,8 +144,11 @@ class BibleFileset extends Model
     {
         return $query
             ->join('bible_fileset_connections as connection', 'connection.hash_id', 'bible_filesets.hash_id')
-            ->join('bibles', 'connection.bible_id', 'bibles.id', function ($q) use ($language_id) {
-                $q->where('bibles.language_id', $language_id);
+            ->join('bibles', function ($q) use ($language_id) {
+                $q->on('connection.bible_id', 'bibles.id')
+                    ->when($language_id, function ($subquery) use ($language_id) {
+                        $subquery->where('bibles.language_id', $language_id);
+                    });
             })
             ->leftJoin('languages', 'bibles.language_id', 'languages.id')
             ->join('language_translations', function ($q) {

--- a/app/Transformers/V2/LibraryCatalog/LanguageListingTransformer.php
+++ b/app/Transformers/V2/LibraryCatalog/LanguageListingTransformer.php
@@ -30,13 +30,14 @@ class LanguageListingTransformer extends BaseTransformer
      */
     private $params = [];
 
-    function __construct($params = [])
+    public function __construct($params = [])
     {
+        parent::__construct();
         $this->params = $params;
     }
 
     public function transform($language)
-    {   
+    {
         $language_v2 = optional($this->params)['language_v2'];
         $code = $language_v2->v2Code ?? strtoupper($language->iso);
         $name = $language_v2->name ?? $language->name;
@@ -104,7 +105,7 @@ class LanguageListingTransformer extends BaseTransformer
                 return [
                     'language_code'        => $code,
                     'language_name'        => $name,
-                    'english_name'         => $language->name,
+                    'english_name'         => $english_name,
                     'language_iso'         => (string) $language->iso ?? '',
                     'language_iso_2B'      => $language->iso2B ?? '',
                     'language_iso_2T'      => $language->iso2B ?? '',

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -53,11 +53,9 @@ class LibraryVolumeTransformer extends BaseTransformer
 
             case 'v2_library_version':
                 return [
-                    [
-                        'version_code' => substr($fileset->id, 3) ?? '',
-                        'version_name' => $fileset->ver_title,
-                        'english_name' => $fileset->eng_title
-                    ]
+                    'version_code' => substr($fileset->id, 3) ?? '',
+                    'version_name' => $fileset->ver_title,
+                    'english_name' => $fileset->eng_title
                 ];
                 break;
 


### PR DESCRIPTION
# Description

- FCBHDBP-233 The library volume endpoint has been update to filter by language family code.

- FCBHDBP-257 The volumeLanguageFamily endpoint has been fixed to avoid to get a language v2 record if the language_code parameter is empty.

- FCBHDBP-261, the version endpoint has been fixed and it returns all available records now.

## Issue Link
- https://fullstacklabs.atlassian.net/browse/FCBHDBP-233
- https://fullstacklabs.atlassian.net/browse/FCBHDBP-257
- https://fullstacklabs.atlassian.net/browse/FCBHDBP-261


## How Do I QA This
Execute the next postman URLs

- FCBHDBP-233
https://digitalbibleplatform.postman.co/workspace/0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-233eb7bb-8dd6-460e-ac0b-49960dbee988

- FCBHDBP-257
https://digitalbibleplatform.postman.co/workspace/0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-da0f2aac-99bd-4700-9066-00c07e098571

- FCBHDBP-261
https://digitalbibleplatform.postman.co/workspace/0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-42398305-c5b9-40bb-9445-821096e54706

