### PR TITLE
FCBHDBP-359 Search string needs url decode before being used as a cache key

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -270,7 +270,7 @@ class BiblesController extends APIController
 
         $key = $this->key;
         $cache_params = [$limit, $page, $formatted_search_cache, $key];
-        $cache_key = generateCacheSafeKey('countries', $cache_params);
+        $cache_key = generateCacheSafeKey('bibles_search', $cache_params);
         
         $bibles = cacheRememberByKey($cache_key, now()->addDay(), function () use ($key, $limit, $formatted_search) {
             $bibles = Bible::isContentAvailable($key)

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -268,10 +268,10 @@ class LibraryController extends APIController
         $name = checkParam('name');
         $sort = checkParam('sort_by');
 
-        $cache_params = $this->removeSpaceFromCacheParameters([$code, $name, $sort]);
-        $versions = cacheRemember(
-            'v2_library_version',
-            $cache_params,
+        $cache_params = [$code, $name, $sort];
+        $cache_key = generateCacheSafeKey('v2_library_version', $cache_params);
+        $versions = cacheRememberByKey(
+            $cache_key,
             now()->addDay(),
             function () use ($code, $sort, $name) {
                 $english_id = Language::where('iso', 'eng')->first()->id ?? '6414';


### PR DESCRIPTION
# Description
It has updated /library/version endpoint to use the new logic about the way to generate a cache key.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-359

## How Do I QA This
- Run library version with special chars postman test
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-97570fc1-c810-45b4-b18d-2354a7fe76fa