### PR TITLE
FCBHDBP-149 optimize plan.translate

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -302,19 +302,8 @@ class PlansController extends APIController
             foreach ($plan->days as $day) {
                 if (isset($playlists[$day->playlist_id])) {
                     $day->playlist = $playlists[$day->playlist_id];
-                    $day->playlist->path = route(
-                        'v4_internal_playlists.hls',
-                        ['playlist_id'  => $day->playlist->id, 'v' => $this->v, 'key' => $this->key]
-                    );
                     if (isset($day->playlist->items)) {
                         $day->playlist->items = $day->playlist->items->map(function ($item) use ($show_text) {
-                            if (isset($item->fileset, $item->fileset->bible)) {
-                                $bible = $item->fileset->bible->first();
-                                if ($bible) {
-                                    $item->bible_id = $bible->id;
-                                }
-                            }
-
                             if ($show_text) {
                                 $item->verse_text = $item->getVerseText();
                             }
@@ -978,7 +967,7 @@ class PlansController extends APIController
             'draft'                 => $draft,
             'suggested_start_date'  => $plan->suggested_start_date,
             'thumbnail'             => $plan->thumbnail,
-            'language_id'           => $plan->language_id,
+            'language_id'           => $bible->language_id,
         ];
 
         $new_plan = Plan::create($plan_data);

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -13,6 +13,7 @@ use App\Traits\CheckProjectMembership;
 use App\Models\Plan\PlanDay;
 use App\Models\Plan\UserPlan;
 use App\Models\Playlist\Playlist;
+use App\Models\Playlist\PlaylistItems;
 use App\Transformers\PlanTransformer;
 use App\Transformers\PlanTranslateTransformer;
 use App\Transformers\PlanDayPlaylistItemsTransformer;
@@ -969,49 +970,124 @@ class PlansController extends APIController
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');
         }
 
+        $user_id = empty($user) ? 0 : $user->id;
         $plan_data = [
-            'user_id'               => $user->id,
+            'user_id'               => $user_id,
             'name'                  => $plan->name . ': ' . $bible->language->name . ' ' . substr($bible->id, -3),
             'featured'              => false,
             'draft'                 => $draft,
-            'suggested_start_date'  => $plan->suggested_start_date
+            'suggested_start_date'  => $plan->suggested_start_date,
+            'thumbnail'             => $plan->thumbnail,
+            'language_id'           => $plan->language_id,
         ];
 
         $new_plan = Plan::create($plan_data);
         $playlist_controller = new PlaylistsController();
         $translation_data = [];
         $translated_percentage = 0;
-        $playlists_data = [];
+        $play_day_data = [];
         $order = 1;
         $audio_fileset_types = collect(['audio_stream', 'audio_drama_stream', 'audio', 'audio_drama']);
         $bible_audio_filesets = $bible->filesets->whereIn('set_type_code', $audio_fileset_types);
         $count_plan_days = 0;
-        foreach ($plan->days as $day) {
-            $playlist_by_day = $day->getPlaylistWithItemsAndFilesets();
-            $playlist = (object) $this->translatePlaylist(
-                $playlist_by_day,
-                $user,
-                $new_plan->id,
-                $bible,
-                $audio_fileset_types,
-                $bible_audio_filesets,
-                $playlist_controller
-            );
-            $playlists_data[] = [
-                'plan_id'               => $new_plan->id,
-                'playlist_id'           => $playlist->id,
-                'order_column'          => $order,
-            ];
-            $translation_data[] = $playlist->translation_data;
-            $translated_percentage += $playlist->translated_percentage;
-            $order += 1;
+        $playlist_ids = [];
 
-            if ($day->hasContentAvailable($playlist_by_day)) {
-                $count_plan_days += 1;
+        foreach ($plan->days as $day) {
+            $playlist_ids[] = $day->playlist_id;
+        }
+
+        $playlists = Playlist::findByUserAndIds($user_id, $playlist_ids);
+
+        $playlists_to_create = [];
+        $translated_items = [];
+        foreach ($plan->days as $day) {
+            if (isset($playlists[$day->playlist_id])) {
+                $playlist_by_day = $playlists[$day->playlist_id];
+                $playlist_translated =$this->translatePlaylist(
+                    $playlist_by_day,
+                    $user,
+                    $new_plan->id,
+                    $bible,
+                    $audio_fileset_types,
+                    $bible_audio_filesets,
+                    $playlist_controller
+                );
+                $playlists_to_create[] = $playlist_translated['playlist_data'];
+                $translation_data[$day->playlist_id] = $playlist_translated["translation_data"];
+                $translated_percentage += $playlist_translated["translated_percentage"];
+                $translated_items[$day->playlist_id] = $playlist_translated["translated_items"];
+
+                if ($day->hasContentAvailable($playlist_by_day)) {
+                    $count_plan_days += 1;
+                }
             }
         }
 
-        PlanDay::insert($playlists_data);
+        Playlist::insert($playlists_to_create);
+
+        $new_playlists = Playlist::findByUserAndPlan($user_id, $new_plan->id);
+
+        $new_day_playlist_ids = [];
+        foreach ($new_playlists as $new_palyslist_index => $new_playlist) {
+            $play_day_data[] = [
+                'plan_id'               => $new_plan->id,
+                'playlist_id'           => $new_playlist->id,
+                'order_column'          => $order,
+            ];
+            $order += 1;
+            $new_day_playlist_ids[$playlist_ids[$new_palyslist_index]] = $new_playlist->id;
+        }
+
+        $playlist_items_to_create = [];
+        $playlist_items_to_create_indexed = [];
+
+        foreach ($translated_items as $playlist_id_key => $playlist_translated_item) {
+            $order = 0;
+            foreach ($playlist_translated_item as $translated_item) {
+                $new_playlist_id_key = $new_day_playlist_ids[$playlist_id_key];
+                $playlist_item_data = [
+                    'playlist_id'   => $new_playlist_id_key,
+                    'fileset_id'    => $translated_item['fileset_id'],
+                    'book_id'       => $translated_item['book_id'],
+                    'chapter_start' => $translated_item['chapter_start'],
+                    'chapter_end'   => $translated_item['chapter_end'],
+                    'verse_start'   => $translated_item['verse_start'] ?? null,
+                    'verse_end'     => $translated_item['verse_end'] ?? null,
+                    'verses'        => $translated_item['verses'] ?? 0,
+                    'order_column'  => $translated_item['order_column'] ?? $order,
+                    'duration'      => $translated_item['duration'],
+                ];
+                $key_translated = implode('-', $playlist_item_data);
+                $playlist_items_to_create_indexed[$new_playlist_id_key][$key_translated] = [
+                    "translated_id" => $translated_item['translated_id'],
+                    "playlist_id_key" => $playlist_id_key
+                ];
+                $playlist_items_to_create[] = $playlist_item_data;
+                $order += 1;
+            }
+        }
+
+        PlaylistItems::insert($playlist_items_to_create);
+
+        $new_items = PlaylistItems::findByIdsWithFilesetRelation($new_day_playlist_ids);
+
+        foreach ($new_items as $new_playlist_item) {
+            $key_translated = $new_playlist_item->generateUniqueKey();
+
+            if (isset($playlist_items_to_create_indexed[$new_playlist_item->playlist_id][$key_translated])) {
+                $translated_item_id = $playlist_items_to_create_indexed
+                    [$new_playlist_item->playlist_id][$key_translated]['translated_id'];
+                $translated_playlist_id = $playlist_items_to_create_indexed
+                    [$new_playlist_item->playlist_id][$key_translated]['playlist_id_key'];
+
+                if (isset($translation_data[$translated_playlist_id][$translated_item_id])) {
+                    $translation_data[$translated_playlist_id][$translated_item_id]->translation_item =
+                        $new_playlist_item;
+                }
+            }
+        }
+
+        PlanDay::insert($play_day_data);
         $translated_percentage = $count_plan_days > 0
             ? $translated_percentage / $count_plan_days
             : 0;
@@ -1029,37 +1105,55 @@ class PlansController extends APIController
             $show_details = $show_text;
         }
 
-        $playlist_controller = new PlaylistsController();
         if ($show_details) {
+            $playlists = Playlist::findWithFollowersByUserAndIds($user_id, $new_day_playlist_ids);
             foreach ($plan->days as $day) {
-                $day_playlist = $playlist_controller->getPlaylist($user, $day->playlist_id);
-                $day_playlist->path = route(
-                    'v4_internal_playlists.hls',
-                    ['playlist_id'  => $day_playlist->id, 'v' => $this->v, 'key' => $this->key]
-                );
-                if ($show_text) {
-                    foreach ($day_playlist->items as $item) {
-                        $item->verse_text = $item->getVerseText();
+                if (isset($playlists[$day->playlist_id])) {
+                    $day->playlist = $playlists[$day->playlist_id];
+                    if (isset($day->playlist->items)) {
+                        foreach ($day->playlist->items as $item) {
+                            $item->verse_text = $item->getVerseText();
+                        }
                     }
                 }
-                $day->playlist = $day_playlist;
             }
         }
 
-        $plan->translation_data = $translation_data;
-        $plan->translated_percentage = $translated_percentage;
+        $plan->translation_data = $this->transformTranslationData($translation_data);
+        $plan->translated_percentage = $translated_percentage*100;
 
-        return $this->reply(fractal(
-            $plan,
-            new PlanTranslateTransformer(
-                [
-                    'user' => $user,
-                    'v' => $this->v,
-                    'key' => $this->key
-                ]
-            ),
-            new ArraySerializer()
-        ));
+        if ($show_details) {
+            return $this->reply(fractal(
+                $plan,
+                new PlanTranslateTransformer(
+                    [
+                        'user' => $user,
+                        'v' => $this->v,
+                        'key' => $this->key
+                    ]
+                ),
+                new ArraySerializer()
+            ));
+        }
+
+        return $this->reply($plan);
+    }
+
+    private function transformTranslationData(?Array $translation_data) : Array
+    {
+        $new_translation_data = [];
+
+        if ($translation_data) {
+            foreach ($translation_data as $translation_data_playlist) {
+                $new_translation_data_item = [];
+                foreach ($translation_data_playlist as $translation_data_item) {
+                    $new_translation_data_item[] = $translation_data_item;
+                }
+                $new_translation_data[] = $new_translation_data_item;
+            }
+        }
+
+        return $new_translation_data;
     }
 
     private function translatePlaylist(
@@ -1098,7 +1192,7 @@ class PlansController extends APIController
                         $item->fileset_id = $preferred_fileset->id;
                         $is_streaming = $preferred_fileset->set_type_code === 'audio_stream'
                             || $preferred_fileset->set_type_code === 'audio_drama_stream';
-                        $translated_items[] = [
+                        $translated_items[$item->id] = [
                             'translated_id' => $item->id,
                             'fileset_id' => $item->fileset_id,
                             'book_id' => $item->book_id,
@@ -1106,36 +1200,31 @@ class PlansController extends APIController
                             'chapter_end' => $item->chapter_end,
                             'verse_start' => $is_streaming ? $item->verse_start : null,
                             'verse_end' => $is_streaming ? $item->verse_end : null,
+                            'order_column' => $item->order_column,
+                            'duration' => $item->duration,
                         ];
                         $total_translated_items += 1;
                     }
                 }
-                $metadata_items[] = $item;
+                $metadata_items[$item->id] = $item;
             }
 
             $translated_percentage = sizeof($playlist->items) ? $total_translated_items / sizeof($playlist->items) : 0;
         }
-        $playlist_data = [
-            'user_id'           => $user->id,
-            'name'              => $playlist->name . ': ' . $bible->language->name . ' ' . substr($bible->id, -3),
-            'external_content'  => $playlist->external_content,
-            'featured'          => false,
-            'draft'             => true,
-            'plan_id'           => $plan_id
+
+        return [
+            "playlist_data" =>
+                [
+                    'user_id'           => $user->id,
+                    'name'              => $playlist->name . ': ' . $bible->language->name . ' ' . substr($bible->id, -3),
+                    'external_content'  => $playlist->external_content,
+                    'featured'          => false,
+                    'draft'             => true,
+                    'plan_id'           => $plan_id
+                ],
+            "translation_data" => $metadata_items,
+            "translated_items" => $translated_items,
+            "translated_percentage" => $translated_percentage
         ];
-
-
-        $playlist = Playlist::create($playlist_data);
-        $items = $playlist_controller->createTranslatedPlaylistItems($playlist, $translated_items);
-
-        foreach ($metadata_items as $item) {
-            if (isset($items[$item->id])) {
-                $item->translation_item = $items[$item->id];
-            }
-        }
-
-        $playlist->translation_data = $metadata_items;
-        $playlist->translated_percentage = $translated_percentage * 100;
-        return $playlist;
     }
 }

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -35,7 +35,7 @@ class Plan extends Model
 
     protected $connection = 'dbp_users';
     public $table         = 'plans';
-    protected $fillable   = ['user_id', 'name', 'suggested_start_date', 'draft'];
+    protected $fillable   = ['user_id', 'name', 'suggested_start_date', 'draft', 'thumbnail', 'language_id'];
     protected $hidden     = ['user_id', 'deleted_at', 'plan_id', 'language_id'];
     protected $dates      = ['deleted_at'];
 

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -4,6 +4,8 @@ namespace App\Models\Playlist;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Carbon\Carbon;
 use App\Models\User\User;
 
@@ -145,7 +147,7 @@ class Playlist extends Model
      */
     public function getVersesAttribute()
     {
-        if ($this->relationLoaded('items') && sizeof($this->items) > 0) {
+        if ($this->relationLoaded('items')) {
             return $this->items->sum('verses');
         }
 
@@ -175,5 +177,120 @@ class Playlist extends Model
     public function items()
     {
         return $this->hasMany(PlaylistItems::class)->orderBy('order_column');
+    }
+
+    public function scopeWithUserAndItemsById(Builder $query, int $playlist_id, int $user_id) : Builder
+    {
+        return Playlist::select([
+            'user_playlists.*',
+            \DB::Raw('IF(playlists_followers.user_id, true, false) as following')
+        ])
+        ->with(['user', 'items' => function ($query_items) use ($user_id) {
+            if (!empty($user_id)) {
+                $query_items->withPlaylistItemCompleted($user_id);
+            }
+
+            $query_items->with(['fileset' => function ($query_fileset) {
+                $query_fileset->with('bible');
+            }]);
+        }])
+            ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user_id) {
+                $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')
+                    ->where('playlists_followers.user_id', $user_id);
+            })
+            ->where('user_playlists.id', $playlist_id);
+    }
+
+    public static function findByUserAndIds(int $user_id, Array $playlist_ids) : Collection
+    {
+        return Playlist::with(
+            [
+                'items' => function ($subquery) use ($user_id) {
+                    if (!empty($user_id)) {
+                        $subquery->withPlaylistItemCompleted($user_id);
+                    }
+                    $subquery->with('fileset');
+                }
+            ]
+        )->whereIn('user_playlists.id', $playlist_ids)
+        ->get()
+        ->keyBy('id');
+    }
+
+    public static function findWithBibleRelationByUserAndId(int $user_id, int $playlist_id) : Playlist
+    {
+        return Playlist::with(['user', 'items' => function ($query_items) use ($user_id) {
+            $query_items->withPlaylistItemCompleted($user_id);
+
+            $query_items->with(['fileset' => function ($query_fileset) {
+                $query_fileset->with(['bible' => function ($query_bible) {
+                    $query_bible->with(['translations', 'vernacularTranslation', 'books.book']);
+                }]);
+            }]);
+        }])
+            ->where('user_playlists.id', $playlist_id)
+            ->select(['user_playlists.*', \DB::Raw('false as following')])
+            ->first();
+    }
+
+    public static function findByUserAndPlan(int $user_id, int $plan_id) : Collection
+    {
+        return Playlist::where('user_id', $user_id)
+            ->where('plan_id', $plan_id)
+            ->orderBy('id')
+            ->get();
+    }
+
+    public static function findWithFollowersByUserAndIds(int $user_id, Array $playlist_ids) : Collection
+    {
+        return Playlist::with(['user', 'items' => function ($query_items) use ($user_id) {
+            if (!empty($user_id)) {
+                $query_items->withPlaylistItemCompleted($user_id);
+            }
+
+            $query_items->with(['fileset' => function ($query_fileset) {
+                $query_fileset->with('bible');
+            }]);
+        }])
+            ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user_id) {
+                $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')
+                    ->where('playlists_followers.user_id', $user_id);
+            })
+            ->whereIn('user_playlists.id', $playlist_ids)
+            ->select(['user_playlists.*', \DB::Raw('IF(playlists_followers.user_id, true, false) as following')])
+            ->get()
+            ->keyBy('id');
+    }
+
+    public static function findWithPlaylistItemsByUserAndId(int $user_id, int $playlist_id) : Playlist
+    {
+        return Playlist::with(['user', 'items' => function ($query_items) {
+            $query_items->select([
+                'id',
+                'fileset_id',
+                'book_id',
+                'chapter_start',
+                'chapter_end',
+                'playlist_id',
+                'verse_start',
+                'verse_end',
+                'verses',
+                'duration',
+                \DB::Raw('false as completed'),
+            ]);
+
+            $query_items->with(['fileset' => function ($query_fileset) {
+                $query_fileset->with(['files.timestamps', 'bible' => function ($query_bible) {
+                    $query_bible->with(['translations', 'vernacularTranslation', 'books.book']);
+                }]);
+            }]);
+        }])
+            ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user_id) {
+                $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')
+                    ->where('playlists_followers.user_id', $user_id);
+            })
+            ->where('user_playlists.id', $playlist_id)
+            ->select(['user_playlists.*', \DB::Raw('IF(playlists_followers.user_id, true, false) as following')])
+            ->first();
     }
 }

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -209,7 +209,15 @@ class Playlist extends Model
                     if (!empty($user_id)) {
                         $subquery->withPlaylistItemCompleted($user_id);
                     }
