### PR TITLE
FCBHDBP Hotfix. Error to return a null method to get a plan/playlist

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -285,14 +285,12 @@ class PlansController extends APIController
         }
 
         if ($show_details) {
-            $day_playlist_ids = [];
-            foreach ($plan->days as $day) {
-                $day_playlist_ids[] = $day->playlist_id;
-            }
-
             $user_id = empty($user) ? 0 : $user->id;
 
-            $this->plan_service->setVerseTextToEachPlaylistItem($plan, $user_id, $day_playlist_ids);
+            $this->plan_service->setPlaylistItemsForEachPlaylist($plan, $user_id);
+            if ($show_text) {
+                $this->plan_service->setVerseTextToEachPlaylistItem($plan);
+            }
         }
 
         return $this->reply(fractal(

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -215,7 +215,7 @@ class Plan extends Model
      *
      * @return Plan
      */
-    public static function getWithDaysAndUserById(int $plan_id, ?int $user_id = null) : Plan
+    public static function getWithDaysAndUserById(int $plan_id, ?int $user_id = null) : ?Plan
     {
         return self::with(['days' => function ($days_query) use ($user_id) {
             if (!empty($user_id)) {
@@ -236,7 +236,7 @@ class Plan extends Model
      *
      * @return Plan
      */
-    public static function getWithDaysPlaylistItemsAndUserById(int $plan_id, int $user_id) : Plan
+    public static function getWithDaysPlaylistItemsAndUserById(int $plan_id, int $user_id) : ?Plan
     {
         return self::withDaysPlaylistItemsAndUserById($plan_id, $user_id)->first();
     }

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -225,7 +225,7 @@ class Playlist extends Model
         ->keyBy('id');
     }
 
-    public static function findWithBibleRelationByUserAndId(int $user_id, int $playlist_id) : Playlist
+    public static function findWithBibleRelationByUserAndId(int $user_id, int $playlist_id) : ?Playlist
     {
         return Playlist::with(['user', 'items' => function ($query_items) use ($user_id) {
             $query_items->withPlaylistItemCompleted($user_id);
@@ -270,7 +270,7 @@ class Playlist extends Model
             ->keyBy('id');
     }
 
-    public static function findWithPlaylistItemsByUserAndId(int $user_id, int $playlist_id) : Playlist
+    public static function findWithPlaylistItemsByUserAndId(int $user_id, int $playlist_id) : ?Playlist
     {
         return Playlist::with(['user', 'items' => function ($query_items) {
             $query_items->select([


### PR DESCRIPTION
# Description
Hotfix. It has added the feature to accept a null value as response for the methods to get a plan or playlist when the ID does not exist or the plan/playlist has been removed.

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
- Execute the postman folder: bibleis with user session
