### PR TITLE
FCBHDBP-454 Add user annotations  to the playlist endpoint response.

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1416,7 +1416,10 @@ class PlaylistsController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_notes"))
+     *         @OA\MediaType(
+     *              mediaType="application/json",
+     *              @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_notes")
+     *         )
      *     ),
      * )
      *
@@ -1487,7 +1490,10 @@ class PlaylistsController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_highlights"))
+     *         @OA\MediaType(
+     *              mediaType="application/json",
+     *              @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_highlights")
+     *         )
      *     )
      * )
      *
@@ -1522,7 +1528,7 @@ class PlaylistsController extends APIController
         ])
         ->whereBelongPlaylistAndBook($playlist_id, $book_id)
         ->where('user_highlights.user_id', $user->id)
-        ->with('tags')
+        ->with(['tags', 'color'])
         ->get();
 
         return $this->reply(fractal(
@@ -1560,7 +1566,10 @@ class PlaylistsController extends APIController
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
-     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_bookmarks"))
+     *         @OA\MediaType(
+     *              mediaType="application/json",
+     *              @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_bookmarks")
+     *         )
      *     ),
      * )
      *

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App\Http\Controllers\Playlist;
+
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Spatie\Fractalistic\ArraySerializer;
 use App\Traits\AccessControlAPI;
@@ -16,16 +17,23 @@ use App\Models\Playlist\Playlist;
 use App\Models\Playlist\PlaylistFollower;
 use App\Models\Playlist\PlaylistItems;
 use App\Models\Bible\BibleVerse;
+use App\Models\User\Study\Note;
+use App\Models\User\Study\Highlight;
+use App\Models\User\Study\Bookmark;
 use App\Traits\CallsBucketsTrait;
 use App\Traits\CheckProjectMembership;
 use App\Transformers\PlaylistTransformer;
 use App\Transformers\PlaylistItemsTransformer;
+use App\Transformers\PlaylistNotesTransformer;
+use App\Transformers\PlaylistHighlightsTransformer;
+use App\Transformers\PlaylistBookmarksTransformer;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use Illuminate\Http\JsonResponse;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use App\Services\Plans\PlaylistService;
 
@@ -234,7 +242,7 @@ class PlaylistsController extends APIController
                         $query_fileset->with(['bible' => function ($query_bible) {
                             $query_bible->with(['translations', 'books.book']);
                         }]);
-                    }])->conditionTagExclude(['opus', 'webm']);
+                    }])->conditionTagExcludeFileset(['opus', 'webm']);
                 }]);
             })
             ->when($language_id, function ($q) use ($language_id) {
@@ -1383,5 +1391,212 @@ class PlaylistsController extends APIController
             'duration' => $playlist_item->duration,
             'timestamps' => $playlist_item->getTimestamps(),
         ]);
