### PR TITLE
FCBHDBP-535 Issue with fileset ENGGIDN2SA book= 2TI chapter=2 verse=12

### DIFF
--- a/app/Models/Bible/StreamBandwidth.php
+++ b/app/Models/Bible/StreamBandwidth.php
@@ -22,6 +22,6 @@ class StreamBandwidth extends Model
 
     public function transportStreamBytes()
     {
-        return $this->hasMany(StreamBytes::class);
+        return $this->hasMany(StreamBytes::class)->orderBy('offset');
     }
 }


### PR DESCRIPTION

# Description
We need to sort using the column offset to make sure the  bible_file_stream_bytes records match with the verses.

# SQL statement
We need to create a new bible_file_stream_bytes record using the following statement:

```sql
INSERT INTO dbp_2022_03_18.bible_file_stream_bytes (stream_bandwidth_id,runtime,bytes,offset,timestamp_id)
	VALUES (537213,4.4,39141,710140,3350395);
```
I have used the same timestamp_id=3350395 reference than verse 12.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-535

## How Do I QA This
The following two postman test should pass:

- playlists item-hls verse 14
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-58450080-59bf-425e-82c0-62e73280754f

- playlists item-hls verse 13 - New
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f88266b8-6bb8-4269-b96b-51c6fff92de9

- playlists item-hls verse 26
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f215cb3a-b630-4a92-9f4d-b99228a9265d

- playlist item-hls bible=ENGESV, book ID= PSA chapter = 23 (ENGESVO2SA-PSA-23-4-5)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-97ec39b7-a58e-4f86-8161-df2494798eb9

- playlist item-hls bible=ENGESV, book ID= PSA chapter = 2 (30989)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-dbb6d767-6978-47cd-966f-5ae24c4dc417
