### PR TITLE
FCBHDBP-353 modify download endpoint for bibleis key - use access groups for key instead of for 19x

### DIFF
--- a/app/Models/User/AccessGroupKey.php
+++ b/app/Models/User/AccessGroupKey.php
@@ -3,6 +3,7 @@
 namespace App\Models\User;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
 /**
  * App\Models\User\AccessGroupFunction
@@ -66,5 +67,22 @@ class AccessGroupKey extends Model
     public function filesets()
     {
         return $this->hasMany(AccessGroupFileset::class, 'access_group_id', 'access_group_id')->unique();
+    }
+
+    /**
+     * Get a list of access group ids associated with the api key
+     *
+     * @param $api_key
+     * @return Array
+     */
+    public static function getAccessGroupIdsByApiKey(string $api_key) : Collection
+    {
+        return  AccessGroupKey::select('access_group_id')
+            ->join('user_keys', function ($join) use ($api_key) {
+                $join->on('user_keys.id', '=', 'access_group_api_keys.key_id')
+                    ->where('user_keys.key', $api_key);
+            })
+            ->get()
+            ->pluck('access_group_id');
     }
 }

--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -158,6 +158,18 @@ trait AccessControlAPI
         );
     }
 
+    /**
+     * Validate if an api key belongs to the Bible.is client
+     *
+     * @param string $api_key
+     *
+     * @return string
+     */
+    private function doesApiKeyBelongToBibleis(string $api_key) : bool
+    {
+        return config('auth.compat_users.api_keys.bibleis') === $api_key;
+    }
+
     public function blockedByAccessControl($fileset)
     {
         $access_control = $this->accessControl($this->key);
@@ -178,8 +190,12 @@ trait AccessControlAPI
 
     public function allowedForDownload($fileset)
     {
-        $download_access_group_list = config('settings.download_access_group_list');
-        $download_access_group_array_ids = explode(',', $download_access_group_list);
+        if ($this->doesApiKeyBelongToBibleis($this->key)) {
+            $download_access_group_array_ids = AccessGroupKey::getAccessGroupIdsByApiKey($this->key)->toArray();
+        } else {
+            $download_access_group_array_ids = explode(',', config('settings.download_access_group_list'));
+        }
+
         $allowed_fileset_for_download = $this->genericAccessControl(
             $this->key,
             $fileset->hash_id,


### PR DESCRIPTION
# Description
It added a feature to skip only for the bible.is key the constraint that validates the access groups 19x for the API key.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-353

## How Do I QA This
- Run all postman URL in the folder (bible is API key)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-dd4eb082-6467-4b3f-83d7-00316604c6b9

- Run all postman URL in the folder (other API key)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-1ff774f6-86d7-480b-a672-539b30beb6e6