### PR TITLE
FCBHDBP-291 optimize plans/reset

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -678,6 +678,7 @@ class PlansController extends APIController
 
         $start_date = checkParam('start_date', true);
         $save_progress = checkParam('save_progress', false) ?? false;
+        $save_progress = filter_var($save_progress, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 
         $plan = \DB::transaction(function () use ($user, $plan, $user_plan, $save_progress, $start_date) {
             $user_plan->reset($start_date, $save_progress, $user->id)->save();


### PR DESCRIPTION

# Description
Fixed the logic to make sure the percent completed needs to remain with the same value as it was on the old user plan and if the save_progress flag is true. It has used `filter_var` method to cast false string to boolean value.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-291

## How Do I QA This
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0f09f27e-8c05-4807-a31a-4326bb0aa31a
