### PR TITLE
FCBHDBP-461 DBP - cache issue with Gideon bible-download-list

### DIFF
--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Bible;
 
+use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use App\Traits\AccessControlAPI;
 use App\Traits\CallsBucketsTrait;
 use App\Traits\BibleFileSetsTrait;
@@ -57,8 +59,12 @@ class BibleFilesetsDownloadController extends APIController
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
      * @throws \Exception
      */
-    public function index($fileset_id, $book_id = null, $chapter = null, $cache_key = 'bible_filesets_download_index')
-    {
+    public function index(
+        string $fileset_id,
+        ?string $book_id = null,
+        ?string $chapter = null,
+        string $cache_key = 'bible_filesets_download_index'
+    ) {
         $type  = checkParam('type') ?? '';
         $limit = (int) (checkParam('limit') ?? 5000);
         $limit = max($limit, 5000);
@@ -73,7 +79,7 @@ class BibleFilesetsDownloadController extends APIController
             function () use ($fileset_id, $book_id, $chapter, $type, $limit) {
                 $fileset_from_id = BibleFileset::where('id', $fileset_id)->first();
                 if (!$fileset_from_id) {
-                    return $this->setStatusCode(404)->replyWithError(
+                    return $this->setStatusCode(Response::HTTP_NOT_FOUND)->replyWithError(
                         trans('api.bible_fileset_errors_404')
                     );
                 }
@@ -169,7 +175,7 @@ class BibleFilesetsDownloadController extends APIController
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View|mixed
      * @throws \Exception
      */
-    public function list($cache_key = 'bible_filesets_download_list')
+    public function list(string $cache_key = 'bible_filesets_download_list') : JsonResponse
     {
         $limit = (int) (checkParam('limit') ?? 50);
         $page = (int) (checkParam('page') ?? 1);

--- a/app/Models/Bible/BibleFilesetLookup.php
+++ b/app/Models/Bible/BibleFilesetLookup.php
@@ -5,6 +5,8 @@ namespace App\Models\Bible;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Pagination\LengthAwarePaginator;
 use App\Models\Bible\Bible;
 use App\Models\Bible\BibleFilesetConnection;
@@ -18,6 +20,8 @@ use App\Models\Bible\BibleFilesetCopyrightRole;
 use App\Models\Language\Language;
 use App\Models\User\Key;
 use App\Models\Organization\Organization;
+use App\Models\User\AccessGroupKey;
+use App\Models\User\AccessGroupFileset;
 
 /**
  * App\Models\Bible\BibleFilesetLookup
@@ -111,39 +115,6 @@ class BibleFilesetLookup extends Model
         return $this->hasMany(BibleFilesetTag::class, 'hash_id', 'hash_id');
     }
 
-
-    public function scopeContentAvailable(Builder $query) : Builder
-    {
-        return $query->from('organizations')
-            ->join('bible_fileset_copyright_organizations', function ($join) {
-                $join->on('bible_fileset_copyright_organizations.organization_id', '=', 'organizations.id')
-                    ->where(
-                        'bible_fileset_copyright_organizations.organization_role',
-                        BibleFilesetCopyrightRole::LICENSOR
-                    );
-            })
-            ->join('bible_filesets', 'bible_fileset_copyright_organizations.hash_id', 'bible_filesets.hash_id')
-            ->join('bible_fileset_connections', 'bible_fileset_connections.hash_id', 'bible_filesets.hash_id')
-            ->join('bibles', 'bibles.id', 'bible_fileset_connections.bible_id')
-            ->join('languages', 'languages.id', 'bibles.language_id')
-            ->join('bible_fileset_tags', function ($join) {
-                $join->on('bible_filesets.hash_id', '=', 'bible_fileset_tags.hash_id')
-                    ->where('bible_fileset_tags.name', 'stock_no');
-            })
-            ->join('organization_translations', function ($join) {
-                $join->on(
-                    'organization_translations.organization_id',
-                    '=',
-                    'bible_fileset_copyright_organizations.organization_id'
-                )
-                    ->where('organization_translations.language_id', Language::ENGLISH_ID);
-            })
-            ->join('bible_translations', function ($join) {
-                $join->on('bible_translations.bible_id', '=', 'bibles.id')
-                    ->where('bible_translations.language_id', Language::ENGLISH_ID);
-            });
-    }
-
     /**
      * Get fileset list available for a user key given
      *
@@ -155,59 +126,43 @@ class BibleFilesetLookup extends Model
      */
     public static function getContentAvailableByKey(string $key, int $limit, string $type = null) : LengthAwarePaginator
     {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
-        $download_access_group_array_ids = getDownloadAccessGroupList();
-
         $user_key_id = Key::getIdByKey($key);
 
-        $select_distinct_columns = [
-            'bible_fileset_tags.description',
-            'bibles.id',
-            'bible_filesets.id',
-            'bible_filesets.set_type_code',
-            'bible_filesets.hash_id',
-            'languages.name',
-            'bible_translations.name',
-            'organization_translations.name'
-        ];
+        $group_id_list_by_user_key = AccessGroupKey::select('access_group_id')
+            ->where('key_id', $user_key_id)
+            ->whereIn('access_group_id', getDownloadAccessGroupList())
+            ->get()
+            ->pluck('access_group_id')
+            ->toArray();
 
-        return BibleFilesetLookup::select([
-                'bible_fileset_tags.description AS stocknumber',
-                'bibles.id AS bibleid',
-                'bible_filesets.id AS filesetid',
-                'bible_filesets.set_type_code AS type',
-                'bible_filesets.hash_id AS hash_id',
-                'languages.name AS language',
-                'bible_translations.name AS version',
-                'organization_translations.name AS licensor'
-            ])
-            ->distinct($select_distinct_columns)
-            ->contentAvailable()
-            ->whereNotIn('bible_filesets.set_type_code', ['text_format'])
-            ->whereRaw('bible_filesets.id NOT LIKE ?', '%DA16')
-            ->join(
-                $dbp_prod . '.access_group_filesets as agfv',
-                function ($join_agfv) use ($download_access_group_array_ids) {
-                    $join_agfv
-                        ->on('agfv.hash_id', 'bible_filesets.hash_id')
-                        ->whereIn('agfv.access_group_id', $download_access_group_array_ids);
-                }
+        return BibleFileset::select([
+            'bible_filesets.id AS filesetid',
+            'bible_filesets.set_type_code AS type',
+            'languages.name AS language',
+            'organization_translations.name AS licensor'
+        ])
+        ->join(
+            'bible_fileset_copyright_organizations',
+            'bible_fileset_copyright_organizations.hash_id',
+            'bible_filesets.hash_id'
+        )->join('bible_fileset_connections', 'bible_fileset_connections.hash_id', 'bible_filesets.hash_id')
+        ->join('bibles', 'bibles.id', 'bible_fileset_connections.bible_id')
+        ->join('languages', 'languages.id', 'bibles.language_id')
+        ->join('organization_translations', function (JoinClause $join) {
+            $join->on(
+                'organization_translations.organization_id',
+                '=',
+                'bible_fileset_copyright_organizations.organization_id'
             )
-            ->join(
-                $dbp_users . '.access_group_api_keys as agak',
-                function ($join_agak) use ($user_key_id, $download_access_group_array_ids) {
-                    $join_agak
-                        ->on('agak.access_group_id', 'agfv.access_group_id')
-                        ->where('agak.key_id', $user_key_id)
-                        ->whereIn('agak.access_group_id', $download_access_group_array_ids);
-                }
-            )
-            ->when($type, function ($query) use ($type) {
-                $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($type);
-                $query->whereIn('bible_filesets.set_type_code', $set_type_code_array);
-            })
-            ->paginate($limit, $select_distinct_columns);
+                ->where('organization_translations.language_id', Language::ENGLISH_ID);
+        })
+        ->where('bible_fileset_copyright_organizations.organization_role', BibleFilesetCopyrightRole::LICENSOR)
+        ->when($type, function (Builder $query) use ($type) {
+            $query->whereIn('bible_filesets.set_type_code', BibleFileset::getsetTypeCodeFromMedia($type));
+        })
+        ->whereNotIn('bible_filesets.set_type_code', ['text_format'])
+        ->where('bible_filesets.id', 'NOT LIKE', '%DA16')
+        ->hasAccessGroup($group_id_list_by_user_key)
+        ->paginate($limit);
     }
 }


### PR DESCRIPTION
# Description
I was checking the following issue is related with the to way to lock and block the cache key.
```shell
Exception 'Exception' with message 'Exception when the cache value is null for key 
```
The above has been recreated, I have pushed a fix to solve it and you can see more detail in the PR: #812 .

Furthermore, It has done a refactor to improve the main query for the v4_download_list endpoint. This refactor improved the performance as you can see in the screenshots.


## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-461

## How Do I QA This
- You should run the following postman test and it should pass.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-5b9e68bd-e763-499b-a7e3-aa969b685f46

- You should execute the [M] Download requests tests and they should pass.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/collection/12519377-3a68ded7-3a3d-40a3-9feb-93ce491311a8?action=share&creator=17122915
## Screenshots (if appropriate)

1. The time performance before refactor
![Screenshot from 2022-10-14 16-08-47](https://user-images.githubusercontent.com/73488660/195946053-cf43a837-0709-4507-a3ad-ebdbc30fd3eb.png)

2. The time performance after refactor
![Screenshot from 2022-10-14 16-07-26](https://user-images.githubusercontent.com/73488660/195946077-deba4910-028d-47e6-bd01-58902e0080d3.png)

