### PR TITLE
FCBHDBP-297 optimize bibles filter on audio_timing by shaving 20% off response time

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -941,7 +941,7 @@ class PlansController extends APIController
             return $this->setStatusCode(404)->replyWithError('Bible Not Found');
         }
 
-        $plan = $this->plan_service->getPlanById($plan_id);
+        $plan = $this->plan_service->getPlanById((int) $plan_id);
 
         if (!$plan) {
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -865,7 +865,7 @@ class PlaylistsController extends APIController
             return $this->setStatusCode(404)->replyWithError('Bible Not Found');
         }
 
-        $playlist = Playlist::findOne($playlist_id);
+        $playlist = Playlist::findOne((int) $playlist_id);
 
         if (!$playlist || (isset($playlist->original) && $playlist->original['error'])) {
             return $this->setStatusCode(404)->replyWithError('Playlist Not Found');


### PR DESCRIPTION

# Description
 It has decrease the sql query response time to pull the bibles that have a bible_file_timestamps record attached.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-297

## How Do I QA This
- Execute the next postman URL
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-2d51eef3-8ae8-47e5-adf2-d00fde945f62

## Screenshot
- The old sql queries are taking around 870ms in my local environment as you can see in the next screenshot
![screenshot-localhost_8080-2022 02 15-00_28_42](https://user-images.githubusercontent.com/73488660/154148889-673f3cbe-7dcb-4412-b644-4811c7550f49.png)

- Now, sql queries are taking around 570ms in my local environment and it has decreased around 300ms as you can see in the next screenshot
![screenshot-localhost_8080-2022 02 15-00_27_47](https://user-images.githubusercontent.com/73488660/154148945-fffbb1ed-b2d0-4e89-b1f4-6a7c65b23d52.png)

