### PR TITLE
FCBHDBP-332 exclude opus audio from playlists

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -18,6 +18,7 @@ use App\Models\Bible\BibleVerse;
 use App\Traits\CallsBucketsTrait;
 use App\Traits\CheckProjectMembership;
 use App\Transformers\PlaylistTransformer;
+use App\Transformers\PlaylistItemsTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
@@ -168,7 +169,7 @@ class PlaylistsController extends APIController
                     }
                     $query_items->with(['fileset' => function ($query_fileset) {
                         $query_fileset->with('bible');
-                    }]);
+                    }])->conditionTagExclude(['opus', 'webm']);
                 }]);
             })
             ->when($language_id, function ($q) use ($language_id) {
@@ -273,35 +274,13 @@ class PlaylistsController extends APIController
             $playlist_items = array_slice($playlist_items, 0, $allowed_size);
         }
 
-        $playlist_items_to_create = [];
-        $order = 1;
+        $playlist_items_object = [];
 
         foreach ($playlist_items as $playlist_item) {
-            $playlist_item = (object) $playlist_item;
-            $playlist_item_data = [
-                'playlist_id'       => $playlist->id,
-                'fileset_id'        => $playlist_item->fileset_id,
-                'book_id'           => $playlist_item->book_id,
-                'chapter_start'     => $playlist_item->chapter_start,
-                'chapter_end'       => $playlist_item->chapter_end,
-                'verse_start'       => $playlist_item->verse_start ?? null,
-                'verse_end'         => $playlist_item->verse_end ?? null,
-                'verses'            => $playlist_items->verses ?? 0,
-                'order_column'      => $order
-            ];
-            $playlist_items_to_create[] = $playlist_item_data;
-            $order += 1;
+            $playlist_items_object[] = (object) $playlist_item;
         }
-        PlaylistItems::insert($playlist_items_to_create);
-        $created_playlist_items = PlaylistItems::where('playlist_id', $playlist->id)->orderBy('order_column')->get();
 
-        $this->playlist_service->calculateDuration($created_playlist_items);
-        $this->playlist_service->calculateVerses($created_playlist_items);
-
-        foreach ($created_playlist_items as $playlist_item) {
-            $playlist_item->save();
-        }
-        return $created_playlist_items;
+        return $this->playlist_service->createPlaylistItems($playlist->id, $playlist_items_object);
     }
 
     /**
@@ -682,18 +661,31 @@ class PlaylistsController extends APIController
         $playlist_items = json_decode($request->getContent());
         $single_item = checkParam('fileset_id');
 
-        if ($single_item) {
+        if ($single_item && !is_array($playlist_items)) {
             $playlist_items = [$playlist_items];
         }
+
         $created_playlist_items = $this->createPlaylistItems($playlist, $playlist_items);
 
-        return $this->reply($single_item ? $created_playlist_items[0] : $created_playlist_items);
+        $final_response = fractal(
+            $created_playlist_items,
+            new PlaylistItemsTransformer(),
+            new ArraySerializer()
+        );
+
+        if ($single_item) {
+            $final_response_array = $final_response->toArray();
+
+            if (!empty($final_response_array)) {
+                return $final_response_array[0];
+            }
+        }
+
+        return $final_response;
     }
 
     private function createPlaylistItems($playlist, $playlist_items)
     {
-        $created_playlist_items = [];
-
         $current_items_size = sizeof($playlist->items);
         $new_items_size = sizeof($playlist_items);
 
@@ -702,28 +694,7 @@ class PlaylistsController extends APIController
             $playlist_items = array_slice($playlist_items, 0, $allowed_size);
         }
 
-        foreach ($playlist_items as $playlist_item) {
-            $verses = $playlist_items->verses ?? 0;
-            $playlist_item = (object) $playlist_item;
-            $created_playlist_item = PlaylistItems::create([
-                'playlist_id'       => $playlist->id,
-                'fileset_id'        => $playlist_item->fileset_id,
-                'book_id'           => $playlist_item->book_id,
-                'chapter_start'     => $playlist_item->chapter_start,
-                'chapter_end'       => $playlist_item->chapter_end,
-                'verse_start'       => $playlist_item->verse_start ?? null,
-                'verse_end'         => $playlist_item->verse_end ?? null,
-                'verses'            => $verses
-            ]);
-            $created_playlist_item->calculateDuration();
-            if (!$verses) {
-                $created_playlist_item->calculateVerses();
-            }
-            $created_playlist_item->save();
-            $created_playlist_items[] = $created_playlist_item;
-        }
-
-        return $created_playlist_items;
+        return $this->playlist_service->createPlaylistItems($playlist->id, $playlist_items);
     }
 
     public function createTranslatedPlaylistItems($playlist, $playlist_items)

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -5,6 +5,8 @@ namespace App\Models\Bible;
 use App\Models\Organization\Asset;
 use App\Models\Organization\Organization;
 use App\Models\User\AccessGroupFileset;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -312,5 +314,42 @@ class BibleFileset extends Model
                 break;
         }
         return $result;
+    }
+
+    /**
+     * Filter record by given ids array
+     *
+     * @param Builder $query
+     * @param Array $fileset_ids
+     *
+     * @return Builder
+     */
+    public function scopeFilterByIds(Builder $query, Array $fileset_ids) : Builder
+    {
+        return $query->select('id', 'hash_id')
+            ->whereIn('id', $fileset_ids);
+    }
+
+    /**
+     * Get records that they are not related with the tag
+     *
+     * @param Builder $query
+     * @param Array $tags_exclude
+     *
+     * @return Builder
+     */
+    public function scopeConditionTagExclude(Builder $query, Array $tags_exclude) : Builder
+    {
+        return $query->whereDoesntHave('meta', function ($query_meta) use ($tags_exclude) {
+            $query_meta->where('description', $tags_exclude);
+        });
+    }
+
+    public static function getConditionTagExcludeByIds(Array $fileset_ids, Array $tags_exclude) : Collection
+    {
+        return self::filterByIds($fileset_ids)
+            ->conditionTagExclude($tags_exclude)
+            ->get()
+            ->keyBy('id');
     }
 }

