### PR TITLE
FCBHDBP-377 return books in order dictated by bible, not necessarily protestant

### DIFF
--- a/app/Http/Controllers/Bible/BooksController.php
+++ b/app/Http/Controllers/Bible/BooksController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Bible;
 
+use Symfony\Component\HttpFoundation\Response;
 use App\Models\Bible\BibleVerse;
 use App\Models\Bible\Book;
 use App\Models\Bible\BibleFileset;
@@ -88,7 +89,7 @@ class BooksController extends APIController
         $books = cacheRemember('v4_books', $cache_params, now()->addDay(), function () use ($fileset_type, $id) {
             $books = $this->getActiveBooksFromFileset($id, $fileset_type);
             if (isset($books->original, $books->original['error'])) {
-                return $this->setStatusCode(404)->replyWithError('Fileset Not Found');
+                return $this->setStatusCode(Response::HTTP_NOT_FOUND)->replyWithError('Fileset Not Found');
             }
             return fractal($books, new BooksTransformer(), $this->serializer);
         });
@@ -100,81 +101,10 @@ class BooksController extends APIController
     {
         $fileset = BibleFileset::with('bible')->where('id', $id)->where('set_type_code', $fileset_type)->first();
         if (!$fileset) {
-            return $this->setStatusCode(404)->replyWithError('Fileset Not Found'); // BWF: shouldn't reply like this, as it masks error later on
+            return $this->setStatusCode(Response::HTTP_NOT_FOUND)->replyWithError('Fileset Not Found'); // BWF: shouldn't reply like this, as it masks error later on
         }
-        $is_plain_text = BibleVerse::where('hash_id', $fileset->hash_id)->exists();
 
         $versification = optional($fileset->bible->first())->versification;
-        $book_order_column_exists = \Schema::connection('dbp')->hasColumn('books', $versification . '_order');
-        $book_order_column = $book_order_column_exists ? 'books.' . $versification . '_order' : 'books.protestant_order';
-
-        $dbp_database = config('database.connections.dbp.database');
-        return \DB::connection('dbp')->table($dbp_database . '.bible_filesets as fileset')
-            ->where('fileset.id', $id)
-            ->leftJoin($dbp_database . '.bible_fileset_connections as connection', 'connection.hash_id', 'fileset.hash_id')
-            ->leftJoin($dbp_database . '.bibles', 'bibles.id', 'connection.bible_id')
-            ->when($fileset_type, function ($q) use ($fileset_type) {
-                $q->where('set_type_code', $fileset_type);
-            })
-            ->when($is_plain_text, function ($query) use ($fileset) {
-                $this->compareFilesetToSophiaBooks($query, $fileset->hash_id);
-            }, function ($query) use ($fileset) {
-                $this->compareFilesetToFileTableBooks($query, $fileset->hash_id);
-            })
-            ->orderBy($book_order_column)->select([
-                'books.id',
-                'books.id_usfx',
-                'books.id_osis',
-                'books.book_testament',
-                'books.testament_order',
-                'books.book_group',
-                'bible_books.chapters',
-                'bible_books.name',
-                'bible_books.name_short',
-                'books.protestant_order',
-                $book_order_column . ' as book_order_column'
-            ])->get();
-    }
-
-    /**
-     *
-     * @param $query
-     * @param $id
-     */
-    private function compareFilesetToSophiaBooks($query, $hash_id)
-    {
-        // If the fileset references sophia.*_vpl than fetch the existing books from that database
-        $dbp_database = config('database.connections.dbp.database');
-        $sophia_books = BibleVerse::where('hash_id', $hash_id)->select('book_id')->distinct()->get();
-
-        // Join the books for the books returned from Sophia
-        $query->join($dbp_database . '.bible_books', function ($join) use ($sophia_books) {
-            $join->on('bible_books.bible_id', 'bibles.id')
-                ->whereIn('bible_books.book_id', $sophia_books->pluck('book_id'));
-        })->rightJoin($dbp_database . '.books', 'books.id', 'bible_books.book_id');
-    }
-
-    /**
-     *
-     * @param $query
-     * @param $hashId
-     */
-    private function compareFilesetToFileTableBooks($query, $hashId)
-    {
-        // If the fileset referencesade dbp.bible_files from that table
-        $dbp_database = config('database.connections.dbp.database');
-        $fileset_book_ids = DB::connection('dbp')
-            ->table('bible_files')
-            ->where('hash_id', $hashId)
-            ->select(['book_id'])
-            ->distinct()
-            ->get()
-            ->pluck('book_id');
-
-        // Join the books for the books returned from bible_files
-        $query->join($dbp_database . '.bible_books', function ($join) use ($fileset_book_ids) {
-            $join->on('bible_books.bible_id', 'bibles.id')
-                ->whereIn('bible_books.book_id', $fileset_book_ids);
-        })->rightJoin($dbp_database . '.books', 'books.id', 'bible_books.book_id');
+        return Book::getActiveBooksFromFileset($fileset, $versification, $fileset_type);
     }
 }

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -9,6 +9,7 @@ use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileSecondary;
 use App\Models\Bible\BibleVerse;
 use App\Models\Bible\BibleFileTag;
