### PR TITLE
FCBHDBP-257 v2_compat: library / volumelanguagefamily returns nothing

### DIFF
--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -386,8 +386,10 @@ class LanguageControllerV2 extends APIController
         $media           = checkParam('media');
         $organization_id = checkParam('organization_id');
 
-        $cache_params = [$root, $iso, $media, $organization_id];
-        $languages = cacheRemember('volumeLanguageFamily', $cache_params, now()->addDay(), function () use ($root, $iso, $media, $organization_id) {
+        $key = $this->key;
+
+        $cache_params = [$root, $iso, $media, $organization_id, $key];
+        $languages = cacheRemember('volumeLanguageFamily', $cache_params, now()->addDay(), function () use ($root, $iso, $media, $organization_id, $key) {
             $language_v2 = !empty($iso) ? $this->getV2Language($iso) : null;
             $v2_code = optional($language_v2)->language_ISO_639_3_id;
 
@@ -395,7 +397,7 @@ class LanguageControllerV2 extends APIController
                 ->includeAutonymTranslation()
                 ->includeCurrentTranslation()
                 ->withRequiredFilesets([
-                    'key'             => $this->key,
+                    'key'             => $key,
                     'media'           => $media,
                     'organization_id' => $organization_id
                 ])


### PR DESCRIPTION
# Description
It has added the user_key to the cache parameters to the `volumeLanguageFamily` endpoint. You can re-create this issue in prod.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-257

## How Do I QA This
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-da0f2aac-99bd-4700-9066-00c07e098571
