### PR TITLE
FCBHDBP-508 Temporarily add stocknum attribute, with no value

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -626,6 +626,9 @@ if (!function_exists('formatFilesetMeta')) {
                     $fileset[$metadata['name']] = $metadata['description'];
                 }
             }
+            // December 2022, this is temporary to support older versions of 5fish applications.
+            // Revisit in one year after discussing with James Thomas mailto:jamesthomas@globalrecordings.net
+            $fileset['stock_no'] = null;
         }
         return $fileset;
     }


### PR DESCRIPTION

# Description
It has added stock_no attribute to the fileset object temporarily to support older versions of 5fish applications.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-508

## How Do I QA This
- Chapter detail
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-89017364-bf03-4664-a314-a311bad52269
- translate plan 209 SPNSEV
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-fea3c2d5-a970-4774-8cd5-0940ad49e106
- translate playlist BENBBS
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9c1f544c-37f4-40f5-b467-02e59e685a90

Also, it should pass all postman test of [M] bible.is mobile requests:
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/collection/12519377-87d1d0ee-d642-4fb7-ba80-606638d4e5e3?action=share&creator=17122915
