### PR TITLE
FCBHDBP-291 optimize plans/reset

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Plan;
 
+use Spatie\Fractalistic\ArraySerializer;
 use App\Traits\AccessControlAPI;
 use App\Http\Controllers\APIController;
 use App\Http\Controllers\Playlist\PlaylistsController;
@@ -12,6 +13,7 @@ use App\Traits\CheckProjectMembership;
 use App\Models\Plan\PlanDay;
 use App\Models\Plan\UserPlan;
 use App\Models\Playlist\Playlist;
+use App\Transformers\PlanTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
@@ -102,9 +104,9 @@ class PlansController extends APIController
 
         $language_id = null;
         if ($iso !== null) {
-          $language_id = cacheRemember('v4_language_id_from_iso', [$iso], now()->addDay(), function () use ($iso) {
-              return optional(Language::where('iso', $iso)->select('id')->first())->id;
-          });
+            $language_id = cacheRemember('v4_language_id_from_iso', [$iso], now()->addDay(), function () use ($iso) {
+                return optional(Language::where('iso', $iso)->select('id')->first())->id;
+            });
         }
 
         return $this->reply($this->getPlans($featured, $limit, $sort_by, $sort_dir, $user, $language_id));
@@ -643,6 +645,7 @@ class PlansController extends APIController
      *              @OA\Property(property="start_date", type="string")
      *          )
      *     )),
+     *     @OA\Parameter(name="save_progress", in="query"),
      *     @OA\Response(response=200, ref="#/components/responses/plan")
      * )
      *
@@ -674,9 +677,18 @@ class PlansController extends APIController
         }
 
         $start_date = checkParam('start_date');
+        $save_progress = checkParam('save_progress', false);
 
-        $user_plan->reset($start_date)->save();
-        $plan = $this->getPlan($plan->id, $user);
+        $plan = \DB::transaction(function () use ($user, $plan, $user_plan, $save_progress, $start_date) {
+            $user_plan->reset($start_date, $save_progress, $user->id)->save();
+            return fractal(
+                $plan,
+                new PlanTransformer(
+                    ['user' => $user, 'user_plan' => $user_plan]
+                ),
+                new ArraySerializer()
+            );
+        });
         return $this->reply($plan);
     }
 

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -118,9 +118,9 @@ class PlaylistsController extends APIController
         
         $language_id = null;
         if ($iso !== null) {
-          $language_id = cacheRemember('v4_language_id_from_iso', [$iso], now()->addDay(), function () use ($iso) {
-              return optional(Language::where('iso', $iso)->select('id')->first())->id;
-          });
+            $language_id = cacheRemember('v4_language_id_from_iso', [$iso], now()->addDay(), function () use ($iso) {
+                return optional(Language::where('iso', $iso)->select('id')->first())->id;
+            });
         }
         
         if ($featured) {
@@ -1378,7 +1378,7 @@ class PlaylistsController extends APIController
         $playlist_item->setAttribute('chapter_start', $chapter);
         $playlist_item->setAttribute('chapter_end', $chapter);
         $playlist_item->setAttribute('verse_start', $verse_start);
-        $playlist_item->setAttribute('verse_end',  $verse_end);
+        $playlist_item->setAttribute('verse_end', $verse_end);
         $playlist_item->calculateVerses();
         $playlist_item->calculateDuration();
 

--- a/app/Models/Plan/PlanDay.php
+++ b/app/Models/Plan/PlanDay.php
@@ -205,4 +205,23 @@ class PlanDay extends Model implements Sortable
             })
             ->whereNull('plan_days_completed.plan_day_id');
     }
+
+    /**
+     * Get the Play List IDs attached to a Plan and an User
+     *
+     * @param int $plan_id
+     * @param int $user_id
+     *
+     * @return Array
+     */
+    public static function getPlanDayIdsByPlanAndUser(int $plan_id, int $user_id) : Array
+    {
+        return PlanDay::select('playlist_id')
+            ->join('plan_days_completed as pdc', 'pdc.plan_day_id', 'plan_days.id')
+            ->where('plan_days.plan_id', $plan_id)
+            ->where('pdc.user_id', $user_id)
+            ->get()
+            ->pluck('playlist_id')
+            ->all();
+    }
 }

--- a/app/Models/Plan/PlanDayComplete.php
+++ b/app/Models/Plan/PlanDayComplete.php
@@ -55,4 +55,25 @@ class PlanDayComplete extends Model
 
         return $this->getAttribute($keyName);
     }