+    }
+
+    /**
+     *
+     * @OA\Get(
+     *     path="/playlists/{playlist_id}/{book_id}/notes",
+     *     tags={"Playlists", "Notes"},
+     *     summary="Get Note records related to playlist and book",
+     *     operationId="v4_internal_playlists.notes",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(
+     *          name="playlist_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Playlist/properties/id")
+     *     ),
+     *     @OA\Parameter(
+     *          name="bookd_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_notes"))
+     *     ),
+     * )
+     *
+     * @param Request $request
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return JsonResponse
+     */
+    public function notes(Request $request, int $playlist_id, string $book_id) : JsonResponse
+    {
+        $user = $request->user();
+        $user_is_member = $this->compareProjects($user->id, $this->key);
+
+        if (!$user_is_member) {
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_UNAUTHORIZED)
+                ->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $notes = Note::select([
+            'user_notes.id',
+            'user_notes.user_id',
+            'user_notes.bible_id',
+            'user_notes.book_id',
+            'user_notes.chapter',
+            'user_notes.verse_start',
+            'user_notes.verse_end',
+            'user_notes.notes',
+        ])
+        ->whereBelongPlaylistAndBook($playlist_id, $book_id)
+        ->where('user_notes.user_id', $user->id)
+        ->with('tags')
+        ->get();
+
+        return $this->reply(fractal(
+            $notes,
+            new PlaylistNotesTransformer(),
+        ));
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/playlists/{playlist_id}/{book_id}/highlights",
+     *     tags={"Playlists", "Highlights"},
+     *     summary="Get Highlight records related to playlist and book",
+     *     operationId="v4_internal_playlists.highlights",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(
+     *          name="playlist_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Playlist/properties/id")
+     *     ),
+     *     @OA\Parameter(
+     *          name="bookd_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
+     *     ),
+     *     @OA\Parameter(
+     *          name="prefer_color",
+     *          in="query",
+     *          @OA\Schema(type="string",default="rgba",enum={"hex","rgba","rgb","full"}),
+     *          description="Choose the format that highlighted colors will be returned in. If no color
+     *          is not specified than the default is a six letter hexadecimal color."
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_highlights"))
+     *     )
+     * )
+     *
+     * @param Request $request
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return JsonResponse
+     */
+    public function highlights(Request $request, int $playlist_id, string $book_id) : JsonResponse
+    {
+        $user = $request->user();
+        $user_is_member = $this->compareProjects($user->id, $this->key);
+
+        if (!$user_is_member) {
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_UNAUTHORIZED)
+                ->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $notes = Highlight::select([
+            'user_highlights.id',
+            'user_highlights.user_id',
+            'user_highlights.bible_id',
+            'user_highlights.book_id',
+            'user_highlights.chapter',
+            'user_highlights.verse_start',
+            'user_highlights.verse_end',
+            'user_highlights.highlight_start',
+            'user_highlights.highlighted_words',
+            'user_highlights.highlighted_color',
+        ])
+        ->whereBelongPlaylistAndBook($playlist_id, $book_id)
+        ->where('user_highlights.user_id', $user->id)
+        ->with('tags')
+        ->get();
+
+        return $this->reply(fractal(
+            $notes,
+            new PlaylistHighlightsTransformer()
+        ));
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/playlists/{playlist_id}/{book_id}/bookmarks",
+     *     tags={"Playlists"},
+     *     summary="Get Bookmarks records related to playlist and book",
+     *     operationId="v4_internal_playlists.bookmarks",
+     *     security={{"api_token":{}}},
+     *     @OA\Parameter(
+     *          name="playlist_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Playlist/properties/id")
+     *     ),
+     *     @OA\Parameter(
+     *          name="bookd_id",
+     *          in="path",
+     *          required=true,
+     *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
+     *     ),
+     *     @OA\Parameter(
+     *          name="prefer_color",
+     *          in="query",
+     *          @OA\Schema(type="string",default="rgba",enum={"hex","rgba","rgb","full"}),
+     *          description="Choose the format that highlighted colors will be returned in. If no color
+     *          is not specified than the default is a six letter hexadecimal color."
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_playlist_user_bookmarks"))
+     *     ),
+     * )
+     *
+     * @param Request $request
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return JsonResponse
+     */
+    public function bookmarks(Request $request, int $playlist_id, string $book_id) : JsonResponse
+    {
+        $user = $request->user();
+        $user_is_member = $this->compareProjects($user->id, $this->key);
+
+        if (!$user_is_member) {
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_UNAUTHORIZED)
+                ->replyWithError(trans('api.projects_users_not_connected'));
+        }
+
+        $notes = Bookmark::select([
+            'user_bookmarks.id',
+            'user_bookmarks.user_id',
+            'user_bookmarks.bible_id',
+            'user_bookmarks.book_id',
+            'user_bookmarks.chapter',
+            'user_bookmarks.verse_start',
+        ])
+        ->whereBelongPlaylistAndBook($playlist_id, $book_id)
+        ->where('user_bookmarks.user_id', $user->id)
+        ->with('tags')
+        ->get();
+
+        return $this->reply(fractal(
+            $notes,
+            new PlaylistBookmarksTransformer()
+        ));
     }
 }

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -727,7 +727,7 @@ class PlaylistItems extends Model implements Sortable
      */
     public function scopeConditionTagExcludeFileset(Builder $query, Array $tags_exclude)
     {
-        $query->whereNotExists(function ($sub_query) {
+        $query->whereNotExists(function ($sub_query) use ($tags_exclude) {
             $dbp_prod = config('database.connections.dbp.database');
 
             return $sub_query
@@ -735,7 +735,7 @@ class PlaylistItems extends Model implements Sortable
                 ->from($dbp_prod . '.bible_filesets as bf')
                 ->join($dbp_prod . '.bible_fileset_tags as bft', 'bft.hash_id', 'bf.hash_id')
                 ->whereColumn('bf.id', '=', 'playlist_items.fileset_id')
-                ->whereIn($dbp_prod . '.bft.description', ['opus', 'webm']);
+                ->whereIn($dbp_prod . '.bft.description', $tags_exclude);
         });
     }
 }

--- a/app/Models/User/Study/Bookmark.php
+++ b/app/Models/User/Study/Bookmark.php
@@ -9,7 +9,6 @@ use App\Models\Bible\BibleVerse;
 use App\Models\Bible\Book;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * App\Models\User\Study
@@ -41,6 +40,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class Bookmark extends Model
 {
+    use UserAnnotationTrait;
+
     protected $connection = 'dbp_users';
     protected $table = 'user_bookmarks';
     protected $fillable = [
@@ -173,41 +174,5 @@ class Bookmark extends Model
             ->get()
             ->pluck('verse_text');
         return implode(' ', $verses->toArray());
-    }
-
-    /**
-     * Get bookmarks related the playlist items that belong to playlist and a given book ID
-     *
-     * @param Illuminate\Database\Query\Builder $query
-     * @param int $playlist_id
-     * @param string $book_id
-     *
-     * @return Illuminate\Database\Query\Builder
-     */
-    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
-    {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
-        return $query
-            ->join($dbp_prod . '.bible_fileset_connections AS bfc', 'bfc.bible_id', 'user_bookmarks.bible_id')
-            ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
-            ->join($dbp_users . '.playlist_items AS pli', function ($join) use ($book_id) {
-                $join
-                    ->on('bf.id', '=', 'pli.fileset_id')
-                    ->where('pli.book_id', $book_id)
-                    ->whereColumn('user_bookmarks.chapter', '=', 'pli.chapter_start')
-                    ->where(function ($wherequery) {
-                        $wherequery
-                        ->orWhereNull('pli.verse_start')
-                        ->orWhere(function ($verse_start_where) {
-                            $verse_start_where
-                                ->whereColumn('user_bookmarks.verse_start', '<=', 'pli.verse_end')
-                                ->whereColumn('user_bookmarks.verse_start', '>=', 'pli.verse_start');
-                        });
-                    });
-            })
-            ->where('pli.playlist_id', $playlist_id)
-            ->where('user_bookmarks.book_id', $book_id);
     }
 }

--- a/app/Models/User/Study/Bookmark.php
+++ b/app/Models/User/Study/Bookmark.php
@@ -9,6 +9,7 @@ use App\Models\Bible\BibleVerse;
 use App\Models\Bible\Book;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * App\Models\User\Study
@@ -43,14 +44,14 @@ class Bookmark extends Model
     protected $connection = 'dbp_users';
     protected $table = 'user_bookmarks';
     protected $fillable = [
-    'id',
-    'bible_id',
-    'v2_id',
-    'user_id',
-    'book_id',
-    'chapter',
-    'verse_start'
-  ];
+        'id',
+        'bible_id',
+        'v2_id',
+        'user_id',
+        'book_id',
+        'chapter',
+        'verse_start'
+    ];
 
     /**
      *
@@ -126,9 +127,9 @@ class Bookmark extends Model
     public function book()
     {
         return $this->hasOne(BibleBook::class, 'book_id', 'book_id')->where(
-      'bible_id',
-      $this['bible_id']
-    );
+            'bible_id',
+            $this['bible_id']
+        );
     }
 
     public function bible()
@@ -151,25 +152,62 @@ class Bookmark extends Model
             return '';
         }
         $fileset = BibleFileset::join(
-      'bible_fileset_connections as connection',
-      'connection.hash_id',
-      'bible_filesets.hash_id'
-    )
-      ->where('bible_filesets.set_type_code', 'text_plain')
-      ->where('connection.bible_id', $bible->id)
-      ->first();
+            'bible_fileset_connections as connection',
+            'connection.hash_id',
+            'bible_filesets.hash_id'
+        )
+        ->where('bible_filesets.set_type_code', 'text_plain')
+        ->where('connection.bible_id', $bible->id)
+        ->first();
+
         if (!$fileset) {
             return '';
         }
         $verses = BibleVerse::withVernacularMetaData($bible)
-      ->where('hash_id', $fileset->hash_id)
-      ->where('bible_verses.book_id', $bookmark['book_id'])
-      ->where('verse_start', $verse_start)
-      ->where('chapter', $chapter)
-      ->orderBy('verse_start')
-      ->select(['bible_verses.verse_text'])
-      ->get()
-      ->pluck('verse_text');
+            ->where('hash_id', $fileset->hash_id)
+            ->where('bible_verses.book_id', $bookmark['book_id'])
+            ->where('verse_start', $verse_start)
+            ->where('chapter', $chapter)
+            ->orderBy('verse_start')
+            ->select(['bible_verses.verse_text'])
+            ->get()
+            ->pluck('verse_text');
         return implode(' ', $verses->toArray());
+    }
+
+    /**
+     * Get bookmarks related the playlist items that belong to playlist and a given book ID
+     *
+     * @param Illuminate\Database\Query\Builder $query
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return Illuminate\Database\Query\Builder
+     */
+    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
+    {
+        $dbp_users = config('database.connections.dbp_users.database');
+        $dbp_prod = config('database.connections.dbp.database');
+
+        return $query
+            ->join($dbp_prod . '.bible_fileset_connections AS bfc', 'bfc.bible_id', 'user_bookmarks.bible_id')
+            ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
+            ->join($dbp_users . '.playlist_items AS pli', function ($join) use ($book_id) {
+                $join
+                    ->on('bf.id', '=', 'pli.fileset_id')
+                    ->where('pli.book_id', $book_id)
+                    ->whereColumn('user_bookmarks.chapter', '=', 'pli.chapter_start')
+                    ->where(function ($wherequery) {
+                        $wherequery
+                        ->orWhereNull('pli.verse_start')
+                        ->orWhere(function ($verse_start_where) {
+                            $verse_start_where
+                                ->whereColumn('user_bookmarks.verse_start', '<=', 'pli.verse_end')
+                                ->whereColumn('user_bookmarks.verse_start', '>=', 'pli.verse_start');
+                        });
+                    });
+            })
+            ->where('pli.playlist_id', $playlist_id)
+            ->where('user_bookmarks.book_id', $book_id);
     }
 }

