### PR TITLE
FCBHDBP-hotfix enable non-integer verse identifier

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Bible;
 
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use App\Http\Controllers\APIController;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileset;
@@ -32,7 +33,9 @@ class StreamController extends APIController
         $current_file = cacheRemember('stream_master_index', $cache_params, now()->addHours(12), function () use ($id, $file_id_location) {
             $fileset = BibleFileset::uniqueFileset($id)->select('hash_id', 'id', 'asset_id')->first();
             if (!$fileset) {
-                return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+                return $this
+                    ->setStatusCode(HttpResponse::HTTP_NOT_FOUND)
+                    ->replyWithError('No fileset found for the provided params');
             }
 
             $is_multiple_mp3 = $this->isMultipleMp3($file_id_location);
@@ -44,7 +47,9 @@ class StreamController extends APIController
             $file = $this->getFileFromLocation($fileset, $file_id_location);
 
             if (!$file) {
-                return $this->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id_location]));
+                return $this
+                    ->setStatusCode(HttpResponse::HTTP_NOT_FOUND)
+                    ->replyWithError(trans('api.bible_file_errors_404', ['id' => $file_id_location]));
             }
             $asset_id = $fileset->asset_id;
             $current_file = '#EXTM3U';

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -233,7 +233,7 @@ trait BibleFileSetsTrait
                     'chapter' => $fileset_chapter->chapter_start,
                     'verse_start' => $fileset_chapter->verse_sequence,
                     'verse_start_alt' => $fileset_chapter->verse_start,
-                    'verse_end' => (int) $fileset_chapter->verse_end
+                    'verse_end' => $fileset_chapter->verse_end ? (int) $fileset_chapter->verse_end : null
                 ];
                 $fileset_chapters[$key]->file_name = route('v4_media_stream', array_filter(
                     $routeParameters,


### PR DESCRIPTION
# Description
It has added a constraint to handle the case when the verse_end value is empty into the chapter detail endpoint.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-515

## How Do I QA This
- You should execute the following postman test and it should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-daa3fa8c-be9a-4ed0-91a1-671e0b6ae6a2
