### PR TITLE
FCBHDBP-278 fix artisan command translate:plan

### DIFF
--- a/app/Console/Commands/TranslatePlan.php
+++ b/app/Console/Commands/TranslatePlan.php
@@ -82,11 +82,10 @@ class TranslatePlan extends Command
                     $translated_plan = $this->plan_service->translate($plan_id, $bible, $plan->user_id, false, false);
                     $plan = Plan::where('id', $translated_plan['id'])->first();
 
-                    $this->line('Calculating duration and verses ' . Carbon::now());
+                    $this->line('Calculating verses' . Carbon::now());
                     foreach ($plan->days as $day) {
                         $playlist_items = PlaylistItems::where('playlist_id', $day['playlist_id'])->get();
                         foreach ($playlist_items as $playlist_item) {
-                            $playlist_item->calculateDuration()->save();
                             $playlist_item->calculateVerses()->save();
                         }
                     }

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -196,6 +196,8 @@ class PlaylistItems extends Model implements Sortable
 
     public function calculateDuration()
     {
+        // Currently, this method may not work because it is not supporting to use the cache methods
+        // that are executing into the getDuration method
         $playlist_item = (object) $this->attributes;
         $this->attributes['duration'] = $this->getDuration($playlist_item) ?? 0;
         return $this;


### PR DESCRIPTION

# Description
It has removed the method to calculate the Duration value for each playlist item for the Translate Plan command. The above because there is no need to do more than is done in the web transaction to translate a plan.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-278

## How Do I QA This
```bash
php artisan translate:plan 209 BENBBS
```
