### PR TITLE
FCBHDBP-313 Improve performance for the methods to calculate the duration and verses for playlistItems

### DIFF
--- a/app/Console/Commands/TranslatePlan.php
+++ b/app/Console/Commands/TranslatePlan.php
@@ -79,11 +79,15 @@ class TranslatePlan extends Command
                         $this->alert('Bible with ID:' . $bible_id . ' does not exist' . Carbon::now());
                         continue;
                     }
-                    $translated_plan = $this->plan_service->translate($plan_id, $bible, $plan->user_id, false);
+                    $translated_plan = $this->plan_service->translate(
+                        $plan_id,
+                        $bible,
+                        $plan->user_id,
+                        false,
+                        true,
+                        true
+                    );
                     $plan = Plan::where('id', $translated_plan['id'])->first();
-
-                    $this->line('Calculating Duration and Verses ' . Carbon::now());
-                    $this->plan_service->calculateDurationAndVersesUpdatePlan($plan, true);
 
                     $this->info('Translating plan to bible ' . $bible_id . ' finalized ' . Carbon::now());
                     $this->info('Plan Translated ID: ' . $plan->id . ' ' . Carbon::now());

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -295,8 +295,8 @@ class PlaylistsController extends APIController
         PlaylistItems::insert($playlist_items_to_create);
         $created_playlist_items = PlaylistItems::where('playlist_id', $playlist->id)->orderBy('order_column')->get();
 
-        $this->playlist_service->calculateDurationAndUpdateItem($created_playlist_items);
-        $this->playlist_service->calculateVersesAndUpdateItem($created_playlist_items);
+        $this->playlist_service->calculateDuration($created_playlist_items);
+        $this->playlist_service->calculateVerses($created_playlist_items);
 
         foreach ($created_playlist_items as $playlist_item) {
             $playlist_item->save();

--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -2,6 +2,10 @@
 
 namespace App\Services\Plans;
 
+use App\Models\Bible\BibleFile;
+use App\Models\Bible\BibleFileset;
+use App\Models\Bible\BibleVerse;
+use App\Models\Bible\StreamBandwidth;
 use App\Models\Plan\Plan;
 use App\Models\Plan\PlanDay;
 use App\Models\Plan\PlanDayComplete;
@@ -27,14 +31,19 @@ class PlanService
      * @param int $plan_id
      * @param Bible $bible
      * @param int $user_id
-     * @param int $draft
+     * @param bool $draft
+     * @param bool $save_completed_items
+     * @param bool $calculate_items_duration
+     * @param bool $calculate_items_verses
      */
     public function translate(
         int $plan_id,
         Bible $bible,
         int $user_id = 0,
         bool $draft = true,
-        bool $save_completed_items = true
+        bool $save_completed_items = true,
+        bool $calculate_items_duration = false,
+        bool $calculate_items_verses = false,
     ) : Plan {
         $plan = $this->getPlanWithDaysByIdAndUser($plan_id, $user_id);
 
@@ -133,6 +142,18 @@ class PlanService
             }
         }
 
+        if ($calculate_items_duration === true) {
+            $this->calculateDurationForPlaylistItems($playlist_items_to_create);
+        }
+
+        if ($calculate_items_verses === true) {
+            $bible_filesets = $bible
+                ->filesets
+                ->where('set_type_code', 'text_plain');
+
+            $this->calculateVersesForPlaylistItems($playlist_items_to_create, $bible_filesets);
+        }
+
         PlaylistItems::insert($playlist_items_to_create);
 
         $new_items = PlaylistItems::findByIdsWithFilesetRelation($new_day_playlist_ids);
@@ -187,6 +208,225 @@ class PlanService
         $plan->translated_percentage = $translated_percentage*100;
 
         return $plan;
