### PR TITLE
FCBHDBP-278 fix artisan command translate:plan

### DIFF
--- a/app/Console/Commands/TranslatePlan.php
+++ b/app/Console/Commands/TranslatePlan.php
@@ -82,13 +82,8 @@ class TranslatePlan extends Command
                     $translated_plan = $this->plan_service->translate($plan_id, $bible, $plan->user_id, false, false);
                     $plan = Plan::where('id', $translated_plan['id'])->first();
 
-                    $this->line('Calculating verses' . Carbon::now());
-                    foreach ($plan->days as $day) {
-                        $playlist_items = PlaylistItems::where('playlist_id', $day['playlist_id'])->get();
-                        foreach ($playlist_items as $playlist_item) {
-                            $playlist_item->calculateVerses()->save();
-                        }
-                    }
+                    $this->line('Calculating Duration and Verses ' . Carbon::now());
+                    $this->plan_service->calculateDurationAndVersesUpdatePlan($plan, true);
 
                     $this->info('Translating plan to bible ' . $bible_id . ' finalized ' . Carbon::now());
                     $this->info('Plan Translated ID: ' . $plan->id . ' ' . Carbon::now());

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -294,11 +294,12 @@ class PlaylistsController extends APIController
         }
         PlaylistItems::insert($playlist_items_to_create);
         $created_playlist_items = PlaylistItems::where('playlist_id', $playlist->id)->orderBy('order_column')->get();
-        foreach ($created_playlist_items as $created_playlist_item) {
-            $created_playlist_item->calculateDuration()->save();
-            if (!$created_playlist_item->verses) {
-                $created_playlist_item->calculateVerses()->save();
-            }
+
+        $this->playlist_service->calculateDurationAndUpdateItem($created_playlist_items);
+        $this->playlist_service->calculateVersesAndUpdateItem($created_playlist_items);
+
+        foreach ($created_playlist_items as $playlist_item) {
+            $playlist_item->save();
         }
         return $created_playlist_items;
     }
@@ -689,10 +690,11 @@ class PlaylistsController extends APIController
                 'verse_end'         => $playlist_item->verse_end ?? null,
                 'verses'            => $verses
             ]);
-            $created_playlist_item->calculateDuration()->save();
+            $created_playlist_item->calculateDuration();
             if (!$verses) {
-                $created_playlist_item->calculateVerses()->save();
+                $created_playlist_item->calculateVerses();
             }
+            $created_playlist_item->save();
             $created_playlist_items[] = $created_playlist_item;
         }
 

--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -326,4 +326,31 @@ class PlanService
     {
         return Plan::findOne($plan_id);
     }
+
+    /**
+     * Calculate the duration and verses values for each playlist item that belong to plan
+     *
+     * @param int $plan_id
+     *
+     * @return Plan
+     */
+    public function calculateDurationAndVersesUpdatePlan(Plan $plan, bool $save = false) : Plan
+    {
+        $playlist_ids = [];
+        foreach ($plan->days as $day) {
+            $playlist_ids[] = $day->playlist_id;
+        }
+
+        $playlist_items = PlaylistItems::whereIn('playlist_id', $playlist_ids)->get();
+        $this->playlist_service->calculateDurationAndUpdateItem($playlist_items, $save);
+        $this->playlist_service->calculateVersesAndUpdateItem($playlist_items, $save);
+
+        if ($save === true) {
+            foreach ($playlist_items as $playlist_item) {
+                $playlist_item->save();
+            }
+        }
+
+        return $plan;
+    }
 }

--- a/app/Services/Plans/PlaylistService.php
+++ b/app/Services/Plans/PlaylistService.php
@@ -6,6 +6,7 @@ use App\Models\Plan\Plan;
 use App\Models\Playlist\Playlist;
 use App\Models\Playlist\PlaylistItems;
 use App\Models\Bible\Bible;
+use Illuminate\Database\Eloquent\Collection;
 
 class PlaylistService
 {
@@ -179,5 +180,33 @@ class PlaylistService
             })->first();
         }
         return null;
+    }
+
+    /**
+     * Calculate the duration value for each playlist item that belong to plan
+     *
+     * @param int $plan_id
+     *
+     * @return Plan
+     */
+    public function calculateDurationAndUpdateItem(?Collection $playlist_items) : void
+    {
+        foreach ($playlist_items as $playlist_item) {
+            $playlist_item->calculateDuration();
+        }
+    }
+
+    /**
+     * Calculate the verses value for each playlist item that belong to plan
+     *
+     * @param int $plan_id
+     *
+     * @return Plan
+     */
+    public function calculateVersesAndUpdateItem(?Collection $playlist_items) : void
+    {
+        foreach ($playlist_items as $playlist_item) {
+            $playlist_item->calculateVerses();
+        }
     }
 }


### PR DESCRIPTION

# Description
It has removed the cache method from the methods: `calculateVerses` and `calculateDuration` for the `PlaylistItems` model. The above to avoid the lock issue when DBP is trying to use a same cache key for the same query multiple time for the same request.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-278

## How Do I QA This
```bash
php artisan translate:plan 209 BENBBS
```