--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -8,7 +8,6 @@ use App\Models\Bible\BibleBook;
 use App\Models\Bible\BibleVerse;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * App\Models\User\Highlight
@@ -47,6 +46,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class Highlight extends Model
 {
+    use UserAnnotationTrait;
+
     protected $connection = 'dbp_users';
     public $table = 'user_highlights';
     protected $fillable = ['user_id', 'v2_id', 'bible_id', 'book_id', 'project_id', 'chapter', 'verse_start', 'verse_end', 'highlight_start', 'highlighted_words', 'highlighted_color'];
@@ -234,46 +235,5 @@ class Highlight extends Model
         }
 
         return $color;
-    }
-
-    /**
-     * Get highlights related the playlist items that belong to playlist and a given book ID
-     *
-     * @param Illuminate\Database\Query\Builder $query
-     * @param int $playlist_id
-     * @param string $book_id
-     *
-     * @return Illuminate\Database\Query\Builder
-     */
-    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
-    {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
-        return $query
-            ->join($dbp_prod . '.bible_fileset_connections AS bfc', 'bfc.bible_id', 'user_highlights.bible_id')
-            ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
-            ->join($dbp_users . '.playlist_items AS pli', function ($join) use ($book_id) {
-                $join
-                    ->on('bf.id', '=', 'pli.fileset_id')
-                    ->where('pli.book_id', $book_id)
-                    ->whereColumn('user_highlights.chapter', '=', 'pli.chapter_start')
-                    ->where(function ($wherequery) {
-                        $wherequery
-                        ->orWhereNull('pli.verse_start')
-                        ->orWhere(function ($verse_start_where) {
-                            $verse_start_where
-                                ->whereColumn('user_highlights.verse_start', '<=', 'pli.verse_end')
-                                ->whereColumn('user_highlights.verse_start', '>=', 'pli.verse_start');
-                        })
-                        ->orWhere(function ($verse_end_where) {
-                            $verse_end_where
-                                ->whereColumn('user_highlights.verse_end', '<=', 'pli.verse_end')
-                                ->whereColumn('user_highlights.verse_end', '>=', 'pli.verse_start');
-                        });
-                    });
-            })
-            ->where('pli.playlist_id', $playlist_id)
-            ->where('user_highlights.book_id', $book_id);
     }
 }

