### PR TITLE
FCBHDBP-535 Issue with fileset ENGGIDN2SA book= 2TI chapter=2 verse=12

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -34,6 +34,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Database\Eloquent\Collection;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use App\Services\Plans\PlaylistService;
 
@@ -1089,13 +1090,16 @@ class PlaylistsController extends APIController
         $download = checkBoolean('download');
         $playlist = Playlist::with('items')->find($playlist_id);
         if (!$playlist) {
-            return $this->setStatusCode(404)->replyWithError('Playlist Not Found');
+            return $this->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)->replyWithError('Playlist Not Found');
         }
 
         $hls_playlist = $this->getHlsPlaylist($response, $playlist->items, $download);
 
         if ($download) {
-            return $this->reply(['hls' => $hls_playlist['file_content'], 'signed_files' => $hls_playlist['signed_files']]);
+            return $this->reply([
+                'hls' => $hls_playlist['file_content'],
+                'signed_files' => $hls_playlist['signed_files']
+            ]);
         }
 
         return response($hls_playlist['file_content'], 200, [
@@ -1129,7 +1133,7 @@ class PlaylistsController extends APIController
                             $transportStream->prepend((object)[]);
                         }
                     }
-    
+
                     $transportStream = $this->processVersesOnTransportStream($item, $transportStream, $bible_file);
                 }
     
@@ -1190,19 +1194,49 @@ class PlaylistsController extends APIController
         return (object) ['hls_items' => $hls_items, 'signed_files' => $signed_files, 'durations' => $durations];
     }
 
-    private function processVersesOnTransportStream($item, $transportStream, $bible_file)
-    {
+    private function processVersesOnTransportStream(
+        $item,
+        Collection $transportStream,
+        BibleFile $bible_file
+    ) : Array {
         if ($item->chapter_end  === $item->chapter_start) {
-            $transportStream = $transportStream->splice(1, $item->verse_end)->all();
-            return collect($transportStream)->slice((int)$item->verse_start - 1)->all();
+            $newStreamCollection = [];
+            foreach ($transportStream as $testTransportStream) {
+                $timestamp = optional($testTransportStream)->timestamp;
+                if ($timestamp &&
+                    (int) $timestamp->verse_sequence >= (int)$item->verse_start &&
+                    (int) $timestamp->verse_sequence <= (int)$item->verse_end
+                ) {
+                    $newStreamCollection[] = $testTransportStream;
+                }
+            }
+            return $newStreamCollection;
         }
 
         $transportStream = $transportStream->splice(1)->all();
-        if ($bible_file->chapter_start === $item->chapter_start) {
-            return collect($transportStream)->slice((int)$item->verse_start - 1)->all();
+        if ((int)$bible_file->chapter_start === (int)$item->chapter_start) {
+            $newStreamCollection = [];
+            foreach ($transportStream as $testTransportStream) {
+                $timestamp = optional($testTransportStream)->timestamp;
+                if ($timestamp &&
+                    (int) $timestamp->verse_sequence >= (int)$item->verse_start
+                ) {
+                    $newStreamCollection[] = $testTransportStream;
+                }
+            }
+            return $newStreamCollection;
         }
-        if ($bible_file->chapter_start === $item->chapter_end) {
-            return collect($transportStream)->splice(0, (int)$item->verse_end)->all();
+        if ((int)$bible_file->chapter_start === (int)$item->chapter_end) {
+            $newStreamCollection = [];
+            foreach ($transportStream as $testTransportStream) {
+                $timestamp = optional($testTransportStream)->timestamp;
+                if ($timestamp &&
+                    (int) $timestamp->verse_sequence <= (int)$item->verse_end
+                ) {
+                    $newStreamCollection[] = $testTransportStream;
+                }
+            }
+            return $newStreamCollection;
         }
 
         return $transportStream;


### PR DESCRIPTION
# Description
The logic for processing HLS audio has been improved by adding a mechanism to handle cases where a verse does not have a corresponding record in the `bible_file_timestamps` and `bible_file_stream_bytes` tables. Previously, the assumption was that all verses had a related record stored in these tables, resulting in the DBP fetching all records about the stream bytes and retrieving the stream record associated with the verse based on its position in the array. However, this logic could fail when the stream record is not stored in the database, potentially returning an incorrect record due to reliance on the array position alone.

# NOTE 1
To solve completely this issue we need to do the following changes into database:
1. Create a `bible_file_timestamps` record related `verse_start=13` and the `bible_file_id=561281`. The bible_file_id=561281 is `B16___02_2Timothy____ENGGIDN2DA.mp3`
2. After creating `bible_file_timestamps` record we need to create a `bible_file_stream_bytes` record related to the new bible_file_timestamps, `stream_bandwidth_id = 537213`. The `stream_bandwidth=537213` is `B16___02_2Timothy____ENGGIDN2SA-64kbs.m3u8`
3. Lastly, we must update the bible_file_timestamps record with ID=6202832 as it contains the audio for verses 12 and 13 combined..

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-535

## How Do I QA This
The following two postman test should pass:

- playlists item-hls verse 14
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-58450080-59bf-425e-82c0-62e73280754f

- playlists item-hls verse 26
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f215cb3a-b630-4a92-9f4d-b99228a9265d