### PR TITLE
FCBHDBP renovate fix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "docker-compose.yml",
     "package.json"
   ],
-  "comment": "until AWS updates the PHP platform to 8.1, symfony/* needs to stay below 6.1",
+  "description": "until AWS updates the PHP platform to 8.1, symfony/* needs to stay below 6.1",
   "ignoreDeps": [
     "symfony/http-client", 
     "symfony/yaml"


### PR DESCRIPTION
# Description
It has replaced the comment property by the description property to avoid warning messages of renovate.

## Issue Link

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->

## Screenshots (if appropriate)
- You can see in the renovate log that we are not able to use the comment property:
![screenshot-app renovatebot com-2022 07 27-11_06_29](https://user-images.githubusercontent.com/73488660/181302974-e9f65a27-71d8-4407-99cf-d2a71796be3c.png)


