### PR TITLE
FCBHDBP-331 add ROLV to language 

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -215,6 +215,7 @@ class BiblesController extends APIController
                     MIN(bibles.date) as date,
                     MIN(language_autonym.name) as language_autonym,
                     MIN(language_current.name) as language_current,
+                    MIN(languages.rolv_code) as language_rolv_code,
                     MIN(bibles.priority) as priority,
                     MIN(bibles.id) as id'
                 )

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -132,6 +132,7 @@ class LanguagesController extends APIController
                     'languages.name as backup_name',
                     'current_translation.name as name',
                     'autonym.name as autonym',
+                    'languages.rolv_code',
                     \DB::raw($select_country_population . ' as country_population')
                 ])
                 ->with(['bibles' => function ($query) {
@@ -226,6 +227,7 @@ class LanguagesController extends APIController
                         'languages.name as backup_name',
                         'current_translation.name as name',
                         'autonym.name as autonym',
+                        'languages.rolv_code',
                     ])
                     ->with('bibles');
                 $languages = $languages->paginate($limit);

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -55,6 +55,7 @@ use App\Models\Resource\Resource;
  * @property string $longitude
  * @property string $status
  * @property string $country_id
+ * @property string $rolv_code
  *
  * @method static Language whereId($value)
  * @method static Language whereGlottoId($value)
@@ -75,6 +76,7 @@ use App\Models\Resource\Resource;
  * @method static whereLongitude($value)
  * @method static whereStatus($value)
  * @method static whereCountryId($value)
+ * @method static whereRolvCode($value)
  *
  * @OA\Schema (
  *     type="object",
@@ -116,7 +118,8 @@ class Language extends Model
         'status_id',
         'status_notes',
         'country_id',
-        'scope'
+        'scope',
+        'rolv_code',
     ];
 
     /**
@@ -371,6 +374,17 @@ class Language extends Model
      *
      */
     protected $country_id;
+
+    /**
+     * @OA\Property(
+     *     title="rolv_code",
+     *     description="",
+     *     type="string",
+     *     example=""
+     * )
+     *
+     */
+    protected $rolv_code;
 
     public function scopeIncludeAutonymTranslation($query)
     {

--- a/app/Transformers/BibleTransformer.php
+++ b/app/Transformers/BibleTransformer.php
@@ -178,6 +178,7 @@ class BibleTransformer extends BaseTransformer
                     'language'          => $bible->language_current ?? null,
                     'autonym'           => $bible->language_autonym ?? null,
                     'language_id'       => $bible->language_id,
+                    'language_rolv_code'=> $bible->language_rolv_code,
                     'iso'               => $bible->iso ?? null,
                     'date'              => $bible->date
                 ];
@@ -267,6 +268,7 @@ class BibleTransformer extends BaseTransformer
                     'language'      => optional($bible->language)->name,
                     'language_id'   => optional($bible->language)->id,
                     'iso'           => optional($bible->language)->iso,
+                    'language_rolv_code' => optional($bible->language)->rolv_code,
                     'date'          => $bible->date,
                     'country'       => $bible->language->primaryCountry->name ?? '',
                     'books'         => $bible->books->sortBy('book.' . $bible->versification . '_order')->each(function ($book) {

--- a/app/Transformers/LanguageTransformer.php
+++ b/app/Transformers/LanguageTransformer.php
@@ -46,7 +46,8 @@ class LanguageTransformer extends BaseTransformer
                     'language_family_iso_1'     => ($language->parent ? $language->parent->iso1 : $language->iso1) ?? '',
                     'media'                     => ['text'],
                     'delivery'                  => ['mobile', 'web', 'subsplash'],
-                    'resolution'                => []
+                    'resolution'                => [],
+                    'language_rolv_code'        => $language->rolv_code
                 ];
 
             default:
@@ -60,6 +61,7 @@ class LanguageTransformer extends BaseTransformer
                     'language_iso_1'       => $language->iso1,
                     'language_iso_name'    => $language->name,
                     'language_family_code' => $language->iso,
+                    'language_rolv_code'   => $language->rolv_code
                 ];
         }
     }
@@ -100,7 +102,8 @@ class LanguageTransformer extends BaseTransformer
                     'dialects'             => $language->dialects->pluck('name') ?? '',
                     'classifications'      => $language->classifications->pluck('name', 'classification_id') ?? '',
                     'bibles'               => $language->bibles,
-                    'resources'            => $language->resources
+                    'resources'            => $language->resources,
+                    'rolv_code'            => $language->rolv_code
                 ];
 
                 /**
@@ -121,6 +124,7 @@ class LanguageTransformer extends BaseTransformer
                     'name'       => $language->name ?? $language->backup_name,
                     'autonym'    => $language->autonym,
                     'bibles'     => $language->bibles->count(),
+                    'rolv_code'  => $language->rolv_code
                 ];
             default:
             case 'v4_languages.all':
@@ -133,6 +137,7 @@ class LanguageTransformer extends BaseTransformer
                     'autonym'    => $language->autonym,
                     'bibles'     => $show_bibles ? $language->bibles : $language->bibles->count(),
                     'filesets'   => $language->filesets_count,
+                    'rolv_code'  => $language->rolv_code
                 ];
                 
                 if ($language->country_population) {

--- a/database/migrations/2022_05_26_234615_add_rolv_code_to_languages.php
+++ b/database/migrations/2022_05_26_234615_add_rolv_code_to_languages.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $schema = Schema::connection('dbp');
+        $schema->table('languages', function (Blueprint $table) {
+            $table->string('rolv_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $schema = Schema::connection('dbp');
+        $schema->table('languages', function (Blueprint $table) {
+            $table->dropColumn('rolv_code');
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         printerClass="Codedungeon\PHPUnitPrettyResultPrinter\Printer">
+>
     <testsuites>
         <testsuite name="Feature Tests">
             <directory suffix="Test.php">./tests/Feature</directory>

--- a/tests/Integration/ApiV4NewTest.php
+++ b/tests/Integration/ApiV4NewTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestCase;
+use App\Models\User\Key;
+
+class ApiV4NewTest extends TestCase
+{
+    protected $params;
+    protected $key;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->key    = Key::where('name', 'bible.is mobile')->first()->key;
+        $this->params = [
+            'v' => 4,
+            'key' => $this->key,
+            'pretty'
+        ];
+    }
+}

--- a/tests/Integration/LanguageTest.php
+++ b/tests/Integration/LanguageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\Language\Language;
+use App\Traits\AccessControlAPI;
+
+class LanguageTest extends ApiV4NewTest
+{
+    use AccessControlAPI;
+
+    /**
+     * @category V4_API
+     * @group    V4
+     * @group    integration
+     * @test
+     */
+    public function languagesRolvCodeNewColumn()
+    {
+        $language = Language::select('*')
+            ->limit(1)
+            ->first();
+
+        $exists_rolv_code_column =\Schema::connection('dbp')->hasColumn('languages', 'rolv_code');
+
+        $this->assertEquals($exists_rolv_code_column, true);
+        $this->assertEquals($language->rolv_code, '');
+    }
+}


### PR DESCRIPTION

# Description
It has added the new column: rolv_code to languages entity. We have created a migration file to create the column and we have also created a integration test to validate if the entity has the new column.

## NOTE:
 
We need to run the migration to create the new column and you can do that with the next command:

```shell
./vendor/bin/phpunit tests/Integration/LanguageTest.php
```
The result about the above command should ```OK (1 test, 2 assertions)```
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-331

## How Do I QA This
You can run all postman test from the next folder and they should pass.
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-986c42f9-3e55-40cf-a867-da1fd66e2ec1
