### PR TITLE
FCBHDBP-530 Issue - verse playback for playlist content 

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1124,7 +1124,7 @@ class PlaylistsController extends APIController
                             $transportStream[0]->timestamp->bible_file_id
                         )->count();
                         if ($timestamps_count === $transportStream->count() &&
-                            $transportStream[0]->timestamp->verse_start !== 0
+                            (int) $transportStream[0]->timestamp->verse_start !== 0
                         ) {
                             $transportStream->prepend((object)[]);
                         }
@@ -1194,15 +1194,15 @@ class PlaylistsController extends APIController
     {
         if ($item->chapter_end  === $item->chapter_start) {
             $transportStream = $transportStream->splice(1, $item->verse_end)->all();
-            return collect($transportStream)->slice($item->verse_start - 1)->all();
+            return collect($transportStream)->slice((int)$item->verse_start - 1)->all();
         }
 
         $transportStream = $transportStream->splice(1)->all();
         if ($bible_file->chapter_start === $item->chapter_start) {
-            return collect($transportStream)->slice($item->verse_start - 1)->all();
+            return collect($transportStream)->slice((int)$item->verse_start - 1)->all();
         }
         if ($bible_file->chapter_start === $item->chapter_end) {
-            return collect($transportStream)->splice(0, $item->verse_end)->all();
+            return collect($transportStream)->splice(0, (int)$item->verse_end)->all();
         }
 
         return $transportStream;

--- a/app/Models/User/Study/Note.php
+++ b/app/Models/User/Study/Note.php
@@ -241,8 +241,12 @@ class Note extends Model
         $verses = BibleVerse::withVernacularMetaData($bible)
         ->where('hash_id', $fileset->hash_id)
         ->where('bible_verses.book_id', $this['book_id'])
-        ->where('verse_start', '>=', $verse_start)
-        ->where('verse_end', '<=', $verse_end)
+        ->when($verse_start, function ($subquery) use ($verse_start) {
+            return $subquery->where('verse_sequence', '>=', (int) $verse_start);
+        })
+        ->when($verse_end, function ($subquery) use ($verse_end) {
+            return $subquery->where('verse_sequence', '>=', (int) $verse_end);
+        })
         ->where('chapter', $chapter)
         ->orderBy('verse_sequence')
         ->select(['bible_verses.verse_text'])


### PR DESCRIPTION

# Description
Fixed issue related to the endpoint to get a playlist  and a specific logic in  DBP where it is comparing two verse_start values as if they were integers values. So, For some cases the verse_text value is not being returned but the audio does.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-530

## How Do I QA This
- We should run the following 2 postman test and they have passed:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9ee78ea0-d603-49cb-a21f-38b28ef824d5

https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0ed7d9a7-40dc-4188-a20a-11cde7760b87

- Also, we should run [M] bible.is mobile request and it should pass