### PR TITLE
FCBHDBP-261 v2_compat: library version with no filter should return all versions

### DIFF
--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -270,8 +270,10 @@ class LibraryController extends APIController
         $cache_params = $this->removeSpaceFromCacheParameters([$code, $name, $sort]);
         $versions = cacheRemember('v2_library_version', $cache_params, now()->addDay(), function () use ($code, $sort, $name) {
             $english_id = Language::where('iso', 'eng')->first()->id ?? '6414';
+            $formatted_name = $this->transformQuerySearchText($name);
+            $formatted_name = "+$formatted_name*";
 
-            $versions = BibleFileset::where('asset_id', config('filesystems.disks.s3_fcbh.bucket'))
+            return BibleFileset::where('asset_id', config('filesystems.disks.s3_fcbh.bucket'))
                 ->rightJoin('bible_fileset_connections as bibles', 'bibles.hash_id', 'bible_filesets.hash_id')
                 ->join('bible_translations as ver_title', function ($join) {
                     $join->on('ver_title.bible_id', 'bibles.bible_id')->where('ver_title.vernacular', 1);
@@ -288,18 +290,15 @@ class LibraryController extends APIController
                     'ver_title.name as ver_title',
                     'bible_filesets.id'
                 ])
+                ->when($name, function ($query_name) use ($formatted_name) {
+                    $query_name->where(function ($subquey_name) use ($formatted_name) {
+                        $subquey_name
+                            ->whereRaw('match (eng_title.name) against (? IN BOOLEAN MODE)', [$formatted_name])
+                            ->orWhereRaw('match (ver_title.name) against (? IN BOOLEAN MODE)', [$formatted_name]);
+                    });
+                })
                 ->distinct()
                 ->get();
-            
-            if ($name) {
-                $subsetVersions = $versions->where('eng_title', $name)->first();
-                if (!$subsetVersions) {
-                    $subsetVersions = $versions->where('ver_title', $name)->first();
-                }
-                $versions = [$subsetVersions];
-            }
-
-            return $versions;
         });
 
         return $this->reply(fractal(


### PR DESCRIPTION

# Description
It has fixed the endpoint version and the filter by name.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-261

## How Do I QA This
- The next postman URL should not return 500 code error
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-97570fc1-c810-45b4-b18d-2354a7fe76fa

