### PR TITLE
FCBHDBP-427 alternate name search functionality for Bible.is

### DIFF
--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -500,7 +500,6 @@ class Language extends Model
 
         return \DB::table('language_translations as lang_trans')
             ->select('lang_trans.language_source_id as id')
-            ->whereRaw('lang_trans.language_source_id = lang_trans.language_translation_id')
             ->whereRaw('MATCH (lang_trans.name) against (? IN BOOLEAN MODE)')
             ->whereExists(function ($query) use ($dbp_users, $dbp_prod, $key, $set_type_code, $media) {
                 return $query->select(\DB::raw(1))
@@ -515,7 +514,7 @@ class Language extends Model
                         $query->select(\DB::raw('MAX(`priority`)'))
                             ->from('language_translations as lang_trans_prior')
                             ->whereColumn('lang_trans_prior.language_source_id', '=', 'lang_trans.language_source_id')
-                            ->whereColumn('lang_trans_prior.language_source_id', '=', 'lang_trans_prior.language_translation_id')
+                            ->whereColumn('lang_trans_prior.language_translation_id', '=', 'lang_trans.language_translation_id')
                             ->limit(1);
                     })
                     ->when($set_type_code || $media, function ($query) use ($dbp_prod) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,12 @@
 version: '3.7'
 services:
-  db:
-    image: mysql:5.7
-    environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=1
-      - MYSQL_DATABASE=${DB_CONNECTION}
-    ports:
-      - '${DBP_PORT}:3306'
-    volumes:
-      - 'mysql_data:/var/lib/mysql'
   db8:
     image: mysql:8.0.28
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
       - MYSQL_DATABASE=${DB_CONNECTION}
     ports:
-      - '3307:3306'
+      - '${DBP_PORT}:3306'
     volumes:
       - 'mysql_data8:/var/lib/mysql'
   php:
@@ -27,7 +18,7 @@ services:
       - './:/opt/app'
       - ./docker/php/phpSettings.conf:/usr/local/etc/php-fpm.d/zzz-phpSettings.conf
     depends_on:
-      - db
+      - db8
   server:
     image: nginx:stable-alpine
     volumes:
@@ -44,6 +35,5 @@ services:
       - '${MEMCACHED_PORT}:11211'
 
 volumes:
-  mysql_data:
   mysql_data8:
   app_vendor:


### PR DESCRIPTION
# Description
It has updated the endpoint:`/languages/search/` to be able to search by alternative names as well. We have removed the constraint that was avoiding to search by the alternate name or language translations. We had the following constraint: 
```php
 ->whereRaw('lang_trans.language_source_id = lang_trans.language_translation_id') 
```
the above when we were trying to match the search text with the language translations records.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-427

## How Do I QA This
- All of tests inside following folder should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-f7f37344-fb08-4c92-8bb9-1e1413ccb9a7