+
+    /**
+     * Remove the plan days completed records that belong to a Plan and an User
+     *
+     * @param int $plan_id
+     * @param int $user_id
+     *
+     * @return bool
+     */
+    public static function removeDaysByPlanAndUser(int $plan_id, int $user_id) : bool
+    {
+        return self::select('plan_day_id')
+            ->whereExists(function ($sub_query) use ($plan_id) {
+                return $sub_query->select(\DB::raw(1))
+                    ->from('plan_days as pld')
+                    ->where('pld.plan_id', $plan_id)
+                    ->whereColumn('pld.id', '=', 'plan_days_completed.plan_day_id');
+            })
+            ->where('user_id', $user_id)
+            ->delete();
+    }
 }

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -136,7 +136,7 @@ class UserPlan extends Model
      */
     public function reset(string $start_date = null, bool $save_progress = false, ?int $user_id = null) : UserPlan
     {
-        if ($save_progress) {
+        if ($save_progress === false) {
             if (is_null($user_id)) {
                 $user = Auth::user();
                 $user_id = $user->id;

--- a/app/Models/Playlist/PlaylistItemsComplete.php
+++ b/app/Models/Playlist/PlaylistItemsComplete.php
@@ -55,4 +55,24 @@ class PlaylistItemsComplete extends Model
 
         return $this->getAttribute($keyName);
     }
+
+    /**
+     * Remove the Play List Items completed records that belong to one or more Play lists and an User
+     *
+     * @param Array $playlist_ids
+     * @param int   $user_id
+     *
+     * @return bool
+     */
+    public static function removeItemsByPlayListsAndUser(Array $playlist_ids, int $user_id) : bool
+    {
+        return self::whereExists(function ($sub_query) use ($playlist_ids) {
+            return $sub_query->select(\DB::raw(1))
+                ->from('playlist_items as pli', 'pli.playlist_id', 'pld.playlist_id')
+                ->whereIn('pli.playlist_id', $playlist_ids)
+                ->whereColumn('pli.id', '=', 'playlist_items_completed.playlist_item_id');
+        })
+            ->where('user_id', $user_id)
+            ->delete();
+    }
 }

--- a/app/Transformers/PlanTransformer.php
+++ b/app/Transformers/PlanTransformer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Transformers;
+
+class PlanTransformer extends BaseTransformer
+{
+    private $params = [];
+
+    public function __construct($params = [])
+    {
+        parent::__construct();
+        $this->params = $params;
+    }
+
+    /**
+     * A Fractal transformer.
+     *
+     * @return array
+     */
+    public function transform($plan)
+    {
+        return [
+            "id"        => $plan->id,
+            "name"      => $plan->name,
+            "thumbnail" => $plan->thumbnail,
+            "featured"  => $plan->featured,
+            "suggested_start_date"  => $plan->suggested_start_date,
+            "draft"                 => $plan->draft,
+            "created_at"            => $plan->created_at,
+            "start_date"            => isset($this->params['start_date'])
+                ? $this->params['start_date']
+                : $this->params['user_plan']->start_date,
+            "percentage_completed"  => $this->params['user_plan']->percentage_completed,
+            "user"                  => [
+                "id"   => $this->params['user']->id,
+                "name" => $this->params['user']->name,
+            ],
+        ];
+    }
+}

--- a/app/Transformers/PlanTransformer.php
+++ b/app/Transformers/PlanTransformer.php
@@ -20,21 +20,28 @@ class PlanTransformer extends BaseTransformer
     public function transform($plan)
     {
         return [
-            "id"        => $plan->id,
-            "name"      => $plan->name,
-            "thumbnail" => $plan->thumbnail,
-            "featured"  => $plan->featured,
-            "suggested_start_date"  => $plan->suggested_start_date,
-            "draft"                 => $plan->draft,
-            "created_at"            => $plan->created_at,
-            "start_date"            => isset($this->params['start_date'])
+            "id"         => $plan->id,
+            "name"       => $plan->name,
+            "thumbnail"  => $plan->thumbnail,
+            "featured"   => $plan->featured,
+            "suggested_start_date" => $plan->suggested_start_date,
+            "draft"      => $plan->draft,
+            "created_at" => $plan->created_at,
+            "start_date" => isset($this->params['start_date'])
                 ? $this->params['start_date']
                 : $this->params['user_plan']->start_date,
-            "percentage_completed"  => $this->params['user_plan']->percentage_completed,
-            "user"                  => [
+            "percentage_completed" => $this->params['user_plan']->percentage_completed,
+            "user" => [
                 "id"   => $this->params['user']->id,
                 "name" => $this->params['user']->name,
             ],
+            "days" => $this->params['days']->map(function ($day) {
+                return [
+                    "id"          => $day->id,
+                    "playlist_id" => $day->playlist_id,
+                    "completed"   => (bool) $day->completed
+                ];
+            })
         ];
     }
 }


### PR DESCRIPTION

# Description
The reset action from `PlansController` has been refactored It has added two queries to remove the plan days completed and playlist completed records and it has improved the performance. It has also changed the response of endpoint and it won't return the entire plan object.

Furthermore,  It has done a refactor for the `getPlan` method from `PlansController` and It has added the logic into the `planDay` model to avoid to do a query to compute the completed attribute if the value is set before

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-291

## How Do I QA This
- You can execute the next postman folder to simulate the flow to complete an entire plan and after to reset it.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-b8f88bba-bf61-44e3-b0e9-0b6e2db44db0

## Screenshots
In the next screenshot you can see the response time and the two delete queries that will execute to reset the plan.
![screenshot-localhost_8080-2022 01 11-23_31_46](https://user-images.githubusercontent.com/73488660/149186335-b83e4356-a276-4203-b9e4-2914d6a9ae17.png