--- a/app/Models/Playlist/Playlist.php
+++ b/app/Models/Playlist/Playlist.php
@@ -192,7 +192,8 @@ class Playlist extends Model
 
             $query_items->with(['fileset' => function ($query_fileset) {
                 $query_fileset->with('bible');
-            }]);
+            }])
+            ->conditionTagExcludeFileset(['opus', 'webm']);
         }])
             ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user_id) {
                 $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')
@@ -258,7 +259,8 @@ class Playlist extends Model
 
             $query_items->with(['fileset' => function ($query_fileset) {
                 $query_fileset->with('bible');
-            }]);
+            }])
+            ->conditionTagExcludeFileset(['opus', 'webm']);
         }])
             ->leftJoin('playlists_followers as playlists_followers', function ($join) use ($user_id) {
                 $join->on('playlists_followers.playlist_id', '=', 'user_playlists.id')

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -666,4 +666,26 @@ class PlaylistItems extends Model implements Sortable
             ]
         );
     }
+
+    /**
+     * Get records that they are not related with the tag
+     *
+     * @param Builder $query
+     * @param Array $tags_exclude
+     *
+     * @return Builder
+     */
+    public function scopeConditionTagExcludeFileset(Builder $query, Array $tags_exclude)
+    {
+        $query->whereNotExists(function ($sub_query) {
+            $dbp_prod = config('database.connections.dbp.database');
+
+            return $sub_query
+                ->select(\DB::raw(1))
+                ->from($dbp_prod . '.bible_filesets as bf')
+                ->join($dbp_prod . '.bible_fileset_tags as bft', 'bft.hash_id', 'bf.hash_id')
+                ->whereColumn('bf.id', '=', 'playlist_items.fileset_id')
+                ->whereIn($dbp_prod . '.bft.description', ['opus', 'webm']);
+        });
+    }
 }

