### PR TITLE
FCBHDBP-342 hardening: optimize /v4_bible_filesets_download.list

### DIFF
--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -184,15 +184,7 @@ class BibleFilesetsDownloadController extends APIController
             $cache_params,
             now()->addHours(12),
             function () use ($key, $limit, $type) {
-                return BibleFilesetLookup::contentAvailable($key)
-                    ->select(['filesetid', 'type', 'language', 'licensor'])
-                    ->when($type, function ($query) use ($type) {
-                        $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($type);
-                        $query->whereIn('type', $set_type_code_array);
-                    })
-                    ->distinct()
-                    ->orderBy('filesetid')
-                    ->paginate($limit);
+                return BibleFilesetLookup::getContentAvailableByKey($key, $limit, $type);
             }
         );
 

--- a/app/Models/Bible/BibleFilesetCopyrightRole.php
+++ b/app/Models/Bible/BibleFilesetCopyrightRole.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class BibleFilesetCopyrightRole extends Model
 {
+    const HOLDER = 1;
+    const LICENSOR = 2;
+    const PARTNER = 3;
+
     protected $connection = 'dbp';
     public $table = 'bible_fileset_copyright_roles';
 }

--- a/app/Models/Bible/BibleFilesetLookup.php
+++ b/app/Models/Bible/BibleFilesetLookup.php
@@ -4,14 +4,20 @@ namespace App\Models\Bible;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
-
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Pagination\LengthAwarePaginator;
 use App\Models\Bible\Bible;
 use App\Models\Bible\BibleFilesetConnection;
 use App\Models\Bible\BibleTranslation;
 use App\Models\Bible\BibleVerse;
 use App\Models\Bible\BibleFilesetTag;
+use App\Models\Bible\BibleFileset;
 use App\Models\Bible\BibleFileSecondary;
 use App\Models\Bible\BibleFile;