--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -8,6 +8,7 @@ use App\Models\Bible\BibleBook;
 use App\Models\Bible\BibleVerse;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * App\Models\User\Highlight
@@ -233,5 +234,46 @@ class Highlight extends Model
         }
 
         return $color;
+    }
+
+    /**
+     * Get highlights related the playlist items that belong to playlist and a given book ID
+     *
+     * @param Illuminate\Database\Query\Builder $query
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return Illuminate\Database\Query\Builder
+     */
+    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
+    {
+        $dbp_users = config('database.connections.dbp_users.database');
+        $dbp_prod = config('database.connections.dbp.database');
+
+        return $query
+            ->join($dbp_prod . '.bible_fileset_connections AS bfc', 'bfc.bible_id', 'user_highlights.bible_id')
+            ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
+            ->join($dbp_users . '.playlist_items AS pli', function ($join) use ($book_id) {
+                $join
+                    ->on('bf.id', '=', 'pli.fileset_id')
+                    ->where('pli.book_id', $book_id)
+                    ->whereColumn('user_highlights.chapter', '=', 'pli.chapter_start')
+                    ->where(function ($wherequery) {
+                        $wherequery
+                        ->orWhereNull('pli.verse_start')
+                        ->orWhere(function ($verse_start_where) {
+                            $verse_start_where
+                                ->whereColumn('user_highlights.verse_start', '<=', 'pli.verse_end')
+                                ->whereColumn('user_highlights.verse_start', '>=', 'pli.verse_start');
+                        })
+                        ->orWhere(function ($verse_end_where) {
+                            $verse_end_where
+                                ->whereColumn('user_highlights.verse_end', '<=', 'pli.verse_end')
+                                ->whereColumn('user_highlights.verse_end', '>=', 'pli.verse_start');
+                        });
+                    });
+            })
+            ->where('pli.playlist_id', $playlist_id)
+            ->where('user_highlights.book_id', $book_id);
     }
 }

--- a/app/Models/User/Study/Note.php
+++ b/app/Models/User/Study/Note.php
@@ -10,6 +10,7 @@ use App\Models\User\User;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Crypt;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * App\Models\User\Note
@@ -257,5 +258,45 @@ class Note extends Model
         $ctitle = optional($bible->translations->where('language_id', $GLOBALS['i18n_id'])->first())->name;
         $vtitle = optional($bible->vernacularTranslation)->name;
         return ($vtitle ? $vtitle : $ctitle);
+    }
+
+    /**
+     * Get notes related the playlist items that belong to playlist and a given book ID
+     *
+     * @param Illuminate\Database\Query\Builder $query
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return Illuminate\Database\Query\Builder
+     */
+    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
+    {
+        $dbp_users = config('database.connections.dbp_users.database');
+        $dbp_prod = config('database.connections.dbp.database');
+
+        return $query->join($dbp_prod . '.bible_fileset_connections AS bfc', 'bfc.bible_id', 'user_notes.bible_id')
+            ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
+            ->join($dbp_users . '.playlist_items AS pli', function ($join) use ($book_id) {
+                $join
+                    ->on('bf.id', '=', 'pli.fileset_id')
+                    ->where('pli.book_id', $book_id)
+                    ->whereColumn('user_notes.chapter', '=', 'pli.chapter_start')
+                    ->where(function ($wherequery) {
+                        $wherequery
+                        ->orWhereNull('pli.verse_start')
+                        ->orWhere(function ($verse_start_where) {
+                            $verse_start_where
+                                ->whereColumn('user_notes.verse_start', '<=', 'pli.verse_end')
+                                ->whereColumn('user_notes.verse_start', '>=', 'pli.verse_start');
+                        })
+                        ->orWhere(function ($verse_end_where) {
+                            $verse_end_where
+                                ->whereColumn('user_notes.verse_end', '<=', 'pli.verse_end')
+                                ->whereColumn('user_notes.verse_end', '>=', 'pli.verse_start');
+                        });
+                    });
+            })
+            ->where('pli.playlist_id', $playlist_id)
+            ->where('user_notes.book_id', $book_id);
     }
 }

