### PR TITLE
FCBHDBP-263 v2_compat: library / version returns incorrect results

### DIFF
--- a/app/Models/Bible/Version.php
+++ b/app/Models/Bible/Version.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models\Bible;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * App\Models\Bible\Version
+ *
+ * @property-read \App\Models\Bible\Version $version
+ * @mixin \Eloquent
+ *
+ * @OA\Schema (
+ *     type="object",
+ *     description="Information regarding bible version",
+ *     title="Version",
+ *     @OA\Xml(name="Version")
+ * )
+ *
+ */
+class Version extends Model
+{
+    protected $connection = 'dbp';
+    protected $table = 'version';
+    protected $keyType = 'string';
+    protected $fillable = ['id', 'name', 'english_name'];
+
+    /**
+     *
+     * @OA\Property(
+     *   title="id",
+     *   type="string",
+     * )
+     *
+     * @property int $id
+     * @method static Version whereId($value)
+     *
+     */
+    protected $id;
+
+    /**
+     *
+     * @OA\Property(
+     *   title="name",
+     *   type="string",
+     *   example="ab",
+     *   description="The name for the version"
+     * )
+     *
+     * @property string $name
+     * @method static Version whereName($value)
+     *
+     */
+
+    protected $name;
+
+    /**
+     *
+     * @OA\Property(
+     *   title="english_name",
+     *   type="string",
+     *   example="ab",
+     *   description="The english_name for the version"
+     * )
+     *
+     * @property string $english_name
+     * @method static Version whereEnglishName($value)
+     *
+     */
+    protected $english_name;
+
+    public function scopeAll($query, $english_id)
+    {
+        return $query
+            ->select(['id', 'name', 'english_name'])
+            ->whereIn('id', function ($query) use ($english_id) {
+                $query->select(\DB::raw('SUBSTR(bt.bible_id, 4, 3)'))
+                    ->from('bible_translations as bt')
+                    ->where('bt.language_id', $english_id);
+            });
+    }
+
+    public function scopeFilterableByNameOrEnglishName($query, $search_text)
+    {
+        return $query->when($search_text, function ($query) use ($search_text) {
+            $formatted_name = "+$search_text*";
+            $query->whereRaw(
+                'match (version.name, version.english_name) against (? IN BOOLEAN MODE)',
+                [$formatted_name]
+            );
+        });
+    }
+}

--- a/app/Transformers/V2/LibraryVolumeTransformer.php
+++ b/app/Transformers/V2/LibraryVolumeTransformer.php
@@ -53,9 +53,9 @@ class LibraryVolumeTransformer extends BaseTransformer
 
             case 'v2_library_version':
                 return [
-                    'version_code' => substr($fileset->id, 3) ?? '',
-                    'version_name' => $fileset->ver_title,
-                    'english_name' => $fileset->eng_title
+                    'version_code' => $fileset->id,
+                    'version_name' => $fileset->name,
+                    'english_name' => $fileset->english_name
                 ];
                 break;
 

--- a/database/migrations/2021_12_20_170429_create_version_v2.php
+++ b/database/migrations/2021_12_20_170429_create_version_v2.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateVersionV2 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!\Schema::connection('dbp')->hasTable('version')) {
+            Schema::create('version', function (Blueprint $table) {
+                $table->char('id', 3)->index()->unique();
+                $table->string('name');
+                $table->string('english_name');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('version');
+    }
+}

--- a/database/migrations/2021_12_20_173946_create_version_v2_fulltext_index.php
+++ b/database/migrations/2021_12_20_173946_create_version_v2_fulltext_index.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateVersionV2FulltextIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (\Schema::connection('dbp')->hasTable('version')) {
+            DB::connection('dbp')
+                ->statement('ALTER TABLE version ADD FULLTEXT ft_index_version_name_english_name(name, english_name)');
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('ft_index_version_name_english_name');
+    }
+}


### PR DESCRIPTION
# Description
It has created a new entity called version. This new entity will be used into the version action for the Library Controller. The current implementation is wrong.

### NOTE:

We need to create a full text index for the columns name and english_name. We need to execute the next migration into the server (prod and dev).

```bash
php artisan migrate --path=/database/migrations/2021_12_20_173946_create_version_v2_fulltext_index.php
```
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-263

## How Do I QA This
- The next postman test should not return error.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f9e0b9da-bd56-47f2-a225-ee729e5c79c4
