### PR TITLE
FCBHDBP-526 DBP: filter out bad character in bible_fileset_show request

### DIFF
--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -94,9 +94,9 @@ trait BibleFileSetsTrait
         $bible,
         $fileset,
         $book = null,
-        $chapter_id = null,
-        $verse_start = null,
-        $verse_end = null
+        ?int $chapter_id = null,
+        ?string $verse_start = null,
+        ?string $verse_end = null
     ) {
         $select_columns = [
             'bible_verses.book_id as book_id',


### PR DESCRIPTION
# Description
The endpoint for fetching verses by book and chapter now requires the chapter parameters to be an integer value, with a validation added to enforce this.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-526

## How Do I QA This
We should execute the following postman tests and they should pass:
- Case 1: chapter value as a string value
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-2d6ce1d5-774a-4333-9e8c-e140072f1125

- Case 2: chapter value as a integer value but cache key with special characters
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-02791711-f08d-433a-88c0-45232fb3ad56

- Case 3: chapter value, verse_start and verse_end as a string values
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a49a5342-c818-480f-8972-5fe0c8a1cb7f

- Case 5: chapter value as an integer
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ebf41873-5f01-4005-bb3a-5d3cec7e69ce

- Case 5: chapter value, verse_start and verse_end as an integer values
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ca47a181-7b76-4feb-9438-cf80fbe682cf