--- a/app/Models/User/Study/UserAnnotationTrait.php
+++ b/app/Models/User/Study/UserAnnotationTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models\User\Study;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+use App\Models\Bible\BibleFilesetConnection;
+
+trait UserAnnotationTrait
+{
+    /**
+     * Get bookmarks related the playlist items that belong to playlist and a given book ID
+     *
+     * @param Illuminate\Database\Query\Builder $query
+     * @param int $playlist_id
+     * @param string $book_id
+     *
+     * @return Illuminate\Database\Query\Builder
+     */
+    public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
+    {
+        $dbp_users = config('database.connections.dbp_users.database');
+        $dbp_prod = config('database.connections.dbp.database');
+
+        return $query
+            ->where($this->table.'.book_id', $book_id)
+            ->whereExists(function (QueryBuilder $subquery) use ($dbp_users, $dbp_prod, $book_id, $playlist_id) {
+                return $subquery->select(\DB::raw(1))
+                    ->from($dbp_prod . '.bible_fileset_connections AS bfc')
+                    ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
+                    ->join($dbp_users . '.playlist_items', function (QueryBuilder $join) use ($book_id) {
+                        $join
+                            ->on('bf.id', '=', 'playlist_items.fileset_id')
+                            ->where('playlist_items.book_id', $book_id)
+                            ->whereColumn($this->table.'.chapter', '=', 'playlist_items.chapter_start')
+                            ->whereColumn($this->table.'.bible_id', '=', 'bfc.bible_id');
+                    })
+                    ->where('playlist_items.playlist_id', $playlist_id);
+            });
+    }
+}

--- a/app/Transformers/BibleVerseTransformer.php
+++ b/app/Transformers/BibleVerseTransformer.php
@@ -2,10 +2,6 @@
 
 namespace App\Transformers;
 
-use App\Models\Bible\Bible;
-
-use Illuminate\Support\Arr;
-
 class BibleVerseTransformer extends BaseTransformer
 {
     /**

--- a/app/Transformers/PlaylistBookmarksTransformer.php
+++ b/app/Transformers/PlaylistBookmarksTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Models\User\Study\Bookmark;
+use League\Fractal\TransformerAbstract;
+
+class PlaylistBookmarksTransformer extends TransformerAbstract
+{
+    /**
+     * @OA\Schema (
+     *        type="object",
+     *        schema="v4_internal_playlist_user_bookmarks",
+     *        description="The transformed user bookmarks",
+     *        title="v4_internal_playlist_user_bookmarks",
+     *      @OA\Xml(name="v4_internal_playlist_user_bookmarks"),
+     *   @OA\Property(property="data", type="array",
+     *      @OA\Items(
+     *          @OA\Property(property="id",       type="integer"),
+     *          @OA\Property(property="bible_id", ref="#/components/schemas/Bible/properties/id"),
+     *          @OA\Property(property="book_id",  ref="#/components/schemas/Book/properties/id"),
+     *          @OA\Property(property="chapter",  ref="#/components/schemas/Bookmark/properties/chapter"),
+     *          @OA\Property(property="verse",    ref="#/components/schemas/Bookmark/properties/verse_start"),
+     *          @OA\Property(property="tags",     ref="#/components/schemas/AnnotationTag")
+     *      )
+     *   )
+     *)
+     *
+     * @param Bookmark $bookmark
+     * @return array
+     */
+    public function transform(Bookmark $bookmark)
+    {
+        return [
+            'id'        => (int) $bookmark->id,
+            'bible_id'  => (string) $bookmark->bible_id,
+            'book_id'   => (string) $bookmark->book_id,
+            'chapter'   => (int) $bookmark->chapter,
+            'verse'     => (int) $bookmark->verse_start,
+            'tags'      => $bookmark->tags
+        ];
+    }
+}

