### PR TITLE
FCBHDBP-515 hotfix - enable non-integer verse identifier

### DIFF
--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -232,7 +232,6 @@ trait BibleFileSetsTrait
                     'book_id' => $fileset_chapter->book_id,
                     'chapter' => $fileset_chapter->chapter_start,
                     'verse_start' => $fileset_chapter->verse_sequence,
-                    'verse_start_alt' => $fileset_chapter->verse_start,
                     'verse_end' => $fileset_chapter->verse_end ? (int) $fileset_chapter->verse_end : null
                 ];
                 $fileset_chapters[$key]->file_name = route('v4_media_stream', array_filter(


### PR DESCRIPTION
# Description
hotfix it has removed the param: `verse_start_alt` from the method to generate the `v4_media_stream` route.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-518

## How Do I QA This

- We should runt the two following postman tests and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-daa3fa8c-be9a-4ed0-91a1-671e0b6ae6a2

https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-85c07444-8f4d-4598-a9bd-eb61ca030a4b