### PR TITLE
FCHDBP-440 Check issue related to endpoint to store a playlist item

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -20,7 +20,6 @@ use App\Models\Organization\Asset;
 
 
 use App\Transformers\FileSetTransformer;
-use App\Transformers\TextTransformer;
 
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\Request;

--- a/app/Services/Plans/PlaylistService.php
+++ b/app/Services/Plans/PlaylistService.php
@@ -280,6 +280,10 @@ class PlaylistService
             $order += 1;
         }
 
+        if (empty($playlist_items_to_create)) {
+            return null;
+        }
+
         $created_playlist_items = \DB::transaction(function () use ($playlist_items_to_create, $playlist_id) {
             PlaylistItems::insert($playlist_items_to_create);
 


### PR DESCRIPTION
# Description
It has fixed an issue where it wasn't handling the case where the `fileset_id` is empty when an user was trying to store a plyalist item. Also, It has update the playlistController to use the SymfonyResponse constants.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-440

## How Do I QA This
- You should run the next steps:
1. Login with a user
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-041aa795-75e3-4fb8-bb3b-2c1acfbdd22c
2. Create a new plan
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-49b34ca7-e2c0-4e6f-b37e-6c0a85b5e495
3. Add playlist items
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0fdd1d5c-4958-41be-afc4-ad2a2f8199f4
4. Add a new playlist item with fileset_id empty. It should return a bad request response.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-7352e94e-aff6-43fb-a82c-45ac63851784