--- a/app/Transformers/PlaylistHighlightsTransformer.php
+++ b/app/Transformers/PlaylistHighlightsTransformer.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Models\User\Study\Highlight;
+
+class PlaylistHighlightsTransformer extends UserHighlightsTransformer
+{
+    /**
+     * @OA\Schema (
+     *        type="object",
+     *        schema="v4_internal_playlist_user_highlights",
+     *        description="The transformed user highlights",
+     *        title="v4_internal_playlist_user_highlights",
+     *      @OA\Xml(name="v4_internal_playlist_user_highlights"),
+     *   @OA\Property(property="data", type="array",
+     *      @OA\Items(
+     *          @OA\Property(property="id",                 type="integer"),
+     *          @OA\Property(property="user_id",            ref="#/components/schemas/User/properties/id"),
+     *          @OA\Property(property="bible_id",           ref="#/components/schemas/Bible/properties/id"),
+     *          @OA\Property(property="book_id",            ref="#/components/schemas/Book/properties/id"),
+     *          @OA\Property(property="chapter",            ref="#/components/schemas/Highlight/properties/chapter"),
+     *          @OA\Property(property="verse_start",        ref="#/components/schemas/Highlight/properties/verse_start"),
+     *          @OA\Property(property="verse_end",          ref="#/components/schemas/Highlight/properties/verse_end"),
+     *          @OA\Property(property="highlight_start",    ref="#/components/schemas/Highlight/properties/highlight_start"),
+     *          @OA\Property(property="highlighted_words",  ref="#/components/schemas/Highlight/properties/highlighted_words"),
+     *          @OA\Property(property="highlighted_color",  ref="#/components/schemas/Highlight/properties/highlighted_color"),
+     *          @OA\Property(property="tags",               ref="#/components/schemas/AnnotationTag")
+     *      )
+     *   )
+     *)
+     *
+     * @param Highlight $note
+     * @return array
+     */
+    public function transform(Highlight $highlight)
+    {
+        $this->checkColorPreference($highlight);
+
+        return [
+            'id'                => (int) $highlight->id,
+            'bible_id'          => (string) $highlight->bible_id,
+            'book_id'           => (string) $highlight->book_id,
+            'chapter'           => (int) $highlight->chapter,
+            'verse_start'       => (int) $highlight->verse_start,
+            'verse_end'         => (int) $highlight->verse_end,
+            'highlight_start'   => (int) $highlight->highlight_start,
+            'highlighted_words' => $highlight->highlighted_words,
+            'highlighted_color' => $highlight->color,
+            'tags'              => $highlight->tags,
+        ];
+    }
+}

--- a/app/Transformers/PlaylistHighlightsTransformer.php
+++ b/app/Transformers/PlaylistHighlightsTransformer.php
@@ -15,17 +15,32 @@ class PlaylistHighlightsTransformer extends UserHighlightsTransformer
      *      @OA\Xml(name="v4_internal_playlist_user_highlights"),
      *   @OA\Property(property="data", type="array",
      *      @OA\Items(
-     *          @OA\Property(property="id",                 type="integer"),
-     *          @OA\Property(property="user_id",            ref="#/components/schemas/User/properties/id"),
-     *          @OA\Property(property="bible_id",           ref="#/components/schemas/Bible/properties/id"),
-     *          @OA\Property(property="book_id",            ref="#/components/schemas/Book/properties/id"),
-     *          @OA\Property(property="chapter",            ref="#/components/schemas/Highlight/properties/chapter"),
-     *          @OA\Property(property="verse_start",        ref="#/components/schemas/Highlight/properties/verse_start"),
-     *          @OA\Property(property="verse_end",          ref="#/components/schemas/Highlight/properties/verse_end"),
-     *          @OA\Property(property="highlight_start",    ref="#/components/schemas/Highlight/properties/highlight_start"),
-     *          @OA\Property(property="highlighted_words",  ref="#/components/schemas/Highlight/properties/highlighted_words"),
-     *          @OA\Property(property="highlighted_color",  ref="#/components/schemas/Highlight/properties/highlighted_color"),
-     *          @OA\Property(property="tags",               ref="#/components/schemas/AnnotationTag")
+     *          @OA\Property(property="id",       type="integer"),
+     *          @OA\Property(property="user_id",  ref="#/components/schemas/User/properties/id"),
+     *          @OA\Property(property="bible_id", ref="#/components/schemas/Bible/properties/id"),
+     *          @OA\Property(property="book_id",  ref="#/components/schemas/Book/properties/id"),
+     *          @OA\Property(property="chapter",  ref="#/components/schemas/Highlight/properties/chapter"),
+     *          @OA\Property(
+     *              property="verse_start",
+     *              ref="#/components/schemas/Highlight/properties/verse_start"
+     *          ),
+     *          @OA\Property(
+     *              property="verse_end",
+     *              ref="#/components/schemas/Highlight/properties/verse_end"
+     *          ),
+     *          @OA\Property(
+     *              property="highlight_start",
+     *              ref="#/components/schemas/Highlight/properties/highlight_start"
+     *          ),
+     *          @OA\Property(
+     *              property="highlighted_words",
+     *              ref="#/components/schemas/Highlight/properties/highlighted_words"
+     *          ),
+     *          @OA\Property(
+     *              property="highlighted_color",
+     *              ref="#/components/schemas/Highlight/properties/highlighted_color"
+     *          ),
+     *          @OA\Property(property="tags", ref="#/components/schemas/AnnotationTag")
      *      )
      *   )
      *)

