### PR TITLE
FCBHDBP-269 v2_compat: modify /audio/location to return CDN reference instead of S3 reference

### DIFF
--- a/app/Http/Controllers/Bible/AudioControllerV2.php
+++ b/app/Http/Controllers/Bible/AudioControllerV2.php
@@ -241,7 +241,7 @@ class AudioControllerV2 extends APIController
                 'protocol'  => 'http',
                 'CDN'       => '1',
                 'priority'  => '5',
-            ],            
+            ],
         ]);
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -85,7 +85,7 @@ return [
     // CDN server
     'cdn' => [
         'server' => env('CDN_SERVER', 'content.cdn.dbp-prod.dbp4.org'),
-        'server_v2' => env('CDN_SERVER_V2', 'fcbhabdm.s3.amazonaws.com'),
+        'server_v2' => env('CDN_SERVER_V2', 'cloud.faithcomesbyhearing.com'),
         'video_server' => env('CDN_VIDEO_SERVER', 'content.cdn.dbp-vid.dbp4.org'),
         'video_server_v2' => env('CDN_VIDEO_SERVER_V2', 'video.dbt.io'),
         'fonts_server' => env('CDN_FONTS_SERVER', 'cdn.bible.build'),


### PR DESCRIPTION

# Description
It has updated the audio/location endpoint. It will return CDN locations instead of S3 locations.

# NOTE:
We need to update the .env file with the next value:
```env
.
.
CDN_SERVER_V2=cloud.faithcomesbyhearing.com
.
``` 
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-269

## How Do I QA This
- The next postman URL should pass the tests:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-222b1fb0-9d1a-42bc-897c-f9c814be4e17
