### PR TITLE
FCBHDBP-354 500 error - languages search with special character

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -376,7 +376,7 @@ class APIController extends Controller
      */
     public function transformQuerySearchText(string $search_text): string
     {
-        $formatted_search = preg_replace('/[+\-><\(\)~*\"@]+/', ' ', $search_text);
+        $formatted_search = preg_replace('/[+\-><\(\)~*\"@%]+/', ' ', $search_text);
         $formatted_search = preg_replace('!\s+!', ' ', $formatted_search);
         return trim($formatted_search);
     }


### PR DESCRIPTION

# Description
 It has added the feature to remove the special character: `%` from the search text parameter. The search text parameter is used by the endpoints to search languages, countries and bibles.

### Note
This change should also fix the tickets [DBP-355](https://fullstacklabs.atlassian.net/browse/FCBHDBP-355) and [DBP-356](https://fullstacklabs.atlassian.net/browse/FCBHDBP-356)

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-354

## How Do I QA This
- Run each one postman URL in the `Miscellaneous / Sentinels` dev folder and they should pass
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-2369df70-b9a7-41c5-baa1-98b8ffe10969

- Run [M] Miscellaneous / Sentinels folder
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/collection/12519377-26e0ef3f-c802-4a82-9612-d5c9f62643ce?action=share&creator=17122915