--- a/app/Transformers/PlaylistNotesTransformer.php
+++ b/app/Transformers/PlaylistNotesTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Transformers;
+
+use App\Models\User\Study\Note;
+use League\Fractal\TransformerAbstract;
+
+class PlaylistNotesTransformer extends TransformerAbstract
+{
+    /**
+     * @OA\Schema (
+     *        type="object",
+     *        schema="v4_internal_playlist_user_notes",
+     *        description="The transformed user notes",
+     *        title="v4_internal_playlist_user_notes",
+     *      @OA\Xml(name="v4_internal_playlist_user_notes"),
+     *   @OA\Property(property="data", type="array",
+     *      @OA\Items(
+     *          @OA\Property(property="id",             type="integer"),
+     *          @OA\Property(property="user_id",        ref="#/components/schemas/User/properties/id"),
+     *          @OA\Property(property="bible_id",       ref="#/components/schemas/Bible/properties/id"),
+     *          @OA\Property(property="book_id",        ref="#/components/schemas/Book/properties/id"),
+     *          @OA\Property(property="chapter",        ref="#/components/schemas/Note/properties/chapter"),
+     *          @OA\Property(property="verse_start",    ref="#/components/schemas/Note/properties/verse_start"),
+     *          @OA\Property(property="verse_end",      ref="#/components/schemas/Note/properties/verse_end"),
+     *          @OA\Property(property="tags",           ref="#/components/schemas/AnnotationTag")
+     *      )
+     *   )
+     *)
+     *
+     * @param Note $note
+     * @return array
+     */
+    public function transform(Note $note)
+    {
+        return [
+            "id"            => (int) $note->id,
+            "user_id"       => (int) $note->user_id,
+            "notes"         => (string) $note->notes,
+            "bible_id"      => (string) $note->bible_id,
+            "book_id"       => (string) $note->book_id,
+            "chapter"       => (int) $note->chapter,
+            "verse_start"   => (int) $note->verse_start,
+            "verse_end"     => (int) $note->verse_end,
+            'tags'          => $note->tags,
+        ];
+    }
+}

--- a/app/Transformers/UserBookmarksTransformer.php
+++ b/app/Transformers/UserBookmarksTransformer.php
@@ -39,16 +39,16 @@ class UserBookmarksTransformer extends TransformerAbstract
     public function transform(Bookmark $bookmark)
     {
         return [
-      'id' => (int) $bookmark->id,
-      'bible_id' => (string) $bookmark->bible_id,
-      'book_id' => (string) $bookmark->book_id,
-      'book_name' => (string) optional($bookmark->book)->name,
-      'chapter' => (int) $bookmark->chapter,
-      'verse' => (int) $bookmark->verse_start,
-      'verse_text' => (string) $bookmark->verse_text,
-      'created_at' => (string) $bookmark->created_at,
-      'updated_at' => (string) $bookmark->updated_at,
-      'tags' => $bookmark->tags
-    ];
+          'id' => (int) $bookmark->id,
+          'bible_id' => (string) $bookmark->bible_id,
+          'book_id' => (string) $bookmark->book_id,
+          'book_name' => (string) optional($bookmark->book)->name,
+          'chapter' => (int) $bookmark->chapter,
+          'verse' => (int) $bookmark->verse_start,
+          'verse_text' => (string) $bookmark->verse_text,
+          'created_at' => (string) $bookmark->created_at,
+          'updated_at' => (string) $bookmark->updated_at,
+          'tags' => $bookmark->tags
+        ];
     }
 }

--- a/app/Transformers/UserHighlightsTransformer.php
+++ b/app/Transformers/UserHighlightsTransformer.php
@@ -64,7 +64,7 @@ class UserHighlightsTransformer extends TransformerAbstract
         ];
     }
 
-    private function checkColorPreference($highlight)
+    protected function checkColorPreference($highlight)
     {
         $color_preference = checkParam('prefer_color') ?? 'rgba';
         $highlight->color = Highlight::checkAndReturnColorPreference($highlight, $color_preference);

--- a/app/Transformers/UserNotesTransformer.php
+++ b/app/Transformers/UserNotesTransformer.php
@@ -47,20 +47,19 @@ class UserNotesTransformer extends TransformerAbstract
     public function transform(Note $note)
     {
         return [
-      'id' => (int) $note->id,
-      'bible_id' => (string) $note->bible_id,
-      'bible_name' => (string) $note->bible_name,
-      'book_id' => (string) $note->book_id,
-      'book_name' => (string) optional($note->book)->name,
-      'chapter' => (int) $note->chapter,
-      'verse_start' => (int) $note->verse_start,
-      'verse_end' => (int) $note->verse_end,
-      'verse_text' => (string) $note->verse_text,
-      // 'notes' => (string) $note->notes,
-      'notes' => mb_convert_encoding((string) $note->notes, "UTF-8", "auto"),
-      'created_at' => (string) $note->created_at,
-      'updated_at' => (string) $note->updated_at,
-      'tags' => $note->tags
-    ];
+            'id' => (int) $note->id,
+            'bible_id' => (string) $note->bible_id,
+            'bible_name' => (string) $note->bible_name,
+            'book_id' => (string) $note->book_id,
+            'book_name' => (string) optional($note->book)->name,
+            'chapter' => (int) $note->chapter,
+            'verse_start' => (int) $note->verse_start,
+            'verse_end' => (int) $note->verse_end,
+            'verse_text' => (string) $note->verse_text,
+            'notes' => (string) $note->notes,
+            'created_at' => (string) $note->created_at,
+            'updated_at' => (string) $note->updated_at,
+            'tags' => $note->tags
+        ];
     }
 }

