### PR TITLE
FCBHDBP-359 Search string needs url decode before being used as a cache key

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -376,7 +376,8 @@ class APIController extends Controller
      */
     public function transformQuerySearchText(string $search_text): string
     {
-        $formatted_search = preg_replace('/[+\-><\(\)~*\"@%]+/', ' ', $search_text);
+        $formatted_search = urldecode($search_text);
+        $formatted_search = preg_replace('/[+\-><\(\)~*\"@%]+/', ' ', $formatted_search);
         $formatted_search = preg_replace('!\s+!', ' ', $formatted_search);
         return trim($formatted_search);
     }

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -261,8 +261,8 @@ class BiblesController extends APIController
         $limit          = (int) (checkParam('limit') ?? 15);
         $limit          = min($limit, 50);
         $page           = checkParam('page') ?? 1;
-        $formatted_search_cache = str_replace(' ', '', $search_text);
         $formatted_search = $this->transformQuerySearchText($search_text);
+        $formatted_search_cache = str_replace(' ', '', $search_text);
 
         if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));

--- a/app/Http/Controllers/Wiki/CountriesController.php
+++ b/app/Http/Controllers/Wiki/CountriesController.php
@@ -121,8 +121,8 @@ class CountriesController extends APIController
         $limit     = (int) (checkParam('limit') ?? 15);
         $limit     = min($limit, 50);
         $page      = checkParam('page') ?? 1;
-        $formatted_search_cache = str_replace(' ', '', $search_text);
         $formatted_search = $this->transformQuerySearchText($search_text);
+        $formatted_search_cache = str_replace(' ', '', $search_text);
 
         if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -193,8 +193,8 @@ class LanguagesController extends APIController
         $limit = min($limit, 50);
         $set_type_code = checkParam('set_type_code');
         $media = checkParam('media');
-        $formatted_search_cache = str_replace(' ', '', $search_text);
         $formatted_search = $this->transformQuerySearchText($search_text);
+        $formatted_search_cache = str_replace(' ', '', $search_text);
 
         if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,8 +10,8 @@ Route::name('v4_countries.one')->get(
     'Wiki\CountriesController@show'
 );
 Route::name('v4_countries.search')->get(
-  'countries/search/{search_text}',
-  'Wiki\CountriesController@search'
+    'countries/search/{search_text}',
+    'Wiki\CountriesController@search'
 );
 
 // VERSION 4 | Languages
@@ -65,8 +65,8 @@ Route::name('v4_bible.one')->get(
     'Bible\BiblesController@show'
 ); // see note in Postman. the content is suspect
 Route::name('v4_bible.search')->get(
-  'bibles/search/{search_text}',
-  'Bible\BiblesController@search'
+    'bibles/search/{search_text}',
+    'Bible\BiblesController@search'
 );
 Route::name('v4_bible.all')
     ->get('bibles', 'Bible\BiblesController@index'); // used
