### PR TITLE
FCBHDBP-513 when two text_plain filesets exist, do not return any information for the six character fileset

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -266,7 +266,9 @@ class BiblesController extends APIController
         $formatted_search_cache = str_replace(' ', '', $search_text);
 
         if ($formatted_search_cache === '' || !$formatted_search_cache || empty($formatted_search)) {
-            return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
+            return $this
+                ->setStatusCode(Response::HTTP_BAD_REQUEST)
+                ->replyWithError(trans('api.search_errors_400'));
         }
 
         $key = $this->key;
@@ -318,7 +320,9 @@ class BiblesController extends APIController
         $version_query_cache = str_replace(' ', '', $version_query);
 
         if ($version_query_cache === '' || !$version_query_cache || empty($version_query)) {
-            return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
+            return $this
+                ->setStatusCode(Response::HTTP_BAD_REQUEST)
+                ->replyWithError(trans('api.search_errors_400'));
         }
 
         $key = $this->key;
@@ -397,10 +401,10 @@ class BiblesController extends APIController
                     'organizations.translations',
                     'alphabet.primaryFont',
                     'filesets' => function ($query) use ($key, $include_font) {
-                        $query->isContentAvailable($key);
-                        $query->when($include_font, function ($sub_query) {
-                            $sub_query->with('fonts');
-                        });
+                        $query->isContentAvailable($key)
+                            ->when($include_font, function ($sub_query) {
+                                $sub_query->with('fonts');
+                            })->conditionToExcludeOldTextFormat();
                     }
                 ])->find($id);
             }

--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -9,6 +9,7 @@ use App\Models\Language\NumeralSystem;
 use App\Models\Organization\Organization;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use App\Models\Language\Language;
 
 /**
@@ -326,7 +327,13 @@ class Bible extends Model
         });
     }
 
-    public function scopeWithRequiredFilesets($query, $type_filters)
+    /**
+     * Filter bible records according if they has filesets attached
+     *
+     * @param Builder $query
+     * @param array $type_filters
+     */
+    public function scopeWithRequiredFilesets(Builder $query, array $type_filters) : Builder
     {
         return $query->whereHas('filesets', function ($q) use ($type_filters) {
             if ($type_filters['media']) {
@@ -341,7 +348,8 @@ class Bible extends Model
             $q->with(['meta' => function ($subQuery) {
                 $subQuery->where('admin_only', 0);
             }]);
-            $q->isContentAvailable($type_filters['key']);
+            $q->isContentAvailable($type_filters['key'])
+                ->conditionToExcludeOldTextFormat();
             $this->setConditionFilesets($q, $type_filters);
             $this->setConditionTagExclude($q, $type_filters);
         }]);


### PR DESCRIPTION
# Description
It has added a feature to avoid returning information about the old six character fileset. It has changed `BiblesController@index` and `BiblesController@show` endpoints. This will stop returning information on six character text_plain filesets when the ten character text_plain fileset is available but when there is only six character text_plain it should return it.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-513

## How Do I QA This
- The following postman test should pass. The bible AKEBSS has both six and ten character filesets and the following test should only return the fileset: `AKEBSSN_ET`. BiblesController@index
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-4808bd5b-3d9e-40f5-a5cf-fe50c0f9574a

- Using language ID and BiblesController@index:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a0221dc3-01cd-44b8-a56d-2cfa1b7f77b8

-  Using language ID and BiblesController@show:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6d43e4db-3850-4eea-a7f1-29bf025f2f35