+use App\Models\Bible\BibleBook;
 use App\Models\Organization\Asset;
 use App\Models\Bible\BibleFileset;
 use App\Transformers\FileSetTransformer;
@@ -29,7 +30,7 @@ trait BibleFileSetsTrait
     ) {
         $query = BibleFile::byHashIdJoinBooks(
             $fileset->hash_id,
-            $bible->id,
+            $bible,
             $chapter_id,
             $book ? $book->id : null
         );
@@ -99,7 +100,7 @@ trait BibleFileSetsTrait
         $select_columns = [
             'bible_verses.book_id as book_id',
             'books.name as book_name',
-            'books.protestant_order as book_order',
+            BibleBook::getBookOrderSelectColumnExpressionRaw($bible->versification, 'book_order'),
             'bible_books.name as book_vernacular_name',
             'bible_verses.chapter',
             'bible_verses.verse_start',

--- a/app/Transformers/BooksTransformer.php
+++ b/app/Transformers/BooksTransformer.php
@@ -120,18 +120,19 @@ class BooksTransformer extends BaseTransformer
     public function transformForV4($book)
     {
         switch ($this->route) {
-            case 'v4_bible_books_all':
-                return [
-                    'book_id'         => $book->id,
-                    'book_id_usfx'    => $book->id_usfx,
-                    'book_id_osis'    => $book->id_osis,
-                    'name'            => $book->name,
-                    'testament'       => $book->book_testament,
-                    'testament_order' => $book->testament_order,
-                    'book_order'      => $book->protestant_order,
-                    'book_group'      => $book->book_group,
-                    'chapters'        => $book->chapters,
-                ];
+            // this action is commented, so we have commented this transformer as well
+            // case 'v4_bible_books_all':
+            //     return [
+            //         'book_id'         => $book->id,
+            //         'book_id_usfx'    => $book->id_usfx,
+            //         'book_id_osis'    => $book->id_osis,
+            //         'name'            => $book->name,
+            //         'testament'       => $book->book_testament,
+            //         'testament_order' => $book->testament_order,
+            //         'book_order'      => $book->protestant_order,
+            //         'book_group'      => $book->book_group,
+            //         'chapters'        => $book->chapters,
+            //     ];
 
             case 'v4_bible.books':
                 $result = [
@@ -141,7 +142,7 @@ class BooksTransformer extends BaseTransformer
                     'name'            => $book->name,
                     'testament'       => $book->book->book_testament,
                     'testament_order' => $book->book->testament_order,
-                    'book_order'      => $book->book->protestant_order,
+                    'book_order'      => $book->book_order_column,
                     'book_group'      => $book->book->book_group,
                     'name_short'      => $book->name_short,
                     'chapters'        => array_map('\intval', explode(',', $book->chapters)),

--- a/tests/Integration/BibleFileTest.php
+++ b/tests/Integration/BibleFileTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Bible\BibleFile;
+use App\Models\Bible\Book;
+use App\Models\User\Key;
+use App\Traits\AccessControlAPI;
+
+class BibleFileTest extends ApiV4NewTest
+{
+    use AccessControlAPI;
+
+    /**
+     * @category V4_API
+     * @group    V4
+     * @group    integration
+     * @test
+     */
+    public function bibleFiles()
+    {
+        $bible_file = BibleFile::with('book')
+            ->limit(1)
+            ->first();
+
+        $book = Book::where('id', $bible_file->book->id)->first();
+
+        $this->assertEquals($book->id, $bible_file->book->id);
+    }
+}


### PR DESCRIPTION

# Description
It changed all classes related with the API v4 to support the new way to sort the books records. If book_seq field is populated, we should use it, otherwise we should use order from bible.versification.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-377

## How Do I QA This
- You can run all postman test of folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-25c2819c-56c8-4681-b7c2-774d8b56eaa3

- You should run the next integration test and it should be ok:

```shell
./vendor/bin/phpunit tests/Integration/BibleFileTest.php
```