### PR TITLE
FCBHDBP-532 Hotfix. API - fix bug in v2 API regarding verse ordering

### DIFF
--- a/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
+++ b/app/Http/Controllers/Bible/Traits/TextControllerTrait.php
@@ -42,13 +42,13 @@ trait TextControllerTrait
                         return $query->where('bible_verses.book_id', $book->id);
                     })
                     ->when($verse_start, function ($query) use ($verse_start) {
-                        return $query->where('verse_end', '>=', $verse_start);
+                        return $query->where('verse_sequence', '>=', (int) $verse_start);
                     })
                     ->when($chapter, function ($query) use ($chapter) {
                         return $query->where('chapter', $chapter);
                     })
                     ->when($verse_end, function ($query) use ($verse_end) {
-                        return $query->where('verse_end', '<=', $verse_end);
+                        return $query->where('verse_sequence', '<=', (int) $verse_end);
                     })
                     ->orderBy('chapter')
                     ->orderBy('verse_sequence')

--- a/app/Http/Controllers/User/HighlightsController.php
+++ b/app/Http/Controllers/User/HighlightsController.php
@@ -475,7 +475,7 @@ class HighlightsController extends APIController
             'user_id'           => ((request()->method() === 'POST') ? 'required|' : '') . 'exists:dbp_users.users,id',
             'book_id'           => ((request()->method() === 'POST') ? 'required|' : '') . 'exists:dbp.books,id',
             'chapter'           => ((request()->method() === 'POST') ? 'required|' : '') . 'max:150|min:1|integer',
-            'verse_start'       => ((request()->method() === 'POST') ? 'required|' : '') . 'max:177|min:1|integer',
+            'verse_start'       => ((request()->method() === 'POST') ? 'required|' : '') . 'max:10|min:1',
             'verse_end'         => ((request()->method() === 'POST') ? 'required|' : '') . 'max:10|min:1',
             'reference'         => 'string',
             'highlight_start'   => ((request()->method() === 'POST') ? 'required|' : '') . 'min:0|integer',

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -118,10 +118,10 @@ trait BibleFileSetsTrait
             return $query->where('chapter', (int) $chapter_id);
         })
         ->when($verse_start, function ($query) use ($verse_start) {
-            return $query->where('verse_end', '>=', $verse_start);
+            return $query->where('verse_sequence', '>=', (int) $verse_start);
         })
         ->when($verse_end, function ($query) use ($verse_end) {
-            return $query->where('verse_end', '<=', $verse_end);
+            return $query->where('verse_sequence', '<=', (int) $verse_end);
         })
         ->orderBy('verse_sequence')
         ->orderBy('books.name', 'ASC')


### PR DESCRIPTION
# Description
 It has fixed the queries that were comparing the verse_start and verse_end columns as string values.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-532

## Note 1
@bradflood if the postman tests: `v2 get verses` and `v4 get verses` pass, I think that we could add them to the [M] postman test.

## How Do I QA This
We should execute the following 3 postman tests and they should pass:
- v2 get verses
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b99dfe85-f2fa-4314-a61a-e669f9d7ced2
- v4 get verses
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-5877742e-e8a9-4e34-8aee-64cdb7894e86
- anotations - This a folder and so, we need to use a runner
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-3cc08c6e-6640-45c3-bc82-96d2d51162d3