### PR TITLE
FCBHDBP-266 Add feature to filter languages search by  bible_fileset media type (audio/video)

### DIFF
--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -191,6 +191,8 @@ class LanguagesController extends APIController
         $page  = checkParam('page') ?? 1;
         $limit = (int) (checkParam('limit') ?? 15);
         $limit = min($limit, 50);
+        $set_type_code = checkParam('set_type_code');
+        $media = checkParam('media');
         $formatted_search_cache = str_replace(' ', '', $search_text);
         $formatted_search = $this->transformQuerySearchText($search_text);
 
@@ -213,8 +215,8 @@ class LanguagesController extends APIController
             'languages_search',
             $cache_params,
             now()->addDay(),
-            function () use ($formatted_search, $limit, $key) {
-                $languages = Language::filterableByNameAndKey($formatted_search, $key)
+            function () use ($formatted_search, $limit, $key, $set_type_code, $media) {
+                $languages = Language::filterableByNameAndKey($formatted_search, $key, $set_type_code, $media)
                     ->select([
                         'languages.id',
                         'languages.glotto_id',


### PR DESCRIPTION

# Description
added the media and set_type_code filter to the languages search endpoint. It has added the media filter to the language search endpoint. Also, **It has replaced some raw queries to use the query builder.**

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-266

## How Do I QA This
- Execute the next postman URL: languages search with filter set_type_code video_drama by name
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b063e093-a95c-493a-b3b5-20ea298bb49d

- Execute the next postman URL: languages search with filter media video
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ed2f8c3a-d557-4ad2-b268-2615fd313a9c

- Execute the next postman URL: languages search with filter media video - empty
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-925a6a1a-724b-49a7-9083-b5ba8f9da87c