### PR TITLE
FCBHDBP-353 modify download endpoint for bibleis key - use access groups for key instead of for 19x

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -222,11 +222,24 @@ class StreamController extends APIController
             return $this->setStatusCode(404)->replyWithError('No Audio fileset found for the provided params');
         }
 
-        $bible_files = BibleFile::where([
-            'hash_id' => $audio_fileset->hash_id,
-            'book_id' => $parts[0],
-            'chapter_start' => $parts[1]
-        ])->get();
+        // The implementation of the new download endpoint has caused a route collision on
+        // route: /api/bible/filesets/{fileset_id}/{book_id}-{chapter}-{verse_start?}-{verse_end?}/playlist.m3u8.
+        // Route name: v4_media_stream
+        // Example: http://APP_ROOT_PATH/api/bible/filesets/SVCWBTS2DA/MAT---/playlist.m3u8
+        // The existing route has a required chapter identifier, which is not present when called by the download route.
+        // This logic will return all mp3 files if no chapter is provided.
+        if ($parts[1]) {
+            $bible_files = BibleFile::where([
+                'hash_id' => $audio_fileset->hash_id,
+                'book_id' => $parts[0],
+                'chapter_start' => $parts[1]
+            ])->get();
+        } else {
+            $bible_files = BibleFile::where([
+                'hash_id' => $audio_fileset->hash_id,
+                'book_id' => $parts[0],
+            ])->whereNull('chapter_start')->get();
+        }
 
         $transaction_id = random_int(0, 10000000);
         $current_file = "#EXTM3U\n";

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -277,14 +277,26 @@ trait BibleFileSetsTrait
                 $this->hasMultipleMp3Chapters($fileset_chapters);
 
             if ($hasMultiMp3Chapter) {
-                $fileset_chapters[0]->file_name = route(
-                    'v4_media_stream',
-                    [
-                        'fileset_id' => $fileset->id,
-                        'book_id' => $fileset_chapters[0]->book_id,
-                        'chapter' => $fileset_chapters[0]->chapter_start,
-                    ]
-                );
+                if ($fileset_chapters[0]->chapter_start) {
+                    $fileset_chapters[0]->file_name = route(
+                        'v4_media_stream',
+                        [
+                            'fileset_id' => $fileset->id,
+                            'book_id' => $fileset_chapters[0]->book_id,
+                            'chapter' => $fileset_chapters[0]->chapter_start,
+                        ]
+                    );
+                } else {
+                    $fileset_chapters[0]->file_name = sprintf(
+                        '%s/bible/filesets/%s/%s-%s-%s-%s/playlist.m3u8',
+                        config('app.api_url'),
+                        $fileset->id,
+                        $fileset_chapters[0]->book_id,
+                        $fileset_chapters[0]->chapter_start,
+                        '',
+                        ''
+                    );
+                }
                 if (!empty($fileset_chapters) > 0 && $fileset_chapters->last() instanceof \App\Models\Bible\BibleFile) {
                     $collection = $fileset_chapters;
                 } else {

--- a/routes/api.php
+++ b/routes/api.php
@@ -153,7 +153,6 @@ Route::name('v4_timestamps.verse')->get(
     'Bible\AudioController@timestampsByReference'
 );
 
-
 // VERSION 4 | Stream
 Route::name('v4_media_stream')->get(
     'bible/filesets/{fileset_id}/{file_id}/playlist.m3u8',


### PR DESCRIPTION

# Description
It has updated the `v4_media_stream` route to set the chapter parameter as not mandatory. This fix is because when it tries to generate to v4_media_stream route it is sending the chapter null. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-353

## How Do I QA This
- Execute the next postman test.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ff2132f5-c332-4a89-8821-76beaf537629
