### PR TITLE
FCBHDBP-542 Error 500 related to the HLS playlist endpoint

### DIFF
--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -1208,7 +1208,11 @@ class PlaylistsController extends APIController
     private function hasTransportStreamVerseRange(Collection $transport_stream) : bool
     {
         return $transport_stream->search(function ($stream) {
-            $timestamp = $stream->timestamp;
+            // To ensure accurate processing, it is important to validate the
+            // stream object as it may be an empty object that has been included
+            // to imitate a transport stream linked with a timestamp with
+            // verse_start set to 0
+            $timestamp = optional($stream)->timestamp;
             return $timestamp &&
                 !is_null($timestamp->verse_end) &&
                 (int)$timestamp->verse_start !== (int)$timestamp->verse_end;
@@ -1221,7 +1225,7 @@ class PlaylistsController extends APIController
 
         foreach ($transport_stream as $stream_idx => $stream) {
             $new_transport_stream->push($stream);
-            $timestamp = $stream->timestamp;
+            $timestamp = optional($stream)->timestamp;
             $next_timestamp = optional($transport_stream->get($stream_idx + 1))->timestamp;
 
             if ($timestamp && $next_timestamp) {


### PR DESCRIPTION
# Description
It has added a constraint to validate the stream object as it may be an empty object that has been included to imitate a transport stream related to timestamp with verse_start = 0.

# NOTE 1
I discovered that the timestamp record with ID 3350836 references to a range of verse audios from verse 1 to verse 5, however, the values are currently incorrect. Based on this finding, we should update the timestamp record executing the following sql statement:

```sql
UPDATE dbp_2022_03_18.bible_file_timestamps
SET verse_start='1',verse_end='5' -- prior: verse_start='5', verse_end=NULL
WHERE id=3350836;
```
## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-542

## How Do I QA This
- We should execute all postman test of the following folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-804eae1f-0a39-4496-bd30-649191a63e2a
- After to do the database change we should execute all postman test of the following folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-3aa4af6e-929a-4d59-8427-11b0a41a832b