### PR TITLE
FCBHDBP-256 shave response time on v4_media_stream_ts

### DIFF
--- a/app/Traits/CallsBucketsTrait.php
+++ b/app/Traits/CallsBucketsTrait.php
@@ -38,6 +38,21 @@ trait CallsBucketsTrait
             return $security_token;
         }
     }
+
+    /**
+     * Get a CloudFrontClient object for a given asset ID
+     *
+     * @param string $asset_id
+     *
+     * @return CloudFrontClient client
+     */
+    public function getCloudFrontClientFromAssetId(string $asset_id) : ?CloudFrontClient
+    {
+        $asset = Asset::where('id', $asset_id)->first();
+
+        return !empty($asset) ? $this->authorizeAWS($asset->asset_type) : null;
+    }
+
     /**
      * Method to sign a URL but the CloudFrontClient object should be passed by parameter
      * to do an only one call to AWS


### PR DESCRIPTION

# Description
It has improved the `transportStream` action that belongs to the `StreamController`. It has rearranged the logic to find the `fileset`. Also, It has removed the `signedUrl` method from the loop and It added the `signedUrlUsingClient` method which is called with the authenticated client as parameter.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-256

## How Do I QA This
- Execute the next postman URL and the time response should be around 1 second.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e7b7585d-d483-4523-bdc1-a0d8c8ba0f4e
