### PR TITLE
FCBHDBP-340 Remove the metada property from the playlist item for the plan translate response

### DIFF
--- a/app/Transformers/PlanTranslateTransformer.php
+++ b/app/Transformers/PlanTranslateTransformer.php
@@ -43,7 +43,7 @@ class PlanTranslateTransformer extends PlanTransformerBase
                 "name" => $this->params['user']->name,
             ],
             "translation_data" => array_map(function ($item_translations) {
-                return $this->parseTranslationData($item_translations, false);
+                return $this->parseTranslationData($item_translations, false, false);
             }, $plan->translation_data),
             "translated_percentage" => $plan->translated_percentage
         ];


### PR DESCRIPTION

# Description
It has done a refactor to removed the metadata property from plan payload when a plan is translateFCBHDBP-340 It has removed the sub-property: metadata from the `TranslationData` property. The `TranslationData` property is in the response that is returned the endpoint to translate a plan. The above is related to decrease the processing for this endpoint and the size of payload.


## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-340

## How Do I QA This
We should run the next postman tests and they should passed:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-23e94960-5e98-4689-af89-a38870a0e102

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-4ced5b59-53b1-442b-9161-40f7967e6ff9