### PR TITLE
FCBHDBP-334 Add the type and limit parameters as cache keys for the download endpoint

### DIFF
--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -64,7 +64,7 @@ class BibleFilesetsDownloadController extends APIController
         $limit = max($limit, 5000);
         $key = $this->getKey();
 
-        $cache_params = $this->removeSpaceFromCacheParameters([$fileset_id, $book_id, $chapter, $key]);
+        $cache_params = $this->removeSpaceFromCacheParameters([$fileset_id, $book_id, $chapter, $key, $limit, $type]);
 
         $fileset_chapters = cacheRemember(
             $cache_key,


### PR DESCRIPTION
# Description
It has added the parameters: type and limit as cache keys for the endpoint to download a fileset by ID.

Currently, the download endpoint is not considering the parameters: type and limit as cache keys. So, it is not working well when we need to filter by type or we need to change the limit value.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-334

## How Do I QA This
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-49822901-3c33-40e1-b4b4-1200c7c35f2d
