### PR TITLE
FCBHDBP - specify in the composer file php version to improve renovate PRs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": ">=8.0 <=8.0.21",
         "algolia/algoliasearch-client-php": "3.2.0",
         "appstract/laravel-opcache": "4.0.2",
         "aws/aws-sdk-php": "3.229.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01b804a96d43bd0f863dc2f738f6318e",
+    "content-hash": "7442bfa7c390e97463197d18afbdac58",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -5052,16 +5052,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.11.6",
+            "version": "v0.11.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "3f5b5f8aaa979fbd0d1783173f4c82ad529fe621"
+                "reference": "77fc7270031fbc28f9a7bea31385da5c4855cb7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/3f5b5f8aaa979fbd0d1783173f4c82ad529fe621",
-                "reference": "3f5b5f8aaa979fbd0d1783173f4c82ad529fe621",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/77fc7270031fbc28f9a7bea31385da5c4855cb7a",
+                "reference": "77fc7270031fbc28f9a7bea31385da5c4855cb7a",
                 "shasum": ""
             },
             "require": {
@@ -5122,9 +5122,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.11.6"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.11.7"
             },
-            "time": "2022-07-03T16:40:23+00:00"
+            "time": "2022-07-07T13:49:11+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -12571,7 +12571,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.0"
+        "php": ">=8.0 <=8.0.21"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"


### PR DESCRIPTION
# Description
It has specified in the composer file the php version to avoid that renovate can create PR where bundles require a php version greater than specified version. We have created a range (">=8.0 <=8.0.21") to make sure that current bundles can be installed but we can not install bundles that require a php version greater. 

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This
- The deploy process should be executed normally.
- Run all [M] postman tests and they should pass.