### PR TITLE
FCHDBP-473 Endpoint to stop a plan is not resetting plan when it has an only one item completed

### DIFF
--- a/app/Models/Plan/PlanDay.php
+++ b/app/Models/Plan/PlanDay.php
@@ -307,12 +307,13 @@ class PlanDay extends Model implements Sortable
      *
      * @return Array
      */
-    public static function getPlanDayIdsByPlanAndUser(int $plan_id, int $user_id) : Array
+    public static function getPlaylistIdsByPlanAndUser(int $plan_id, int $user_id) : Array
     {
-        return PlanDay::select('playlist_id')
-            ->join('plan_days_completed as pdc', 'pdc.plan_day_id', 'plan_days.id')
+        return PlanDay::select('pli.playlist_id')
+            ->join('playlist_items as pli', 'pli.playlist_id', 'plan_days.playlist_id')
+            ->join('playlist_items_completed as pldc', 'pldc.playlist_item_id', '=', 'pli.id')
             ->where('plan_days.plan_id', $plan_id)
-            ->where('pdc.user_id', $user_id)
+            ->where('pldc.user_id', $user_id)
             ->get()
             ->pluck('playlist_id')
             ->all();

--- a/app/Models/Plan/UserPlan.php
+++ b/app/Models/Plan/UserPlan.php
@@ -161,8 +161,10 @@ class UserPlan extends Model
      */
     public static function removePlanDaysCompleteByPlanId(int $plan_id, int $user_id) : void
     {
-        $playlist_ids_by_plan = PlanDay::getPlanDayIdsByPlanAndUser($plan_id, $user_id);
-        PlaylistItemsComplete::removeItemsByPlayListsAndUser($playlist_ids_by_plan, $user_id);
-        PlanDayComplete::removeDaysByPlanAndUser($plan_id, $user_id);
+        \DB::transaction(function () use ($plan_id, $user_id) {
+            $playlist_ids_by_plan = PlanDay::getPlaylistIdsByPlanAndUser($plan_id, $user_id);
+            PlaylistItemsComplete::removeItemsByPlayListsAndUser($playlist_ids_by_plan, $user_id);
+            PlanDayComplete::removeDaysByPlanAndUser($plan_id, $user_id);
+        });
     }
 }

--- a/app/Models/Playlist/PlaylistItemsComplete.php
+++ b/app/Models/Playlist/PlaylistItemsComplete.php
@@ -68,7 +68,7 @@ class PlaylistItemsComplete extends Model
     {
         return self::whereExists(function ($sub_query) use ($playlist_ids) {
             return $sub_query->select(\DB::raw(1))
-                ->from('playlist_items as pli', 'pli.playlist_id', 'pld.playlist_id')
+                ->from('playlist_items as pli')
                 ->whereIn('pli.playlist_id', $playlist_ids)
                 ->whereColumn('pli.id', '=', 'playlist_items_completed.playlist_item_id');
         })


### PR DESCRIPTION
# Description
1. It has fixed an issue related to the endpoint to stop a plan. The stop endpoint was not resetting the plan when it had an only one item completed but, if the Plan had a day completed, all items were reset correctly. 
2. Also, it has fixed an issue related to avoid return a 500 error when user tries to create a playlist with an empty playlist item.


## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-473

## How Do I QA This
1. You should run the following two postman folders and they should pass. The following postman folders are related to the endpoint to stop a plan.

   - https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-d68ccda0-18f3-44a6-904c-a7250e51860b

   - https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-cee146ec-ef4f-4814-bf41-e63b6d371659


2. You should run the following  postman test and it should pass. The following postman test is related to the endpoint to create a playlist with an empty playlist item.

   - https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0a6a2023-c882-4b26-978b-625bde9c0f87