### PR TITLE
FCBHDBP-253 v2_compat: recognize v2 language codes not in DBP4

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -55,8 +55,8 @@ class LanguageControllerV2 extends APIController
             $language_v2 = !empty($code) ? $this->getV2Language($code) : null;
             
             $languages = Language::languageListingv2($code)
-                // Filter results by language name when set
                 ->orderBy($sort_by)
+                // Filter results by language name when set
                 ->when($name, function ($query) use ($name, $full_word) {
                     return $query->whereHas('translations', function ($query) use ($name, $full_word) {
                         $added_space = ($full_word === 'true') ? ' ' : '';


### PR DESCRIPTION

# Description
It has added the logic to make sure that LanguageListingv2 method uses the same db connection that the query context given is using.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-253

## How Do I QA This
- The next post url should not return an error 500.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-d31e3984-efee-441f-bcca-26972bafc8be
