### PR TITLE
FCBHDBP-420 Plan 2.0 (Function): Follower Count (API)

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -272,7 +272,7 @@ class PlansController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
-        $plan = $this->getPlan($plan_id, $user);
+        $plan = $this->getPlan((int) $plan_id, $user);
 
         if (!$plan) {
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');
@@ -474,7 +474,7 @@ class PlansController extends APIController
             return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
         }
 
-        $plan = Plan::where('id', $plan_id)->first();
+        $plan = Plan::where('id', (int) $plan_id)->first();
 
         if (!$plan) {
             return $this->setStatusCode(404)->replyWithError('Plan Not Found');

--- a/app/Models/Plan/Plan.php
+++ b/app/Models/Plan/Plan.php
@@ -245,4 +245,24 @@ class Plan extends Model
     {
         return Plan::where('id', $plan_id)->first();
     }
+
+    /**
+     * Get total users attached to the current plan
+     *
+     * @return int
+     */
+    public function getTotalUsersAttribute() : int
+    {
+        return $this->countUsers();
+    }
+
+    /**
+     * Get count user by plan ID
+     *
+     * @return int
+     */
+    public function countUsers() : int
+    {
+        return UserPlan::where('plan_id', $this['id'])->count();
+    }
 }

--- a/app/Transformers/PlanDayPlaylistItemsTransformer.php
+++ b/app/Transformers/PlanDayPlaylistItemsTransformer.php
@@ -35,6 +35,7 @@ class PlanDayPlaylistItemsTransformer extends PlanTransformerBase
 
                 return $day_result;
             }),
+            "total_users" => $plan->total_users,
             "user" => [
                 "id" => $plan->user->id,
                 "name" => $plan->user->name


### PR DESCRIPTION
# Description
It has added the new property: total_users to the endpoint to pull the plan detail (`v4_internal_plans.show`). It will count all users that have started a specific plan and the sum will be returned in the property: total_users

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-420

## How Do I QA This
- You can test this new feature if you run the following postman test:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b64f3025-141d-4017-bf57-e5bf62128022