### PR TITLE
FCBHDBP-325 Update languages endpoint to sort by default by country_population virtual field

### DIFF
--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -119,6 +119,7 @@ class LanguagesController extends APIController
                 ->includeAutonymTranslation()
                 ->includeExtraLanguageTranslations($include_translations)
                 ->includeCountryPopulation($country)
+                ->includeOrderByCountryPopulation()
                 ->isContentAvailable($key)
                 ->filterableByCountry($country)
                 ->filterableByIsoCode($code)

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -9,6 +9,7 @@ use App\Models\Bible\Video;
 use App\Models\Country\CountryLanguage;
 use App\Models\Country\CountryRegion;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use App\Models\Country\Country;
 use App\Models\Resource\Resource;
 
@@ -820,5 +821,18 @@ class Language extends Model
         }
 
         return $new_language_query;
+    }
+
+    /**
+     * Sort the languages records by country_population
+     *
+     * @param Builder $query
+     * @see scopeIncludeCountryPopulation
+     *
+     * @return Builder
+     */
+    public function scopeIncludeOrderByCountryPopulation(Builder $query) : Builder
+    {
+        return $query->orderBy('country_population', 'DESC');
     }
 }


### PR DESCRIPTION

# Description
It has added to the languages endpoint the feature to sort by default by the country_population field descending.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-325

## How Do I QA This
- Execute the next postman test
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-93d594d1-39af-4d49-8ed7-b1781f52ed2a