### PR TITLE
FCBHDBP-335 download of usx fileset returns a playlist, which is incorrect

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -364,4 +364,32 @@ class BibleFileset extends Model
             ->get()
             ->keyBy('id');
     }
+
+    /**
+     * Get a boolean to know if the fileset belongs to audio type
+     *
+     * @return bool
+     */
+    public function isAudio() : bool
+    {
+        return in_array(
+            $this['set_type_code'],
+            [
+                BibleFileset::TYPE_AUDIO_DRAMA,
+                BibleFileset::TYPE_AUDIO,
+                BibleFileset::TYPE_AUDIO_DRAMA,
+                BibleFileset::TYPE_AUDIO_DRAMA_STREAM
+            ]
+        );
+    }
+
+    /**
+     * Get a boolean to know if the fileset belongs to video type
+     *
+     * @return bool
+     */
+    public function isVideo() : bool
+    {
+        return Str::contains($this['set_type_code'], BibleFileset::VIDEO);
+    }
 }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -36,12 +36,24 @@ use Illuminate\Support\Str;
  */
 class BibleFileset extends Model
 {
+    public const AUDIO = 'audio';
+    public const VIDEO = 'video';
+    public const TEXT = 'text';
+
+    public const TYPE_AUDIO_DRAMA = 'audio_drama';
+    public const TYPE_AUDIO = 'audio';
+    public const TYPE_AUDIO_STREAM = 'audio_stream';
+    public const TYPE_AUDIO_DRAMA_STREAM = 'audio_drama_stream';
+    public const TYPE_VIDEO_STREAM = 'video_stream';
+    public const TYPE_TEXT_FORMAT = 'text_format';
+    public const TYPE_TEXT_PLAIN = 'text_plain';
+    public const TYPE_TEXT_USX = 'text_usx';
+
     protected $connection = 'dbp';
     public $incrementing = false;
     protected $keyType = 'string';
     protected $hidden = ['created_at', 'updated_at', 'response_time', 'hidden', 'bible_id', 'hash_id'];
     protected $fillable = ['name', 'set_type', 'organization_id', 'variation_id', 'bible_id', 'set_copyright'];
-
 
     /**
      *

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -3,7 +3,6 @@
 namespace App\Traits;
 
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
-use Illuminate\Support\Str;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileSecondary;
 use App\Models\Bible\BibleVerse;
@@ -253,7 +252,6 @@ trait BibleFileSetsTrait
             $fileset->set_type_code === BibleFileset::TYPE_VIDEO_STREAM ||
             $fileset->set_type_code === BibleFileset::TYPE_AUDIO_STREAM ||
             $fileset->set_type_code === BibleFileset::TYPE_AUDIO_DRAMA_STREAM;
-        $is_video = Str::contains($fileset->set_type_code, BibleFileset::VIDEO);
 
         if ($is_stream) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
@@ -273,11 +271,11 @@ trait BibleFileSetsTrait
             }
         } else {
             // Multiple files per chapter
-            $hasMultiMp3Chapter = $this->hasMultipleMp3Chapters($fileset_chapters);
-            if (sizeof($fileset_chapters) > 1 &&
-                !$is_video && $hasMultiMp3Chapter &&
-                $fileset->set_type_code !== BibleFileset::TYPE_TEXT_USX
-            ) {
+            $hasMultiMp3Chapter = $fileset->isAudio() &&
+                sizeof($fileset_chapters) > 1 &&
+                $this->hasMultipleMp3Chapters($fileset_chapters);
+
+            if ($hasMultiMp3Chapter) {
                 $fileset_chapters[0]->file_name = route(
                     'v4_media_stream',
                     [
@@ -310,7 +308,7 @@ trait BibleFileSetsTrait
             }
         }
 
-        if ($is_video) {
+        if ($fileset->isVideo()) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
                 $fileset_chapters[$key]->thumbnail = $this->signedUrlUsingClient(
                     $client,

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -8,6 +8,7 @@ use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileSecondary;
 use App\Models\Bible\BibleVerse;
 use App\Models\Organization\Asset;
+use App\Models\Bible\BibleFileset;
 use App\Transformers\FileSetTransformer;
 use App\Transformers\TextTransformer;
 use DB;
@@ -249,10 +250,10 @@ trait BibleFileSetsTrait
         $client
     ) {
         $is_stream =
-            $fileset->set_type_code === 'video_stream' ||
-            $fileset->set_type_code === 'audio_stream' ||
-            $fileset->set_type_code === 'audio_drama_stream';
-        $is_video = Str::contains($fileset->set_type_code, 'video');
+            $fileset->set_type_code === BibleFileset::TYPE_VIDEO_STREAM ||
+            $fileset->set_type_code === BibleFileset::TYPE_AUDIO_STREAM ||
+            $fileset->set_type_code === BibleFileset::TYPE_AUDIO_DRAMA_STREAM;
+        $is_video = Str::contains($fileset->set_type_code, BibleFileset::VIDEO);
 
         if ($is_stream) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
@@ -273,7 +274,10 @@ trait BibleFileSetsTrait
         } else {
             // Multiple files per chapter
             $hasMultiMp3Chapter = $this->hasMultipleMp3Chapters($fileset_chapters);
-            if (sizeof($fileset_chapters) > 1 && !$is_video && $hasMultiMp3Chapter) {
+            if (sizeof($fileset_chapters) > 1 &&
+                !$is_video && $hasMultiMp3Chapter &&
+                $fileset->set_type_code !== BibleFileset::TYPE_TEXT_USX
+            ) {
                 $fileset_chapters[0]->file_name = route(
                     'v4_media_stream',
                     [


### PR DESCRIPTION
# Description
It has added the constraint to handle the `TEXT_USX` type when user tries to download a fileset and it has fixed the issue related with the endpoint to download the fileset and the `usx` type.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-335

## How Do I QA This
- Execute the next postman test
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-8c747e11-8ae5-4014-afaf-284e37d24861

## NOTE
The above postman test has been updated because the book name for the MAT book id is: "SAN MATEO" as you can see in the next block

```javascript
pm.test("Matthew 1 properties", function () {
    const target = jsonData.find (m => m.book_id === "MAT");
    pm.expect(target.book_id).to.eql("MAT");
    pm.expect(target.book_name).to.eql("SAN MATEO");
    //pm.expect(target.book_name).to.eql("1 CORINTIOS");
    pm.expect(target).to.have.property("path");
});
```
