### PR TITLE
FCBHDBP-357 fix batch of errors found in NewRelic (April 2022)

### DIFF
--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Symfony\Component\HttpFoundation\Response;
 use App\Models\Language\Language;
 use App\Models\User\Key;
 
@@ -160,16 +161,16 @@ class APIController extends Controller
             // If is an api call require the v parameter
             $this->v   = (int) checkParam('v', true, $this->preset_v);
             $this->key = checkParam('key', true);
-
-            $cache_params = [$this->key];
+            $cache_params = $this->removeSpaceFromCacheParameters([$this->key]);
             $keyExists = cacheRemember('keys', $cache_params, now()->addDay(), function () {
-                return Key::with('user')->where('key', $this->key)->first();
+                $user = Key::with('user')->where('key', $this->key)->first();
+                return $user ?? false;
             });
             $this->user = $keyExists->user ?? null;
 
             if (!$this->user) {
                 abort(
-                    401,
+                    Response::HTTP_UNAUTHORIZED,
                     'You need to provide a valid API key. To request an api key please email support@digitalbibleplatform.com'
                 );
             }

--- a/app/Http/Controllers/Bible/AudioController.php
+++ b/app/Http/Controllers/Bible/AudioController.php
@@ -136,9 +136,11 @@ class AudioController extends APIController
                 ->get();
             foreach ($bible_files as $bible_file) {
                 $currentBandwidth = $bible_file->streamBandwidth->first();
-                foreach ($currentBandwidth->transportStreamBytes as $stream) {
-                    if ($stream->timestamp) {
-                        $audioTimestamps[] = $stream->timestamp;
+                if ($currentBandwidth && $currentBandwidth->transportStreamBytes) {
+                    foreach ($currentBandwidth->transportStreamBytes as $stream) {
+                        if ($stream->timestamp) {
+                            $audioTimestamps[] = $stream->timestamp;
+                        }
                     }
                 }
             }

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -403,7 +403,7 @@ class BiblesController extends APIController
         $verse_count = checkBoolean('verse_count');
 
         $key = $this->key;
-        $cache_params = [$bible_id, $key, $verify_content];
+        $cache_params = [$bible_id, $key, $verify_content, $verse_count];
         $bible = cacheRemember('bible_books_bible', $cache_params, now()->addDay(), function () use ($bible_id, $verify_content, $key) {
             if (!$verify_content) {
                 return Bible::find($bible_id);

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -449,7 +449,8 @@ class LibraryController extends APIController
         }
 
         $cache_params = [$dam_id, $media, $language_name, $iso, $updated, $organization, $version_code, $key];
-        $filesets = cacheRemember('v2_library_volume', $cache_params, now()->addDay(), function () use ($dam_id, $media, $language_name, $iso, $updated, $organization, $version_code, $key) {
+        $cache_key = generateCacheSafeKey('v2_library_volume', $cache_params);
+        $filesets = cacheRememberByKey($cache_key, now()->addDay(), function () use ($dam_id, $media, $language_name, $iso, $updated, $organization, $version_code, $key) {
             $language_v2 = $this->getV2Language($iso);
             $v2_iso = optional($language_v2)->language_ISO_639_3_id;
             $language_id = $iso ? optional(Language::where('iso', $v2_iso ?? $iso)->first())->id : null;
@@ -669,12 +670,11 @@ class LibraryController extends APIController
         }
     }
     // This is used as an interface for backward compat with v2 languages due to iso code differences
-    private function getV2Language($code) 
+    private function getV2Language($code)
     {
-        $language_v2 = LanguageCodeV2::select(['id as v2Code', 'language_ISO_639_3_id', 'name', 'english_name'])
+        return LanguageCodeV2::select(['id as v2Code', 'language_ISO_639_3_id', 'name', 'english_name'])
             ->when($code, function ($query) use ($code) {
                 return $query->where('id', $code);
             })->first();
-        return $language_v2;
     }
 }

--- a/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
+++ b/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
@@ -8,9 +8,10 @@ trait TextControllerTrait
 {
     public function getVerses($cache_params, $fileset, $bible, $book, $chapter, $verse_start, $verse_end)
     {
-        return cacheRemember(
-            'bible_text',
-            $cache_params,
+        $cache_key = generateCacheSafeKey('bible_text', $cache_params);
+
+        return cacheRememberByKey(
+            $cache_key,
             now()->addDay(),
             function () use ($fileset, $bible, $book, $chapter, $verse_start, $verse_end) {
                 $select_columns = [

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1059,13 +1059,21 @@ class PlaylistsController extends APIController
         foreach ($bible_files as $bible_file) {
             if (isset($bible_file->streamBandwidth) && isset($bible_file->fileset)) {
                 $currentBandwidth = $bible_file->streamBandwidth->first();
-                $transportStream = sizeof($currentBandwidth->transportStreamBytes) ? $currentBandwidth->transportStreamBytes : $currentBandwidth->transportStreamTS;
+                $transportStream = $currentBandwidth->transportStreamBytes &&
+                    sizeof($currentBandwidth->transportStreamBytes) > 0
+                    ? $currentBandwidth->transportStreamBytes
+                    : $currentBandwidth->transportStreamTS;
     
                 // Fix verse audio stream starting from different initial verses causing audio missmatch
                 if (isset($item->verse_end) && isset($item->verse_start)) {
                     if (isset($transportStream[0]->timestamp)) {
-                        $timestamps_count = BibleFileTimestamp::where('bible_file_id', $transportStream[0]->timestamp->bible_file_id)->count();
-                        if ($timestamps_count === $transportStream->count() && $transportStream[0]->timestamp->verse_start !== 0) {
+                        $timestamps_count = BibleFileTimestamp::where(
+                            'bible_file_id',
+                            $transportStream[0]->timestamp->bible_file_id
+                        )->count();
+                        if ($timestamps_count === $transportStream->count() &&
+                            $transportStream[0]->timestamp->verse_start !== 0
+                        ) {
                             $transportStream->prepend((object)[]);
                         }
                     }

--- a/app/Transformers/PlaylistTransformer.php
+++ b/app/Transformers/PlaylistTransformer.php
@@ -73,8 +73,8 @@ class PlaylistTransformer extends PlanTransformerBase
             "total_duration" => $playlist->total_duration,
             "verses" => $playlist->verses,
             "user" => [
-                "id" => $playlist->user->id,
-                "name" => $playlist->user->name
+                "id" => $playlist->user ? $playlist->user->id : null,
+                "name" => $playlist->user ? $playlist->user->name : null
             ],
 
         ];

--- a/resources/views/docs/routes/index.blade.php
+++ b/resources/views/docs/routes/index.blade.php
@@ -1,72 +1,15 @@
 @extends('layouts.docs')
      
 @section('content')
-          <!-- Right Content Area -->
-          <div class="col-9 content-column">
-            <h2>Developer Documentation</h2>
-            <p class="txt-intro">Everything you need to know when working with the Digital Bible Platform API</p>
+  <!-- Right Content Area -->
+  <div class="col-9 content-column">
+    <h2>Developer Documentation</h2>
+    <p class="txt-intro">Everything you need to know when working with the Digital Bible Platform API</p>
 
-            <div class="row">
-              <div class="col-sm-4">
-                <a href="{{ route('core_concepts') }}" class="card">
-                  <div class="card-body">
-                    <div class="card-title txt-intro--regular">Core Concepts</div>
-                    <p class="card-text txt-md">Provides some of the fundamental concepts for understanding how to interface with the DBP.</p>
-                  </div>
-                </a>
-              </div>
+    <div class="row">
+      <div class="col-8"><p class="txt-subtitle">Before you begin building with the DBP you’ll need to ensure you have an API Key.</p></div>
+      <div class="col-4"><a href="{{ route('api_key.request') }}" class="btn btn-lg">Get Your API Key</a></div>
+    </div>
 
-              <div class="col-sm-4">
-                <a href="{{ route('available_content') }}" class="card">
-                  <div class="card-body">
-                    <div class="card-title txt-intro--regular">Available Content</div>
-                    <p class="card-text txt-md">Provides information on what content is available</p>
-                  </div>
-                </a>
-            </div>
-
-              <div class="col-sm-4">
-                <a href="{{ route('user_flows') }}" class="card">
-                  <div class="card-body">
-                    <div class="card-title txt-intro--regular">User Flows</div>
-                    <p class="card-text txt-md">Provides examples of user experience, from selecting a language to listening to or reading the Bible.</p>
-                  </div>
-                </a>
-              </div>
-              
-            </div>
-
-            <div class="row">
-
-              <div class="col-sm-4">
-                <a href="{{ route('glossary') }}" class="card">
-                  <div class="card-body">
-                    <div class="card-title txt-intro--regular">Glossary</div>
-                    <p class="card-text txt-md">Provides definitions for commonly-used terms</p>
-                  </div>
-                </a>
-              </div>
-
-              <div class="col-sm-4">
-                <a href="{{ route('api_reference') }}" class="card">
-                  <div class="card-body">
-                    <div class="card-title txt-intro--regular">API Reference</div>
-                    <p class="card-text txt-md">Provides specific information about API request and response structure</p>
-                  </div>
-                </a>
-              </div>
-
-
-
-              
-            </div>
-
-            <div class="row">
-              <div class="col-8"><p class="txt-subtitle">Before you begin building with the DBP you’ll need to ensure you have an API Key.</p></div>
-              <div class="col-4"><a href="{{ route('api_key.request') }}" class="btn btn-lg">Get Your API Key</a></div>
-            </div>
-
-
-          </div> <!-- end div col-9 content-column -->
-
+  </div> <!-- end div col-9 content-column -->
 @endsection

--- a/resources/views/layouts/docs.blade.php
+++ b/resources/views/layouts/docs.blade.php
@@ -2,13 +2,6 @@
 
 @section('left-nav')
 
-            <ul class="navcolUL">
-              <li><a href="{{ route('core_concepts') }}">Core Concepts</a></li>
-              <li><a href="{{ route('available_content') }}">Available Content</a></li>
-              <li><a href="{{ route('user_flows') }}">User Flows</a></li>
-              <li><a href="{{ route('glossary') }}">Glossary</a></li>
-              <li><a href="{{ route('api_reference') }}">API Reference</a></li>
-			</ul>
+  <ul class="navcolUL">
+  </ul>
 @endsection		
-
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,11 +128,6 @@ Route::group(['middleware' => ['web']], function () {
 // ------------------------------  attic. Will likely be removed, but needs research -----------------------------------------------------
 //Localization::localizedRoutesGroup(function () {
 
-    // About
-    Route::get('/about/contact', 'User\ContactController@create')->name(
-        'contact.create'
-    );
-
     Route::get(
         '/organizations',
         'Organization\OrganizationsController@index'
@@ -198,24 +193,8 @@ Route::group(['middleware' => ['web']], function () {
             'guides/getting-started',
             'User\DocsController@start'
         );
-        Route::name('docs_bible_books')->get(
-            'docs/bibles/books',
-            'User\DocsController@books'
-        );
-        Route::name('docs_bibles')->get(
-            'docs/bibles',
-            'User\DocsController@bibles'
-        );
-        Route::name('docs_language_create')->get(
-            'docs/language/create',
-            'User\DocsController@languages'
-        );
         Route::name('docs_language_update')->get(
             'docs/language/update',
-            'User\DocsController@languages'
-        );
-        Route::name('docs_languages')->get(
-            'docs/languages',
             'User\DocsController@languages'
         );
         Route::name('docs_countries')->get(


### PR DESCRIPTION

# Description
It has fixed some issues that were being registered in NewRelic. It has added the feature to create a safe key to store the data into the cache for the controllers: `AudioController`, `AudioControllerV2` and `TextControllerTrait`. Also, it has changed the result stored into the cache that returns method to fetch an user by key, for now on, it will store a boolean value instead a null value when the response is empty. By last, we have removed the routes related with: `docs/languages`,` docs/language/create` and `docs/bibles`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-357

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->

- We can test the next paths and it should return 404 code.
https://dev.dbt.io/docs/languages
https://dev.dbt.io/docs/language/create
https://dev.dbt.io/docs/bibles
https://dev.dbt.io/about/contact

- We should run the next url and it should return 200 code - text/verse
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-59d53fa7-a008-4350-a78f-0bb20095d885

- We should run the next url and it should return 200 code - /library/volume
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-3b496f30-c1a2-4f60-ac79-a4343651a7e9

- We should run the next url and it should return 200 code - /audio/path
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f812b9d2-3b7b-4995-828c-8cccf82d6636