### PR TITLE
FCBHDBP-253 v2_compat: recognize v2 language codes not in DBP4

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -53,20 +53,21 @@ class LanguageControllerV2 extends APIController
         $cache_params = [$this->v, $code, $full_word, $name, $sort_by];
         $cached_languages = cacheRemember('languages', $cache_params, now()->addDay(), function () use ($code, $full_word, $name, $sort_by) {
             $language_v2 = !empty($code) ? $this->getV2Language($code) : null;
-            $v2_code = optional($language_v2)->language_ISO_639_3_id;
-            $languages = Language::select(['id', 'iso2B', 'iso', 'name'])->orderBy($sort_by)
-                ->when($code, function ($query) use ($code, $v2_code) {
-                    return $query->where('iso', $v2_code ?? $code);
-                })
-                ->has('filesets')
+            
+            $languages = Language::languageListingv2($code)
                 // Filter results by language name when set
+                ->orderBy($sort_by)
                 ->when($name, function ($query) use ($name, $full_word) {
                     return $query->whereHas('translations', function ($query) use ($name, $full_word) {
                         $added_space = ($full_word === 'true') ? ' ' : '';
                         $query->where('name', 'like', '%' . $name . $added_space . '%')->orWhere('name', $name);
                     });
                 })->get();
-            return fractal($languages, new LanguageListingTransformer(['language_v2' => $language_v2]), $this->serializer);
+            return fractal(
+                $languages,
+                new LanguageListingTransformer(['language_v2' => $language_v2]),
+                $this->serializer
+            );
         });
 
         return $this->reply($cached_languages);

--- a/app/Models/Language/Alphabet.php
+++ b/app/Models/Language/Alphabet.php
@@ -415,6 +415,13 @@ class Alphabet extends Model
 
     public function numerals()
     {
-        return $this->hasManyThrough(NumeralSystemGlyph::class, AlphabetNumeralSystem::class);
+        return $this->hasManyThrough(
+            NumeralSystemGlyph::class,
+            AlphabetNumeralSystem::class,
+            'script_id',
+            'numeral_system_id',
+            'script',
+            'numeral_system_id'
+        );
     }
 }

--- a/app/Models/Language/AlphabetNumeralSystem.php
+++ b/app/Models/Language/AlphabetNumeralSystem.php
@@ -9,4 +9,22 @@ class AlphabetNumeralSystem extends Model
     protected $table = 'alphabet_numeral_systems';
     protected $connection = 'dbp';
     public $incrementing = false;
+
+
+    /**
+     * @OA\Property(
+     *     title="Numeral system ID",
+     *     description="numeral system ID using for the languages",
+     *     type="string",
+     *     minLength=3,
+     *     example="Cans",
+     *     @OA\ExternalDocumentation(
+     *         description="For more info please refer to the Unicode Consortium",
+     *         url="https://http://www.unicode.org/iso15924/"
+     *     ),
+     * )
+     *
+     * @var string $numeral_system_id
+     */
+    protected $numeral_system_id;
 }

--- a/app/Transformers/V2/LibraryCatalog/LanguageListingTransformer.php
+++ b/app/Transformers/V2/LibraryCatalog/LanguageListingTransformer.php
@@ -47,13 +47,13 @@ class LanguageListingTransformer extends BaseTransformer
             case 'v2_library_volumeLanguage':
                 return [
                     'language_name'             => $language->autonym ?? '',
-                    'english_name'              => (string) $language->name,
+                    'english_name'              => (string) $english_name,
                     'language_code'             => $code,
                     'language_iso'              => (string) $language->iso ?? '',
                     'language_iso_2B'           => (string) $language->iso2B ?? '',
                     'language_iso_2T'           => (string) $language->iso2T ?? '',
                     'language_iso_1'            => (string) $language->iso1 ?? '',
-                    'language_iso_name'         => (string) $language->name ?? '',
+                    'language_iso_name'         => (string) $name ?? '',
                     'language_family_code'      => strtoupper(optional($language->parent)->iso) ?? '',
                     'language_family_name'      => optional($language->parent)->autonym ?? '',
                     'language_family_english'   => optional($language->parent)->name ?? '',
@@ -103,9 +103,9 @@ class LanguageListingTransformer extends BaseTransformer
 
             default:
                 return [
-                    'language_code'        => $code,
-                    'language_name'        => $name,
-                    'english_name'         => $english_name,
+                    'language_code'        => strtoupper($language->code),
+                    'language_name'        => $language->name_v2 ?? $language->name,
+                    'english_name'         => $language->english_name_v2 ?? $language->name,
                     'language_iso'         => (string) $language->iso ?? '',
                     'language_iso_2B'      => $language->iso2B ?? '',
                     'language_iso_2T'      => $language->iso2B ?? '',


### PR DESCRIPTION
# Description
It has added the support to include the old languages and current languages for the next endpoints:

- library/language 
- library/volume
- library/volumelanguage
- library/volumelanguagefamily
- country/countrylang
- library/numbers

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-253

## How Do I QA This
Execute the support dbp2 language codes group of test
