### PR TITLE
FCBHDBP-292 optimize plan days complete

### DIFF
--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -145,7 +145,7 @@ class Playlist extends Model
      */
     public function getVersesAttribute()
     {
-        if (sizeof($this->items) > 0) {
+        if ($this->relationLoaded('items') && sizeof($this->items) > 0) {
             return $this->items->sum('verses');
         }
 

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -575,4 +575,29 @@ class PlaylistItems extends Model implements Sortable
                 ->where('playlist_items_completed.user_id', $user_id);
         });
     }
+
+    /**
+     * Get query with all items that have NOT been completed for a plan day and a specific user
+     *
+     * @param Builder $query
+     * @param int $plan_day_id
+     * @param int $user_id
+     *
+     * @return Builder
+     */
+    public function scopeWithItemsToCompleteByPlanDayAndUser(
+        Builder $query,
+        int $plan_day_id,
+        int $user_id
+    ) : Builder {
+        return $query
+            ->join('plan_days as pld', 'playlist_items.playlist_id', 'pld.playlist_id')
+            ->leftJoin('playlist_items_completed as pldc', function ($query_join) use ($user_id) {
+                $query_join
+                    ->on('pldc.playlist_item_id', '=', 'playlist_items.id')
+                    ->where('pldc.user_id', $user_id);
+            })
+            ->where('pld.id', $plan_day_id)
+            ->whereNull('pldc.playlist_item_id');
+    }
 }

--- a/app/Models/Playlist/PlaylistItemsComplete.php
+++ b/app/Models/Playlist/PlaylistItemsComplete.php
@@ -75,4 +75,25 @@ class PlaylistItemsComplete extends Model
             ->where('user_id', $user_id)
             ->delete();
     }
+
+    /**
+     * Get query with all items completed for a plan day and a specific user
+     *
+     * @param Builder $query
+     * @param int $plan_day_id
+     * @param int $user_id
+     *
+     * @return Builder
+     */
+    public function scopeWithItemsCompletedByPlanDayAndUser(
+        Builder $query,
+        int $plan_day_id,
+        int $user_id
+    ) : Builder {
+        return $query
+            ->join('playlist_items', 'playlist_items.id', 'playlist_items_completed.playlist_item_id')
+            ->join('plan_days as pld', 'playlist_items.playlist_id', 'pld.playlist_id')
+            ->where('pld.id', $plan_day_id)
+            ->where('playlist_items_completed.user_id', $user_id);
+    }
 }


### PR DESCRIPTION

# Description
It has done a refactor to improve the `completeDay` action. It has changed the methods: complete and `uncomplete` to avoid executing a insert query for each playlist item that belongs to a Plan Day. So, it will execute a single insert query to complete all playlist items for a specific day.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-292

## How Do I QA This
- Execute the folder fixture for plan setup and the last test about the fixture.7 should pass.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-b7212767-bd07-47d2-9c36-528fb2e3fa55
- After execute the above postman URL should execute the next URL to uncomplete the Plan Day.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-14414e58-f28a-4433-a5c6-02b450e4e2f2