@@ -98,7 +98,7 @@ Route::name('v4_internal_filesets.checkTypes')->post(
 // DEPRECATED. not used by bible.is after 3.0.x. But needs to remain in the API for backward compatibility until 3.0.x and older are gone
 Route::name('v4_internal_bible_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright', 'Bible\BibleFileSetsController@copyright');
 
-// DEPRECATED. Prefer instead v4_filesets.chapter. Reasons: It takes book and chapter as query parameters. 
+// DEPRECATED. Prefer instead v4_filesets.chapter. Reasons: It takes book and chapter as query parameters.
 Route::name('v4_internal_filesets.show')->get(
     'bibles/filesets/{fileset_id?}',
     'Bible\BibleFileSetsController@show'
@@ -112,12 +112,12 @@ Route::name('v4_filesets.books')->get(
 
 // the order of these next two routes matters, the most general (bibles/filesets/bulk) must go before /bibles/filesets/{fileset_id}
 Route::name('v4_filesets.bulk')->get(
-  'bibles/filesets/bulk/{fileset_id}/{book?}',
-  'Bible\BibleFileSetsController@showBulk'
+    'bibles/filesets/bulk/{fileset_id}/{book?}',
+    'Bible\BibleFileSetsController@showBulk'
 );
 Route::name('v4_filesets.chapter')->get(
-  'bibles/filesets/{fileset_id}/{book}/{chapter}',
-  'Bible\BibleFileSetsController@showChapter'
+    'bibles/filesets/{fileset_id}/{book}/{chapter}',
+    'Bible\BibleFileSetsController@showChapter'
 );
 
 // BibleFileSet download version 4
@@ -186,8 +186,8 @@ Route::name('v4_video_jesus_film_file')->get(
     'Bible\VideoStreamController@jesusFilmFile'
 );// used by bible.is
 Route::name('v4_video_jesus_film_chapter')->get(
-  'jesus-film/{language_iso}/{book}/{chapter}',
-  'Bible\VideoStreamController@jesusFilmGetChapter'
+    'jesus-film/{language_iso}/{book}/{chapter}',
+    'Bible\VideoStreamController@jesusFilmGetChapter'
 );// used by bible.is
 
 
@@ -293,13 +293,22 @@ Route::name('v4_internal_playlists_items.complete')
         'Playlist\PlaylistsController@completeItem'
     );
 Route::name('v4_internal_playlists.translate')
-    ->middleware('APIToken:check')->get('playlists/{playlist_id}/translate',        'Playlist\PlaylistsController@translate');
-Route::name('v4_internal_playlists.hls')->get('playlists/{playlist_id}/hls',                 'Playlist\PlaylistsController@hls');
-Route::name('v4_internal_playlists_item.hls')->get('playlists/{fileset_id}-{book_id}-{chapter}-{verse_start}-{verse_end}/item-hls',  'Playlist\PlaylistsController@itemHls');
-Route::name('v4_internal_playlists_item.hls')->get('playlists/{playlist_item_id}/item-hls',  'Playlist\PlaylistsController@itemHls');
+    ->middleware('APIToken:check')
+    ->get('playlists/{playlist_id}/translate', 'Playlist\PlaylistsController@translate');
+Route::name('v4_internal_playlists.hls')
+    ->get('playlists/{playlist_id}/hls', 'Playlist\PlaylistsController@hls');
+Route::name('v4_internal_playlists_item.hls')
+    ->get(
+        'playlists/{fileset_id}-{book_id}-{chapter}-{verse_start}-{verse_end}/item-hls',
+        'Playlist\PlaylistsController@itemHls'
+    );
+Route::name('v4_internal_playlists_item.hls')
+    ->get('playlists/{playlist_item_id}/item-hls', 'Playlist\PlaylistsController@itemHls');
 Route::name('v4_internal_playlists.draft')
-    ->middleware('APIToken:check')->post('playlists/{playlist_id}/draft',           'Playlist\PlaylistsController@draft');
-Route::name('v4_internal_playlists_item.metadata')->get('playlists/item/metadata',  'Playlist\PlaylistsController@itemMetadata');
+    ->middleware('APIToken:check')
+    ->post('playlists/{playlist_id}/draft', 'Playlist\PlaylistsController@draft');
+Route::name('v4_internal_playlists_item.metadata')
+    ->get('playlists/item/metadata', 'Playlist\PlaylistsController@itemMetadata');
 
 // VERSION 4 | Plans (bible.is private)
 Route::name('v4_internal_plans.index')


### PR DESCRIPTION
# Description
It has added the feature to use the method urldecode for the user-provided search string used by the search endpoints. It will be called immediately before to remove the special characters.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-359

## How Do I QA This
- ### Execute the next postman tests.
1. Language search url encode
 https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6b3d5bf2-770b-44f1-bc4a-f53083921a40
2. Bibles search without url encode characters
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0c02737c-57f9-4ac9-9797-af368e25df22
3. Bibles search url encode
 https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-52fb2655-2af4-4a95-9614-a1f0a8b9eb62
4. Bibles search url encode mixed
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-62c0050f-d17b-49db-810d-90ab4d1c5eb5
5. Countries search url encode
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0baca334-40ae-4b1a-9f3c-5cab14550dec