--- a/app/Transformers/UserNotesTransformer.php
+++ b/app/Transformers/UserNotesTransformer.php
@@ -56,7 +56,8 @@ class UserNotesTransformer extends TransformerAbstract
       'verse_start' => (int) $note->verse_start,
       'verse_end' => (int) $note->verse_end,
       'verse_text' => (string) $note->verse_text,
-      'notes' => (string) $note->notes,
+      // 'notes' => (string) $note->notes,
+      'notes' => mb_convert_encoding((string) $note->notes, "UTF-8", "auto"),
       'created_at' => (string) $note->created_at,
       'updated_at' => (string) $note->updated_at,
       'tags' => $note->tags

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/yaml": "6.0.10",
         "torann/geoip": "3.0.4",
         "yosymfony/toml": "1.0.4",
-        "zircote/swagger-php": "4.4.9"
+        "zircote/swagger-php": "3.3.6"
     },
     "require-dev": {
         "barryvdh/laravel-debugbar": "3.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "708450becaf886bf45ecf0643ef98df6",
+    "content-hash": "3a2607c2be1d085abf2600b535e15962",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -9342,16 +9342,16 @@
         },
         {
             "name": "zircote/swagger-php",
-            "version": "4.4.9",
+            "version": "3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zircote/swagger-php.git",
-                "reference": "0c1cdd31e8cfeb7116c54696aafdab9c778070fd"
+                "reference": "5016342f966fca29dda84455de066c5c90d37941"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/0c1cdd31e8cfeb7116c54696aafdab9c778070fd",
-                "reference": "0c1cdd31e8cfeb7116c54696aafdab9c778070fd",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/5016342f966fca29dda84455de066c5c90d37941",
+                "reference": "5016342f966fca29dda84455de066c5c90d37941",
                 "shasum": ""
             },
             "require": {
@@ -9363,22 +9363,18 @@
                 "symfony/yaml": ">=3.3"
             },
             "require-dev": {
-                "composer/package-versions-deprecated": "^1.11",
+                "composer/package-versions-deprecated": "1.11.99.2",
                 "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
-                "phpstan/phpstan": "^1.6",
-                "phpunit/phpunit": ">=8",
-                "vimeo/psalm": "^4.23"
+                "phpunit/phpunit": ">=8.5.14"
             },
             "bin": [
                 "bin/openapi"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.x-dev"
-                }
-            },
             "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
                 "psr-4": {
                     "OpenApi\\": "src"
                 }
@@ -9413,9 +9409,9 @@
             ],
             "support": {
                 "issues": "https://github.com/zircote/swagger-php/issues",
-                "source": "https://github.com/zircote/swagger-php/tree/4.4.9"
+                "source": "https://github.com/zircote/swagger-php/tree/3.3.6"
             },
-            "time": "2022-09-11T20:51:43+00:00"
+            "time": "2022-05-21T01:52:14+00:00"
         }
     ],
     "packages-dev": [

--- a/routes/api.php
+++ b/routes/api.php
@@ -329,7 +329,21 @@ Route::name('v4_internal_playlists.draft')
     ->post('playlists/{playlist_id}/draft', 'Playlist\PlaylistsController@draft');
 Route::name('v4_internal_playlists_item.metadata')
     ->get('playlists/item/metadata', 'Playlist\PlaylistsController@itemMetadata');
-
+Route::name('v4_internal_playlists.notes')
+    ->middleware('APIToken:check')
+    ->get('playlists/{playlist_id}/{book_id}/notes', 'Playlist\PlaylistsController@notes')
+    ->whereNumber('playlist_id')
+    ->whereAlphaNumeric('book_id');
+Route::name('v4_internal_playlists.highlights')
+    ->middleware('APIToken:check')
+    ->get('playlists/{playlist_id}/{book_id}/highlights', 'Playlist\PlaylistsController@highlights')
+    ->whereNumber('playlist_id')
+    ->whereAlphaNumeric('book_id');
+Route::name('v4_internal_playlists.bookmarks')
+    ->middleware('APIToken:check')
+    ->get('playlists/{playlist_id}/{book_id}/bookmarks', 'Playlist\PlaylistsController@bookmarks')
+    ->whereNumber('playlist_id')
+    ->whereAlphaNumeric('book_id');
 // VERSION 4 | Plans (bible.is private)
 Route::name('v4_internal_plans.index')
     ->middleware('APIToken')


### PR DESCRIPTION
# Description
It has created 3 new endpoints to get the user bookmarks, highlights and notes filtering by playlist ID and Book ID.

- `/playlists/:playlist_id/:book_id/notes`

- `/playlists/:playlist_id/:book_id/highlights`

- `/playlists/:playlist_id/:book_id/bookmarks`

# NOTE
I have downgraded `zircote/swagger-php` to the version 3.3.6 because the task to generate the openapi.json file is not working with the last version of  `zircote/swagger-php`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-454

## How Do I QA This
- We should run all test of the following postman folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-3cc08c6e-6640-45c3-bc82-96d2d51162d3 