+    }
+
+
+    /**
+     * Get the bible filesets attached to the fileset attached to each palylist item
+     *
+     * @param Array $playlist_items_to_create
+     *
+     * @return Collection list filesets indexed by ID
+     */
+    public function getBibleFilesetsFromPlaylistItems(Array $playlist_items_to_create) : Collection
+    {
+        $fileset_ids = [];
+
+        foreach ($playlist_items_to_create as $item_to_create) {
+            $fileset_ids[$item_to_create['fileset_id']] = true;
+        }
+
+        return BibleFileset::select(['id', 'hash_id', 'set_type_code'])
+            ->whereIn('id', array_keys($fileset_ids))
+            ->get()
+            ->keyBy('id');
+    }
+
+    /**
+     * Get the bible files attached to the fileset attached to each palylist item
+     *
+     * @param Array $playlist_items_to_create
+     * @param Collection $bible_filesets - bible fileset collection indexed by filese ID
+     *
+     * @return Array
+     */
+    public function getBibleFilesFromPlaylistItems(
+        Array $playlist_items_to_create,
+        Collection $bible_filesets
+    ) : Array|Collection {
+        $bible_files = BibleFile::select(['id', 'hash_id', 'book_id', 'chapter_start', 'duration'])
+            ->with('streamBandwidth.transportStreamTS')
+            ->with('streamBandwidth.transportStreamBytes');
+
+        $flag_constraint = false;
+        foreach ($playlist_items_to_create as $item_to_create) {
+            $bible_files->orWhere(
+                function ($query_or_duration) use ($item_to_create, $bible_filesets, &$flag_constraint) {
+                    if (isset($bible_filesets[$item_to_create['fileset_id']])) {
+                        $flag_constraint = true;
+                        $query_or_duration
+                            ->where('chapter_start', '>=', $item_to_create['chapter_start'])
+                            ->where('chapter_start', '<=', $item_to_create['chapter_end'])
+                            ->where('hash_id', $bible_filesets[$item_to_create['fileset_id']]->hash_id)
+                            ->where('book_id', $item_to_create['book_id']);
+                    }
+                }
+            );
+        }
+
+        return $flag_constraint ? $bible_files->get() : [];
+    }
+
+    /**
+     * Filter the bible files array according to the chapter values of the playlist item
+     *
+     * @param Array $bible_files
+     * @param Array $item_to_create
+     *
+     * @return Array
+     */
+    public function filterBibleFilesByChapter(Array $bible_files, Array $item_to_create) : ?Array
+    {
+        return array_filter(
+            $bible_files,
+            function ($bible_file) use ($item_to_create) {
+                return $bible_file->chapter_start >= $item_to_create['chapter_start'] &&
+                    $bible_file->chapter_start <= $item_to_create['chapter_end'];
+            }
+        );
+    }
+
+    /**
+     * Get transportStream from a bible file
+     *
+     * @param StreamBandwidth $current_band_width
+     * @param Array $item_to_create
+     */
+    public function getTransportStreamFromBibleFile(StreamBandwidth $current_band_width, Array $item_to_create)
+    {
+        $transportStream = sizeof($current_band_width->transportStreamBytes)
+            ? $current_band_width->transportStreamBytes
+            : $current_band_width->transportStreamTS;
+        if ($item_to_create['verse_end'] && $item_to_create['verse_start']) {
+            $transportStream = $this->processVersesOnTransportStream(
+                $item_to_create,
+                $transportStream,
+                $bible_file
+            );
+        }
+
+        return $transportStream;
+    }
+
+    /**
+     * Update the duration property for each playlist item
+     * @param Array &$playlist_items_to_create
+     *
+     * @return void
+     */
+    public function calculateDurationForPlaylistItems(Array &$playlist_items_to_create) : void
+    {
+        $bible_filesets = $this->getBibleFilesetsFromPlaylistItems($playlist_items_to_create);
+        $bible_files = $this->getBibleFilesFromPlaylistItems($playlist_items_to_create, $bible_filesets);
+
+        $bible_files_indexed = [];
+
+        foreach ($bible_files as $bible_file) {
+            $bible_files_indexed[$bible_file->hash_id][$bible_file->book_id][] = $bible_file;
+        }
+
+        foreach ($playlist_items_to_create as &$item_to_create) {
+            $bible_fileset_attached = $bible_filesets[$item_to_create['fileset_id']];
+
+            if (isset($bible_files_indexed[$bible_fileset_attached->hash_id][$item_to_create['book_id']])) {
+                $hash_id = $bible_fileset_attached->hash_id;
+
+                $bible_files_to_perform_filtered = $this->filterBibleFilesByChapter(
+                    $bible_files_indexed[$hash_id][$item_to_create['book_id']],
+                    $item_to_create
+                );
+                $duration = 0;
+
+                if ($bible_fileset_attached->set_type_code === 'audio_stream' ||
+                    $bible_fileset_attached->set_type_code === 'audio_drama_stream'
+                ) {
+                    foreach ($bible_files_to_perform_filtered as $bible_file) {
+                        $currentBandwidth = $bible_file->streamBandwidth->first();
+                        $transportStream = $this->getTransportStreamFromBibleFile($currentBandwidth, $item_to_create);
+
+                        foreach ($transportStream as $stream) {
+                            $duration += $stream->runtime;
+                        }
+                    }
+                } else {
+                    foreach ($bible_files_to_perform_filtered as $bible_file) {
+                        $duration += $bible_file->duration ?? 180;
+                    }
+                }
+
+                $item_to_create['duration'] = $duration;
+            }
+        }
+
+        unset($item_to_create);
+    }
+
+    /**
+     * Update the verses property for each playlist item
+     * @param Array &$playlist_items_to_create
+     * @param Collection $bible_filesets
+     *
+     * @return void
+     */
+    public function calculateVersesForPlaylistItems(Array &$playlist_items_to_create, Collection $bible_filesets) : void
+    {
+        $book_ids = [];
+        foreach ($playlist_items_to_create as $item_to_create) {
+            $book_ids[$item_to_create['book_id']] = true;
+        }
+
+        $bible_verses = BibleVerse::select([ \DB::raw('COUNT(id) as verse_count'), 'book_id', 'chapter'])
+            ->whereIn('hash_id', $bible_filesets->pluck('hash_id'))
+            ->whereIn('book_id', array_keys($book_ids))
+            ->groupBy(['book_id', 'chapter'])
+            ->get();
+
+        $bible_verses_indexed = [];
+
+        foreach ($bible_verses as $bible_verse) {
+            $bible_verses_indexed[$bible_verse->book_id][(int)$bible_verse->chapter] = $bible_verse->verse_count;
+        }
+
+        foreach ($playlist_items_to_create as &$item_to_create) {
+            if (isset($bible_verses_indexed[$item_to_create['book_id']])) {
+                $verses = 0;
+                foreach ($bible_verses_indexed[$item_to_create['book_id']] as $chapter => $verse_count) {
+                    if ((int) $chapter >= $item_to_create['chapter_start'] &&
+                        (int) $chapter <= $item_to_create['chapter_end']
+                    ) {
+                        $verses = $verses + (int) $verse_count;
+                    }
+                }
+                $item_to_create['verses'] = $verses;
+            }
+        }
+
+        unset($item_to_create);
+    }
+
+    /**
+     * Filter the collection of transport stream by verse_start and verse_end properties
+     *
+     * @param Array $item
+     * @param Collection $transportStream
+     * @param BibleFile $bible_file
+     */
+    public function processVersesOnTransportStream(Array $item, Collection $transportStream, BibleFile $bible_file)
+    {
+        if ($item['chapter_end'] === $item['chapter_start']) {
+            $transportStream = $transportStream->splice(1, $item['verse_end'])->all();
+            return collect($transportStream)->slice($item['verse_start'] - 1)->all();
+        }
+
+        $transportStream = $transportStream->splice(1)->all();
+        if ($bible_file->chapter_start === $item['chapter_start']) {
+            return collect($transportStream)->slice($item['verse_start'] - 1)->all();
+        }
+        if ($bible_file->chapter_start === $item['chapter_end']) {
+            return collect($transportStream)->splice(0, $item['verse_end'])->all();
+        }
+
+        return $transportStream;
     }
 
     /**
@@ -529,8 +769,8 @@ class PlanService
         }
 
         $playlist_items = PlaylistItems::whereIn('playlist_id', $playlist_ids)->get();
-        $this->playlist_service->calculateDurationAndUpdateItem($playlist_items, $save);
-        $this->playlist_service->calculateVersesAndUpdateItem($playlist_items, $save);
+        $this->playlist_service->calculateDuration($playlist_items);
+        $this->playlist_service->calculateVerses($playlist_items);
 
         if ($save === true) {
             foreach ($playlist_items as $playlist_item) {

--- a/app/Services/Plans/PlaylistService.php
+++ b/app/Services/Plans/PlaylistService.php
@@ -218,7 +218,7 @@ class PlaylistService
      *
      * @return Plan
      */
