### PR TITLE
FCBHDBP-149 fixed the playlists.show action

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -395,7 +395,6 @@ class PlaylistsController extends APIController
             foreach ($playlist->items as $item) {
                 $item->verse_text = $item->getVerseText($playlist_text_filesets);
                 $item->item_timestamps = $item->getTimestamps();
-                unset($item->fileset);
             }
         }
 


### PR DESCRIPTION

# Description
It has fixed the playlists.show action to avoid to do aditional sql queries to pull the bible_filesets records.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-149

## How Do I QA This
- Execute the next postman URL
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-24035c11-fdb7-4c83-a652-b8de3c8a7ab3

- Execute the folder: bibleis with user session