--- a/app/Services/Plans/PlaylistService.php
+++ b/app/Services/Plans/PlaylistService.php
@@ -238,4 +238,59 @@ class PlaylistService
             $playlist_item->calculateVerses();
         }
     }
+
+    /**
+     * Create play list items according given playlist ID and the playlist items Data
+     *
+     * @param int $playlist_id
+     * @param Array $playlist_items
+     * @return Collection
+     */
+    public function createPlaylistItems(int $playlist_id, Array $playlist_items) : ?Collection
+    {
+        $playlist_items_to_create = [];
+        $order = 1;
+
+        $fileset_ids = [];
+        foreach ($playlist_items as $playlist_item) {
+            $fileset_ids[] = $playlist_item->fileset_id;
+        }
+
+        $filesets_validated = !empty($fileset_ids)
+            ? BibleFileset::getConditionTagExcludeByIds($fileset_ids, ['opus', 'webm'])
+            : [];
+
+        foreach ($playlist_items as $playlist_item) {
+            if (!isset($filesets_validated[$playlist_item->fileset_id])) {
+                continue;
+            }
+
+            $playlist_item_data = [
+                'playlist_id'       => $playlist_id,
+                'fileset_id'        => $playlist_item->fileset_id,
+                'book_id'           => $playlist_item->book_id,
+                'chapter_start'     => $playlist_item->chapter_start,
+                'chapter_end'       => $playlist_item->chapter_end,
+                'verse_start'       => $playlist_item->verse_start ?? null,
+                'verse_end'         => $playlist_item->verse_end ?? null,
+                'verses'            => $playlist_items->verses ?? 0,
+                'order_column'      => $order
+            ];
+            $playlist_items_to_create[] = $playlist_item_data;
+            $order += 1;
+        }
+
+        PlaylistItems::insert($playlist_items_to_create);
+
+        $created_playlist_items = PlaylistItems::findByIdsWithFilesetRelation([$playlist_id], 'order_column');
+
+        $this->calculateDuration($created_playlist_items);
+        $this->calculateVerses($created_playlist_items);
+
+        foreach ($created_playlist_items as $playlist_item) {
+            $playlist_item->save();
+        }
+
+        return $created_playlist_items;
+    }
 }

--- a/app/Transformers/PlaylistItemsTransformer.php
+++ b/app/Transformers/PlaylistItemsTransformer.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Transformers;
+
+class PlaylistItemsTransformer extends PlanTransformerBase
+{
+    /**
+     * A Fractal transformer.
+     *
+     * @return array
+     */
+    public function transform($playlist_item)
+    {
+        $bible = optional(optional($playlist_item->fileset)->bible)->first();
+        $book_name = $bible
+            ? $this->getBookNameFromItem($bible, $playlist_item->book_id)
+            : null;
+
+        return [
+            "id" => $playlist_item->id,
+            "fileset_id" => $playlist_item->fileset_id,
+            "book_id" => $playlist_item->book_id,
+            "chapter_start" => $playlist_item->chapter_start,
+            "chapter_end" => $playlist_item->chapter_end,
+            "verse_start" => $playlist_item->verse_start,
+            "verse_end" => $playlist_item->verse_end,
+            "verses" => $playlist_item->verses,
+            "duration" => $playlist_item->duration,
+            "completed" => $playlist_item->completed,
+            "full_chapter" => $playlist_item->full_chapter,
+            "path" => $playlist_item->path,
+            "metadata" => $bible ? [
+                "bible_id" => $bible->id,
+                "bible_name" => optional(
+                    $bible->translations->where('language_id', $GLOBALS['i18n_id'])->first()
+                )->name,
+                "bible_vname" => optional($bible->vernacularTranslation)->name,
+                "book_name" => $book_name
+            ] : null,
+        ];
+    }
+}


### PR DESCRIPTION

# Description
It has added the feature to ignore `opus` and `webm` content when DPB is creating or serving the playlist through the plan endpoint and the playlist endpoint.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-332

## How Do I QA This
- Execute a runner with the next folder: exclude opus content
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-6602194c-3589-4e1a-9a0c-c0710a592cd8
