### PR TITLE
FCBHDBP-414 DBP: 500 error in bulk endpoint

### DIFF
--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -44,8 +44,9 @@ trait BibleFileSetsTrait
                 ->orderBy('verse_start', 'ASC');
         }
         if ($limit !== null) {
-            $fileset_chapters = $query->paginate($limit);
-            $filesets_pagination = new IlluminatePaginatorAdapter($fileset_chapters);
+            $fileset_chapters_paginated = $query->paginate($limit);
+            $filesets_pagination = new IlluminatePaginatorAdapter($fileset_chapters_paginated);
+            $fileset_chapters = $fileset_chapters_paginated->getCollection();
         } else {
             $fileset_chapters = $query->get();
         }


### PR DESCRIPTION
# Description
It has fixed the `v4_filesets` bulk endpoint. When we try to use the limit value we need to validate that it will use the collection object rather a `LengthAwarePaginator` instance.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-414

## How Do I QA This
- I have created a postman test to re-create the issue.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-13abc396-05e1-43e1-be19-644366fded85