### PR TITLE
FCBHDBP-260 fix batch of errors found in NewRelic

### DIFF
--- a/app/Http/Controllers/ApiKey/DashboardController.php
+++ b/app/Http/Controllers/ApiKey/DashboardController.php
@@ -10,6 +10,7 @@ use App\Models\User\KeyRequest;
 use App\Models\User\AccessGroupKey;
 
 use Illuminate\Support\Facades\Validator;
+use App\Exceptions\ResponseException as Response;
 use Auth;
 use Exception;
 
@@ -227,10 +228,15 @@ class DashboardController extends APIController
             $key_request->save();
 
             $target_key = Key::where('key', $key)->first();
-            AccessGroupKey::where('key_id', $target_key->id)->delete();
-            $deleted_key = $target_key->delete();
 
-            return $target_key;
+            if (empty($target_key)) {
+                return $this->setStatusCode(Response::HTTP_NOT_FOUND)->replyWithError(
+                    'Key doesn\'t exist'
+                );
+            }
+
+            AccessGroupKey::where('key_id', $target_key->id)->delete();
+            return $target_key->delete();
         }
     }
 

--- a/app/Http/Controllers/Bible/BooksControllerV2.php
+++ b/app/Http/Controllers/Bible/BooksControllerV2.php
@@ -104,7 +104,9 @@ class BooksControllerV2 extends APIController
                     $books[$key]->bible_id        = $bible_id;
                     $books[$key]->number_chapters = $current_chapters[$key]->count();
                     $books[$key]->chapters        = $current_chapters[$key]->implode(',');
-                    $books[$key]->name            = $book_translation[$book->id];
+                    $books[$key]->name            = isset($book_translation[$book->id])
+                        ? $book_translation[$book->id]
+                        : '';
                 }
 
                 return fractal($books, new BookTransformer(), $this->serializer);

--- a/app/Http/Controllers/User/HighlightsController.php
+++ b/app/Http/Controllers/User/HighlightsController.php
@@ -17,6 +17,7 @@ use Validator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 class HighlightsController extends APIController
 {
@@ -111,6 +112,10 @@ class HighlightsController extends APIController
         $sort_by    = checkParam('sort_by') ?? 'book';
         $sort_dir   = checkParam('sort_dir') ?? 'asc';
         $query      = checkParam('query');
+
+        if (!in_array(Str::lower($sort_dir), ['asc', 'desc'])) {
+            $sort_dir = 'desc';
+        }
 
         // Validate Project / User Connection
         $user = User::where('id', $user_id)->select('id')->first();

--- a/app/Http/Controllers/User/PasswordsController.php
+++ b/app/Http/Controllers/User/PasswordsController.php
@@ -192,7 +192,9 @@ class PasswordsController extends APIController
 
         if ($request->token_id) {
             $reset = PasswordReset::where('email', $user->email)->where('token', $request->token_id)->first();
-            $reset->delete();
+            if (!empty($reset)) {
+                $reset->delete();
+            }
         }
 
         if ($this->api) {

--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -27,6 +27,7 @@ use Validator;
 use Illuminate\Support\Facades\Auth;
 
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use App\Exceptions\ResponseException as Response;
 
 class UsersController extends APIController
 {
@@ -859,7 +860,7 @@ class UsersController extends APIController
         $validator = Validator::make(request()->all(), $rules);
 
         if ($validator->fails()) {
-            return $this->setStatusCode(422)->replyWithError(
+            return $this->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY)->replyWithError(
                 $validator->errors()
             );
         }

--- a/app/Transformers/V2/CountryLanguageTransformer.php
+++ b/app/Transformers/V2/CountryLanguageTransformer.php
@@ -2,9 +2,9 @@
 
 namespace App\Transformers\V2;
 
-use League\Fractal\TransformerAbstract;
+use App\Transformers\BaseTransformer;
 
-class CountryLanguageTransformer extends TransformerAbstract
+class CountryLanguageTransformer extends BaseTransformer
 {
     /**
      * A Fractal transformer.
@@ -14,8 +14,9 @@ class CountryLanguageTransformer extends TransformerAbstract
 
     private $params = [];
 
-    function __construct($params = [])
+    public function __construct($params = [])
     {
+        parent::__construct();
         $this->params = $params;
     }
 


### PR DESCRIPTION
# Description
It has added fixes for 5 newrelic issues reported for dbp v4.

The next issues was handling in this ticket:

- `Exception 'InvalidArgumentException' with message 'Order direction must be "asc" or "desc".' in /var/app/current/vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php:1984`

- `Exception 'ErrorException' with message 'Undefined array key "language_v2"' in /var/app/current/app/Transformers/V2/CountryLanguageTransformer.php:44`

- `Exception 'ErrorException' with message 'Attempt to read property "id" on null' in /var/app/current/app/Http/Controllers/ApiKey/DashboardController.php:230`

- `Exception 'ErrorException' with message 'Undefined array key "GEN"' in /var/app/current/vendor/laravel/framework/src/Illuminate/Collections/Collection.php:1595`

- `Exception 'Error' with message 'Call to a member function delete() on null' in /var/app/current/app/Http/Controllers/User/PasswordsController.php:195`

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-260

## How Do I QA This
- Get highlights with sort_dir incorrect and it shouldn't get an error.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e42d08c3-3695-4162-9f3d-96a40e451097

- Denied an API  key request.

- Execute the country/countrylang endpoint and it should keep working.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-dedf0d9d-a407-4aa4-82c7-a79a924882f8

- Execute the library/book endpoint and it should keep working.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-001f6e62-6516-4958-bb7b-654dcaaabd67

- Try to reset your password and it should work ok.
