### PR TITLE
FCBHDBP enable non-integer verse identifier

### DIFF
--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -378,6 +378,7 @@ class PlaylistItems extends Model implements Sortable
             $verses =  cacheRemember('playlist_item_text', $cache_params, now()->addDay(), function () use ($text_fileset, $where) {
                 return BibleVerse::where('hash_id', $text_fileset->hash_id)
                     ->where($where)
+                    ->orderBy('verse_sequence')
                     ->get()
                     ->pluck('verse_text');
             });


### PR DESCRIPTION

# Description
It has added the explicit method to order by verse_sequence when a playlist_item fetches the verse_text records.

## Issue Link

## How Do I QA This
- We should execute the following postman folder and it should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-c03d49d4-8b41-4b33-ade4-3774de944c09