### PR TITLE
FCBHDBP-377 return books in order dictated by bible, not necessarily protestant

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -429,7 +429,7 @@ class BiblesController extends APIController
             $cache_params,
             now()->addDay(),
             function () use ($bible_id, $book_id, $bible) {
-                return BibleBook::getAllSortedByBookSeqOrVersification($bible_id, $book_id, $bible->versification);
+                return BibleBook::getAllSortedByBookSeqOrVersification($bible_id, $bible->versification, $book_id);
             }
         );
 

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -424,17 +424,14 @@ class BiblesController extends APIController
         }
 
         $cache_params = [$bible_id, $book_id];
-        $books = cacheRemember('bible_books_books', $cache_params, now()->addDay(), function () use ($bible_id, $book_id, $bible) {
-            return BibleBook::where('bible_id', $bible_id)
-                ->when($book_id, function ($query) use ($book_id) {
-                    $query->where('book_id', $book_id);
-                })
-                ->with('book')
-                ->get()->sortBy('book.' . $bible->versification . '_order')
-                ->filter(function ($item) {
-                    return $item->book;
-                })->flatten();
-        });
+        $books = cacheRemember(
+            'bible_books_books',
+            $cache_params,
+            now()->addDay(),
+            function () use ($bible_id, $book_id, $bible) {
+                return BibleBook::getAllSortedByBookSeqOrVersification($bible_id, $book_id, $bible->versification);
+            }
+        );
 
         if ($verify_content) {
             $cache_params = [$bible_id, $key, $verify_content, $book_id];

--- a/app/Models/Bible/BibleBook.php
+++ b/app/Models/Bible/BibleBook.php
@@ -3,6 +3,8 @@
 namespace App\Models\Bible;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use App\Models\Bible\Book;
 
 /**
  * App\Models\Bible\BibleBook
@@ -22,14 +24,14 @@ class BibleBook extends Model
     protected $connection = 'dbp';
     protected $table = 'bible_books';
     public $incrementing = false;
-    public $fillable = ['abbr','book_id', 'name', 'name_short', 'chapters'];
+    public $fillable = ['abbr','book_id', 'name', 'name_short', 'chapters', 'book_seq'];
     public $hidden = ['created_at','updated_at','bible_id'];
 
 
     /**
      *
      * @OA\Property(ref="#/components/schemas/Bible/properties/id")
-     * @method static BibleFileset whereBibleId($value)
+     * @method static BibleBook whereBibleId($value)
      * @property string $bible_id
      *
      */
@@ -38,7 +40,7 @@ class BibleBook extends Model
     /**
      *
      * @OA\Property(ref="#/components/schemas/Book/properties/id")
-     * @method static BibleFileset whereBookId($value)
+     * @method static BibleBook whereBookId($value)
      * @property string $book_id
      *
      */
@@ -54,7 +56,7 @@ class BibleBook extends Model
      *     maxLength=191
      * )
      *
-     * @method static BibleFileset whereName($value)
+     * @method static BibleBook whereName($value)
      * @property string $name
      *
      */
@@ -70,7 +72,7 @@ class BibleBook extends Model
      *     maxLength=191
      * )
      *
-     * @method static BibleFileset whereNameShort($value)
+     * @method static BibleBook whereNameShort($value)
      * @property string $name_short
      *
      */
@@ -86,11 +88,28 @@ class BibleBook extends Model
      *     maxLength=491
      * )
      *
-     * @method static BibleFileset whereChapters($value)
+     * @method static BibleBook whereChapters($value)
      * @property string $chapters
      *
      */
     protected $chapters;
+
+    /**
+     *
+     * @OA\Property(
+     *     title="book_seq",
+     *     description="The ordering provided by the licensor in the USX file, this column
+     *                  would likely populated for audio and video where there is no text"
+     *     type="string",
+     *     example="B07",
+     *     maxLength=4
+     * )
+     *
+     * @method static BibleBook whereBookSeq($value)
+     * @property string $book_seq
+     *
+     */
+    protected $book_seq;
 
     /**
      * Remove brackets from uncertain book names
@@ -118,5 +137,52 @@ class BibleBook extends Model
     public function book()
     {
         return $this->belongsTo(Book::class);
+    }
+
+    /**
+     * Get collection of bible books sorted by bible versification or the book_seq column if it not empty.
+     *
+     * @param string $bible_id
+     * @param string $book_id
+     * @param string $bible_versification
+     *
+     * @return Collection
+     */
+    public static function getAllSortedByBookSeqOrVersification(
+        string $bible_id,
+        ?string $book_id = null,
+        ?string $bible_versification = null
+    ) : Collection {
+        $select_columns = [
+            'bible_books.bible_id',
+            'bible_books.book_id',
+            'bible_books.name',
+            'bible_books.name_short',
+            'bible_books.chapters',
+            'bible_books.book_seq'
+        ];
+
+        if ($bible_versification) {
+            $select_columns[] = \DB::raw(
+                'CASE
+                    WHEN bible_books.book_seq IS NOT NULL THEN bible_books.book_seq
+                    WHEN books.'.$bible_versification.'_order IS NOT NULL THEN books.'.$bible_versification.'_order
+                    ELSE bible_books.book_id
+                END AS book_by_order'
+            );
+        }
+
+        return BibleBook::select($select_columns)
+            ->where('bible_id', $bible_id)
+            ->when($book_id, function ($query) use ($book_id) {
+                $query->where('book_id', $book_id);
+            })
+            ->join('books', 'books.id', 'bible_books.book_id')
+            ->with('book')
+            ->when($bible_versification, function ($order_by_query) {
+                $order_by_query->orderBy('book_by_order');
+            })
+            ->get()
+            ->flatten();
     }
 }


### PR DESCRIPTION
# Description
It has changed the way to sort the book records. For now on, If the book_seq field is populated it will sort by book_seq field but if it does not, the book records will sort by <versification>_order column. The sorting process will be performed from database.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-377

## How Do I QA This
- You can run the next 2 postman test and they should pass:

1. ENGESV bible and the bible_books records have populated the field book_seq.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-79eef8c9-3e44-471e-a614-40da8783d368

1. AA1WBT bible and the bible_books records DOES NOT have populated the field book_seq.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-48ca83d6-c78b-4748-af48-16ad3cffcd49