+use App\Models\Bible\BibleFilesetCopyrightRole;
+use App\Models\Language\Language;
+use App\Models\User\Key;
+use App\Models\Organization\Organization;
 
 /**
  * App\Models\Bible\BibleFilesetLookup
@@ -106,7 +112,48 @@ class BibleFilesetLookup extends Model
     }
 
 
-    public function scopeContentAvailable($query, $key)
+    public function scopeContentAvailable(Builder $query) : Builder
+    {
+        return $query->from('organizations')
+            ->join('bible_fileset_copyright_organizations', function ($join) {
+                $join->on('bible_fileset_copyright_organizations.organization_id', '=', 'organizations.id')
+                    ->where(
+                        'bible_fileset_copyright_organizations.organization_role',
+                        BibleFilesetCopyrightRole::LICENSOR
+                    );
+            })
+            ->join('bible_filesets', 'bible_fileset_copyright_organizations.hash_id', 'bible_filesets.hash_id')
+            ->join('bible_fileset_connections', 'bible_fileset_connections.hash_id', 'bible_filesets.hash_id')
+            ->join('bibles', 'bibles.id', 'bible_fileset_connections.bible_id')
+            ->join('languages', 'languages.id', 'bibles.language_id')
+            ->join('bible_fileset_tags', function ($join) {
+                $join->on('bible_filesets.hash_id', '=', 'bible_fileset_tags.hash_id')
+                    ->where('bible_fileset_tags.name', 'stock_no');
+            })
+            ->join('organization_translations', function ($join) {
+                $join->on(
+                    'organization_translations.organization_id',
+                    '=',
+                    'bible_fileset_copyright_organizations.organization_id'
+                )
+                    ->where('organization_translations.language_id', Language::ENGLISH_ID);
+            })
+            ->join('bible_translations', function ($join) {
+                $join->on('bible_translations.bible_id', '=', 'bibles.id')
+                    ->where('bible_translations.language_id', Language::ENGLISH_ID);
+            });
+    }
+
+    /**
+     * Get fileset list available for a user key given
+     *
+     * @param string $key
+     * @param int $limit
+     * @param string $type
+     *
+     * @return LengthAwarePaginator
+     */
+    public static function getContentAvailableByKey(string $key, int $limit, string $type = null) : LengthAwarePaginator
     {
         $dbp_users = config('database.connections.dbp_users.database');
         $dbp_prod = config('database.connections.dbp.database');
@@ -114,27 +161,54 @@ class BibleFilesetLookup extends Model
         $download_access_group_list = config('settings.download_access_group_list');
         $download_access_group_array_ids = explode(',', $download_access_group_list);
 
-        return $query
-            ->from($dbp_prod . '.bible_fileset_lookup as bfl')
+        $user_key_id = Key::getIdByKey($key);
+
+        $select_distinct_columns = [
+            'bible_fileset_tags.description',
+            'bibles.id',
+            'bible_filesets.id',
+            'bible_filesets.set_type_code',
+            'bible_filesets.hash_id',
+            'languages.name',
+            'bible_translations.name',
+            'organization_translations.name'
+        ];
+
+        return BibleFilesetLookup::select([
+                'bible_fileset_tags.description AS stocknumber',
+                'bibles.id AS bibleid',
+                'bible_filesets.id AS filesetid',
+                'bible_filesets.set_type_code AS type',
+                'bible_filesets.hash_id AS hash_id',
+                'languages.name AS language',
+                'bible_translations.name AS version',
+                'organization_translations.name AS licensor'
+            ])
+            ->distinct($select_distinct_columns)
+            ->contentAvailable()
+            ->whereNotIn('bible_filesets.set_type_code', ['text_format'])
+            ->whereRaw('bible_filesets.id NOT LIKE ?', '%DA16')
             ->join(
-                $dbp_prod . '.access_group_filesets_view as agfv',
+                $dbp_prod . '.access_group_filesets as agfv',
                 function ($join_agfv) use ($download_access_group_array_ids) {
                     $join_agfv
-                        ->on('agfv.hash_id', 'bfl.hash_id')
+                        ->on('agfv.hash_id', 'bible_filesets.hash_id')
                         ->whereIn('agfv.access_group_id', $download_access_group_array_ids);
                 }
             )
             ->join(
                 $dbp_users . '.access_group_api_keys as agak',
-                function ($join_agak) {
-                    $join_agak->on('agak.access_group_id', 'agfv.access_group_id');
+                function ($join_agak) use ($user_key_id, $download_access_group_array_ids) {
+                    $join_agak
+                        ->on('agak.access_group_id', 'agfv.access_group_id')
+                        ->where('agak.key_id', $user_key_id)
+                        ->whereIn('agak.access_group_id', $download_access_group_array_ids);
                 }
             )
-            ->whereRaw(
-                'agak.key_id = (select id from '.$dbp_users.'.user_keys where '.$dbp_users.'.user_keys.key = ?)',
-                [$key]
-            )
-            ->whereNotIn('bfl.type', ['text_format'])
-            ->whereRaw('filesetid NOT LIKE ?', '%DA16');
+            ->when($type, function ($query) use ($type) {
+                $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($type);
+                $query->whereIn('bible_filesets.set_type_code', $set_type_code_array);
+            })
+            ->paginate($limit, $select_distinct_columns);
     }
 }

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -86,6 +86,8 @@ use App\Models\Resource\Resource;
  */
 class Language extends Model
 {
+    const ENGLISH_ID = 6414;
+
     protected $connection = 'dbp';
     public $table = 'languages';
     protected $fillable = [

--- a/app/Models/User/Key.php
+++ b/app/Models/User/Key.php
@@ -106,4 +106,9 @@ class Key extends Model
     {
         return $this->belongsToMany(AccessGroup::class, config('database.connections.dbp_users.database').'.access_group_api_keys');
     }
+
+    public static function getIdByKey(string $key) : ?int
+    {
+        return optional(Key::select(['id'])->where('key', $key)->first())->id;
+    }
 }


### PR DESCRIPTION
# Description
It has done a refactor to improve the performance the list download endpoint. It has replaced the `bible_fileset_lookup` view with the entities themselves. Also, it has removed the `orderBy` clause because it affects the performance.

About the performance, in my local environment the response time is around 400ms with these changes. Before these changes the response time was about around 800ms.

## NOTE
The `orderBy` clause has been removed because it is affecting the performance. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-342

## How Do I QA This
- Execute the next postman test
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-c8406567-7b03-4070-91a6-46c645c82377

## Screenshot

- Time response related with the sql query with NEW changes.
![screenshot-localhost_8080-2022 03 22-12_49_09](https://user-images.githubusercontent.com/73488660/159544188-b0712fd1-ebd0-4407-bdf2-06254fc5e8cc.png)

- Time response related with the sql query with OLD code.
![screenshot-localhost_8080-2022 03 22-12_50_08](https://user-images.githubusercontent.com/73488660/159544311-ac54246d-1048-4a38-b740-3fe4052d8188.png)

