### PR TITLE
FCBHDBP-291 optimize plans/reset

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -625,14 +625,14 @@ class PlansController extends APIController
         $user_plan->calculatePercentageCompleted()->save();
 
         return $this->reply([
-            'percentage_completed' => $user_plan->percentage_completed,
+            'percentage_completed' => (int) $user_plan->percentage_completed,
             'message' => 'Plan Day ' . $result
         ]);
     }
     /**
      * Reset the specified plan.
      *
-     *  @OA\Post(
+     * @OA\Post(
      *     path="/plans/{plan_id}/reset",
      *     tags={"Plans"},
      *     summary="Reset a plan",
@@ -642,7 +642,8 @@ class PlansController extends APIController
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\RequestBody(@OA\MediaType(mediaType="application/json",
      *          @OA\Schema(
-     *              @OA\Property(property="start_date", type="string")
+     *              required={"start_date"},
+     *              @OA\Property(property="start_date", type="string", ref="#/components/schemas/UserPlan/properties/start_date")
      *          )
      *     )),
      *     @OA\Parameter(name="save_progress", in="query"),
@@ -675,7 +676,7 @@ class PlansController extends APIController
             return $this->setStatusCode(404)->replyWithError('User Plan Not Found');
         }
 
-        $start_date = checkParam('start_date');
+        $start_date = checkParam('start_date', true);
         $save_progress = checkParam('save_progress', false) ?? false;
 
         $plan = \DB::transaction(function () use ($user, $plan, $user_plan, $save_progress, $start_date) {

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -772,7 +772,7 @@ class PlaylistsController extends APIController
             $user_plan->calculatePercentageCompleted()->save();
 
             return $this->reply([
-                'percentage_completed' => $user_plan->percentage_completed,
+                'percentage_completed' => (int) $user_plan->percentage_completed,
                 'message' => 'Playlist Item ' . $result
             ]);
         });

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -143,9 +143,9 @@ class UserPlan extends Model
             }
 
             self::removePlanDaysCompleteByPlanId($this->plan_id, $user_id);
+            $this->attributes['percentage_completed'] = 0;
         }
 
-        $this->attributes['percentage_completed'] = 0;
         $this->attributes['start_date'] = $start_date;
 
         return $this;

--- a/app/Transformers/PlanTransformer.php
+++ b/app/Transformers/PlanTransformer.php
@@ -30,7 +30,7 @@ class PlanTransformer extends BaseTransformer
             "start_date" => isset($this->params['start_date'])
                 ? $this->params['start_date']
                 : $this->params['user_plan']->start_date,
-            "percentage_completed" => $this->params['user_plan']->percentage_completed,
+            "percentage_completed" => (int) $this->params['user_plan']->percentage_completed,
             "user" => [
                 "id"   => $this->params['user']->id,
                 "name" => $this->params['user']->name,


### PR DESCRIPTION
# Description
Fixed the logic to make sure the percent completed needs to remain with the same value as it was on the old user plan and if the save_progress flag is true. Also, it has updated the endpoints: `reset`, `completeItem` and `completeDay` to keep the consistent for the percent completed value.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-291

## How Do I QA This
- We need to execute the next postman folder
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-d0ea423c-87bf-4367-ae07-75faaa66ee3d