-    public function calculateDurationAndUpdateItem(?Collection $playlist_items) : void
+    public function calculateDuration(?Collection $playlist_items) : void
     {
         foreach ($playlist_items as $playlist_item) {
             $playlist_item->calculateDuration();
@@ -232,7 +232,7 @@ class PlaylistService
      *
      * @return Plan
      */
-    public function calculateVersesAndUpdateItem(?Collection $playlist_items) : void
+    public function calculateVerses(?Collection $playlist_items) : void
     {
         foreach ($playlist_items as $playlist_item) {
             $playlist_item->calculateVerses();


### PR DESCRIPTION

# Description
It has added a refactor to improve the methods to calculate the duration and the amount of verses for each playlist item. It has created a single sql query to avoid running a sql query for each playlist item.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-313

## How Do I QA This
- Execute the translate method from sever through shell command

```bash
php artisan translate:plan 209 BENBBS
```

- I have tested it from local environment and the next was the result. It is taking around 1 second to translate the plan 209 to BENBBS

```bash
**************************************************************************
*     Translating plan Bible in a Year starting: 2022-02-11 21:19:59     *
**************************************************************************

Translating plan to bible BENBBS started 2022-02-11 21:19:59
Translating plan to bible BENBBS finalized 2022-02-11 21:20:00
Plan Translated ID: 76090 2022-02-11 21:20:00
Plan Translated Language ID: 748 2022-02-11 21:20:00


*****************************************************
*     Translating plan end: 2022-02-11 21:20:00     *
*****************************************************
```