-                    $subquery->with('fileset');
+                    $subquery->with(['fileset' => function ($query_fileset) {
+                        $query_fileset->with(['bible' => function ($query_bible) {
+                            $query_bible->with([
+                                'translations',
+                                'vernacularTranslation',
+                                'books.book'
+                            ]);
+                        }]);
+                    }]);
                 }
             ]
         )->whereIn('user_playlists.id', $playlist_ids)

--- a/app/Transformers/PlanDayPlaylistItemsTransformer.php
+++ b/app/Transformers/PlanDayPlaylistItemsTransformer.php
@@ -11,7 +11,6 @@ class PlanDayPlaylistItemsTransformer extends PlanTransformerBase
      */
     public function transform($plan)
     {
-        $book_name_indexed_by_id = [];
         return [
             "id" => $plan->id,
             "name" => $plan->name,
@@ -23,73 +22,11 @@ class PlanDayPlaylistItemsTransformer extends PlanTransformerBase
             "updated_at" => $plan->updated_at,
             "start_date" => $plan->start_date,
             "percentage_completed" => $plan->percentage_completed,
-            "days" => $plan->days->map(function ($day) use (&$book_name_indexed_by_id) {
+            "days" => $plan->days->map(function ($day) {
                 return [
                     "id" => $day->id,
                     "playlist_id" => $day->playlist_id,
-                    "playlist" => $day->playlist
-                        ? [
-                            "id" => $day->playlist->id,
-                            "name" => $day->playlist->name,
-                            "featured" => $day->playlist->featured,
-                            "draft" => $day->playlist->draft,
-                            "created_at" => $day->playlist->created_at,
-                            "updated_at" => $day->playlist->updated_at,
-                            "external_content" => $day->playlist->external_content,
-                            "following" => $day->playlist->following,
-                            "items" => $day->playlist->items->map(function ($item) use (&$book_name_indexed_by_id) {
-
-                                $bible = optional($item->fileset->bible)->first();
-                                $book_name = $bible
-                                    ? $this->getBookNameFromItem($book_name_indexed_by_id, $bible, $item->book_id)
-                                    : null;
-
-                                $result_item = [
-                                    "id" => $item->id,
-                                    "fileset_id" => $item->fileset_id,
-                                    "book_id" => $item->book_id,
-                                    "chapter_start" => $item->chapter_start,
-                                    "chapter_end" => $item->chapter_end,
-                                    "verse_start" => $item->verse_start,
-                                    "verse_end" => $item->verse_end,
-                                    "verses" => $item->verses,
-                                    "duration" => $item->duration,
-                                    "bible_id" => $bible ? $bible->id : null,
-                                    "completed" => $item->completed,
-                                    "full_chapter" => $item->full_chapter,
-                                    "path" => $item->path,
-                                    "metadata" => $bible ? [
-                                        "bible_id" => $bible->id,
-                                        "bible_name" => optional(
-                                            $bible->translations->where('language_id', $GLOBALS['i18n_id'])->first()
-                                        )->name,
-                                        "bible_vname" => optional($bible->vernacularTranslation)->name,
-                                        "book_name" => $book_name
-                                    ] : [],
-                                ];
-
-                                if (isset($item->verse_text)) {
-                                    $result_item["verse_text"] = $item->verse_text;
-                                }
-
-                                return $result_item;
-                            }),
-                            "path" => route(
-                                'v4_internal_playlists.hls',
-                                [
-                                    'playlist_id'  => $day->playlist->id,
-                                    'v' => $this->params['v'],
-                                    'key' => $this->params['key']
-                                ]
-                            ),
-                            "verses" => $day->playlist->verses,
-                            "verses" => 0,
-                            "user" => [
-                                "id" => $day->playlist->user->id,
-                                "name" => $day->playlist->user->name
-                            ]
-                        ]
-                    : [],
+                    "playlist" => $this->parsePlaylistData($day->playlist),
                     "completed" => $day->completed
                 ];
             }),

--- a/app/Transformers/PlanTranslateTransformer.php
+++ b/app/Transformers/PlanTranslateTransformer.php
@@ -17,6 +17,7 @@ class PlanTranslateTransformer extends PlanTransformerBase
             "id"         => $plan->id,
             "name"       => $plan->name,
             "thumbnail"  => $plan->thumbnail,
+            "language_id"  => $plan->language_id,
             "featured"   => $plan->featured,
             "suggested_start_date" => $plan->suggested_start_date,
             "draft"      => $plan->draft,
@@ -24,11 +25,69 @@ class PlanTranslateTransformer extends PlanTransformerBase
             "updated_at" => $plan->updated_at,
             "start_date" => $plan->start_date,
             "percentage_completed" => (int) $plan->percentage_completed,
-            "days" => $plan->days->map(function ($day) {
+            "days" => $plan->days->map(function ($day) use (&$book_name_indexed_by_id) {
                 return [
-                    "id"          => $day->id,
+                    "id" => $day->id,
                     "playlist_id" => $day->playlist_id,
-                    "completed"   => (bool) $day->completed
+                    "playlist" => $day->playlist
+                        ? [
+                            "id" => $day->playlist->id,
+                            "name" => $day->playlist->name,
+                            "featured" => $day->playlist->featured,
+                            "draft" => $day->playlist->draft,
+                            "created_at" => $day->playlist->created_at,
+                            "updated_at" => $day->playlist->updated_at,
+                            "external_content" => $day->playlist->external_content,
+                            "following" => $day->playlist->following,
+                            "items" => $day->playlist->items->map(function ($item) use (&$book_name_indexed_by_id) {
+
+                                $bible = optional($item->fileset->bible)->first();
+                                $book_name = $bible
+                                    ? $this->getBookNameFromItem($book_name_indexed_by_id, $bible, $item->book_id)
+                                    : null;
+
+                                return [
+                                    "id" => $item->id,
+                                    "fileset_id" => $item->fileset_id,
+                                    "book_id" => $item->book_id,
+                                    "chapter_start" => $item->chapter_start,
+                                    "chapter_end" => $item->chapter_end,
+                                    "verse_start" => $item->verse_start,
+                                    "verse_end" => $item->verse_end,
+                                    "verses" => $item->verses,
+                                    "duration" => $item->duration,
+                                    "bible_id" => $bible ? $bible->id : null,
+                                    "verse_text" => $item->verse_text,
+                                    "completed" => $item->completed,
+                                    "full_chapter" => $item->full_chapter,
+                                    "path" => $item->path,
+                                    "metadata" => $bible ? [
+                                        "bible_id" => $bible->id,
+                                        "bible_name" => optional(
+                                            $bible->translations->where('language_id', $GLOBALS['i18n_id'])->first()
+                                        )->name,
+                                        "bible_vname" => optional($bible->vernacularTranslation)->name,
+                                        "book_name" => $book_name
+                                    ] : [],
+                                ];
+                            }),
+                            "path" => route(
+                                'v4_internal_playlists.hls',
+                                [
+                                    'playlist_id'  => $day->playlist->id,
+                                    'v' => $this->params['v'],
+                                    'key' => $this->params['key']
+                                ]
+                            ),
+                            "verses" => $day->playlist->verses,
+                            "verses" => 0,
+                            "user" => [
+                                "id" => $day->playlist->user->id,
+                                "name" => $day->playlist->user->name
+                            ]
+                        ]
+                    : [],
+                    "completed" => $day->completed
                 ];
             }),
             "user" => [
@@ -36,7 +95,7 @@ class PlanTranslateTransformer extends PlanTransformerBase
                 "name" => $this->params['user']->name,
             ],
             "translation_data" => array_map(function ($item_translations) {
-                return $this->parseTranslationData($item_translations);
+                return $this->parseTranslationData($item_translations, false);
             }, $plan->translation_data),
             "translated_percentage" => $plan->translated_percentage
         ];

--- a/app/Transformers/PlanTranslateTransformer.php
+++ b/app/Transformers/PlanTranslateTransformer.php
@@ -25,68 +25,11 @@ class PlanTranslateTransformer extends PlanTransformerBase
             "updated_at" => $plan->updated_at,
             "start_date" => $plan->start_date,
             "percentage_completed" => (int) $plan->percentage_completed,
-            "days" => $plan->days->map(function ($day) use (&$book_name_indexed_by_id) {
+            "days" => $plan->days->map(function ($day) {
                 return [
                     "id" => $day->id,
                     "playlist_id" => $day->playlist_id,
-                    "playlist" => $day->playlist
-                        ? [
-                            "id" => $day->playlist->id,
-                            "name" => $day->playlist->name,
-                            "featured" => $day->playlist->featured,
-                            "draft" => $day->playlist->draft,
-                            "created_at" => $day->playlist->created_at,
-                            "updated_at" => $day->playlist->updated_at,
-                            "external_content" => $day->playlist->external_content,
-                            "following" => $day->playlist->following,
-                            "items" => $day->playlist->items->map(function ($item) use (&$book_name_indexed_by_id) {
-
-                                $bible = optional($item->fileset->bible)->first();
-                                $book_name = $bible
-                                    ? $this->getBookNameFromItem($book_name_indexed_by_id, $bible, $item->book_id)
-                                    : null;
-
-                                return [
-                                    "id" => $item->id,
-                                    "fileset_id" => $item->fileset_id,
-                                    "book_id" => $item->book_id,
-                                    "chapter_start" => $item->chapter_start,
-                                    "chapter_end" => $item->chapter_end,
-                                    "verse_start" => $item->verse_start,
-                                    "verse_end" => $item->verse_end,
-                                    "verses" => $item->verses,
-                                    "duration" => $item->duration,
-                                    "bible_id" => $bible ? $bible->id : null,
-                                    "verse_text" => $item->verse_text,
-                                    "completed" => $item->completed,
-                                    "full_chapter" => $item->full_chapter,
-                                    "path" => $item->path,
-                                    "metadata" => $bible ? [
-                                        "bible_id" => $bible->id,
-                                        "bible_name" => optional(
-                                            $bible->translations->where('language_id', $GLOBALS['i18n_id'])->first()
-                                        )->name,
-                                        "bible_vname" => optional($bible->vernacularTranslation)->name,
-                                        "book_name" => $book_name
-                                    ] : [],
-                                ];
-                            }),
-                            "path" => route(
-                                'v4_internal_playlists.hls',
-                                [
-                                    'playlist_id'  => $day->playlist->id,
-                                    'v' => $this->params['v'],
-                                    'key' => $this->params['key']
-                                ]
-                            ),
-                            "verses" => $day->playlist->verses,
-                            "verses" => 0,
-                            "user" => [
-                                "id" => $day->playlist->user->id,
-                                "name" => $day->playlist->user->name
-                            ]
-                        ]
-                    : [],
+                    "playlist" => $this->parsePlaylistData($day->playlist),
                     "completed" => $day->completed
                 ];
             }),

--- a/app/Transformers/PlaylistTransformer.php
+++ b/app/Transformers/PlaylistTransformer.php
@@ -11,7 +11,6 @@ class PlaylistTransformer extends PlanTransformerBase
      */
     public function transform($playlist)
     {
-        $book_name_indexed_by_id = [];
         $result = [
             "id" => $playlist->id,
             "name" => $playlist->name,
@@ -21,11 +20,11 @@ class PlaylistTransformer extends PlanTransformerBase
             "updated_at" => $playlist->updated_at,
             "external_content" => $playlist->external_content,
             "following" => $playlist->following,
-            "items" => $playlist->items->map(function ($item) use (&$book_name_indexed_by_id) {
+            "items" => $playlist->items->map(function ($item) {
 
                 $bible = optional($item->fileset->bible)->first();
                 $book_name = $bible
-                    ? $this->getBookNameFromItem($book_name_indexed_by_id, $bible, $item->book_id)
+                    ? $this->getBookNameFromItem($bible, $item->book_id)
                     : null;
 
                 return [

--- a/app/Transformers/PlaylistTransformer.php
+++ b/app/Transformers/PlaylistTransformer.php
@@ -12,7 +12,7 @@ class PlaylistTransformer extends PlanTransformerBase
     public function transform($playlist)
     {
         $book_name_indexed_by_id = [];
-        return [
+        $result = [
             "id" => $playlist->id,
             "name" => $playlist->name,
             "featured" => $playlist->featured,
@@ -63,8 +63,6 @@ class PlaylistTransformer extends PlanTransformerBase
                 ]
             ),
             "total_duration" => $playlist->total_duration,
-            "translation_data" => $this->parseTranslationData($playlist->translation_data),
-            "translated_percentage" => $playlist->translated_percentage,
             "verses" => $playlist->verses,
             "user" => [
                 "id" => $playlist->user->id,
@@ -72,5 +70,15 @@ class PlaylistTransformer extends PlanTransformerBase
             ],
 
         ];
+
+        if (isset($playlist->translation_data) && !empty($playlist->translation_data)) {
+            $result["translation_data"] = $this->parseTranslationData($playlist->translation_data);
+        }
+
+        if (isset($playlist->translated_percentage) && !empty($playlist->translated_percentage)) {
+            $result["translated_percentage"] = $playlist->translated_percentage;
+        }
+
+        return $result;
     }
 }

--- a/database/migrations/2022_01_26_054449_add_index_plan_id_user_playlists.php
+++ b/database/migrations/2022_01_26_054449_add_index_plan_id_user_playlists.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexPlanIdUserPlaylists extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->index('plan_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp_users')->table('user_playlists', function (Blueprint $table) {
+            $table->dropIndex(['plan_id']);
+        });
+    }
+}


### PR DESCRIPTION


# Description
It has added a refactor for the endpoint to translate a plan. Also, Fix the PlaylistItems when the fileset is empty. Added the feature to insert a batch of playlist records and playlist items records.

#### NOTE:
I recommend to create a index for the `plan_id` column of the `user_playlists` entity. This PR has a migration to create the index. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-149

## How Do I QA This
- Translate a the plan: Bible in a year to BENBBS 
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1b0c03bd-7477-46f9-b28d-e56b4395a4ea

- Translate a the plan: Bible in a year to SPNSEV 
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-fea3c2d5-a970-4774-8cd5-0940ad49e106

- Translate a specific playlist to BENBBS 
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9c1f544c-37f4-40f5-b467-02e59e685a90

- Execute the folder `bibleis with user session` on postman.

## Screenshots
You can see in the next screenshot the performance time in my local machine
![screenshot-localhost_8080-2022 01 26-08_58_37](https://user-images.githubusercontent.com/73488660/151185944-3052b0d4-b5d2-4400-b6ca-92ac7c5c35fd.png)
