### PR TITLE
FCBHDBP-437 DBP - Enable "Discover search" and "search My Bible" to find scripture references such as "Romans 2:4"

### DIFF
--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -246,6 +246,18 @@ class Bible extends Model
         }]);
     }
 
+    public function filesetsWithoutMeta()
+    {
+        return $this->hasManyThrough(
+            BibleFileset::class,
+            BibleFilesetConnection::class,
+            'bible_id',
+            'hash_id',
+            'id',
+            'hash_id'
+        );
+    }
+
     public function files()
     {
         return $this->hasMany(BibleFile::class);

--- a/app/Models/Bible/BibleVerse.php
+++ b/app/Models/Bible/BibleVerse.php
@@ -156,16 +156,27 @@ class BibleVerse extends Model
             ->join('bible_filesets', 'bible_filesets.hash_id', 'bible_verses.hash_id')
             ->join('bible_fileset_connections', 'bible_filesets.hash_id', 'bible_fileset_connections.hash_id')
             ->join('bibles', 'bibles.id', 'bible_fileset_connections.bible_id')
+            ->with(["fileset.bible.filesetsWithoutMeta" => function ($query) use ($book_id, $chapter_id) {
+                return $query->whereExists(function ($subquery) use ($book_id, $chapter_id) {
+                    return $subquery->select(\DB::raw(1))
+                        ->from('bible_files')
+                        ->where('bible_files.chapter_start', $chapter_id)
+                        ->where('bible_files.book_id', $book_id)
+                        ->whereColumn('bible_files.hash_id', '=', 'bible_filesets.hash_id');
+                });
+            }])
             ->select([
                 'bible_verses.verse_start',
                 'bible_verses.verse_end',
                 'bible_verses.chapter',
                 'bible_verses.book_id',
+                'bible_verses.verse_text',
+                'bible_verses.hash_id',
                 'bibles.language_id',
                 'bibles.id AS bible_id',
-                'bible_verses.verse_text',
                 'bible_filesets.id AS fileset_id',
                 'bible_filesets.set_type_code AS fileset_set_type_code',
+                'bible_filesets.set_size_code AS fileset_set_size_code',
             ]);
     }
 

--- a/app/Transformers/BibleVerseTransformer.php
+++ b/app/Transformers/BibleVerseTransformer.php
@@ -2,6 +2,9 @@
 
 namespace App\Transformers;
 
+use App\Models\Bible\BibleFileset;
+use App\Models\Bible\BibleVerse;
+
 class BibleVerseTransformer extends BaseTransformer
 {
     /**
@@ -26,6 +29,7 @@ class BibleVerseTransformer extends BaseTransformer
      *      @OA\Property(property="verse_text",            ref="#/components/schemas/BibleVerse/properties/verse_text"),
      *      @OA\Property(property="fileset_id",            ref="#/components/schemas/Language/properties/iso"),
      *      @OA\Property(property="fileset_set_type_code", ref="#/components/schemas/Bible/properties/date"),
+     *      @OA\Property(property="bible_filesets",        ref="#/components/schemas/BibleFileset"),
      *    ),
      *    @OA\Property(property="meta",ref="#/components/schemas/pagination")
      *   )
@@ -36,7 +40,7 @@ class BibleVerseTransformer extends BaseTransformer
      *
      * @return array
      */
-    public function transform($bible_verse)
+    public function transform(BibleVerse $bible_verse)
     {
         /**
          * schema=v4_bible_verses.all
@@ -51,6 +55,17 @@ class BibleVerseTransformer extends BaseTransformer
             'verse_text'=> $bible_verse->verse_text,
             'fileset_id'=> $bible_verse->fileset_id,
             'fileset_set_type_code'=> $bible_verse->fileset_set_type_code,
+            'fileset_set_size_code'=> $bible_verse->fileset_set_size_code,
+            'bible_filesets' =>$bible_verse->fileset->bible->first()
+                ->filesetsWithoutMeta
+                ->map(function (BibleFileset $fileset) {
+                    return [
+                        'id' => $fileset->id,
+                        'asset_id' => $fileset->asset_id,
+                        'set_type_code' => $fileset->set_type_code,
+                        'set_size_code' => $fileset->set_size_code,
+                    ];
+                })
         ];
     }
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4966,6 +4966,9 @@
                                 },
                                 "fileset_set_type_code": {
                                     "$ref": "#/components/schemas/Bible/properties/date"
+                                },
+                                "bible_filesets": {
+                                    "$ref": "#/components/schemas/BibleFileset"
                                 }
                             },
                             "type": "object"


### PR DESCRIPTION
# Description
It has added a new parameter to the response called: `bible_filesets.` This new parameter will be the filesets records related to the verse filtered by book, chapter and verse number.

It will attach all filesets related to the verse record filter by chapter, book and verse.

# NOTE
The new parameter won't affect the response timing. The endpoints are keeping the respond timing less than 100ms.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-437

## How Do I QA This
- It should pass the following postman test folder:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-47ae182e-c9fa-4fac-a11b-3dfa13519d7c