### PR TITLE
Extend the logic to store the user_downloads records to the new downl…

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -308,7 +308,7 @@ class BibleFileset extends Model
     {
         $result = [];
         switch ($media) {
-            case 'audio':
+            case self::AUDIO:
                 $result = [
                     'audio_drama',
                     'audio',
@@ -316,10 +316,10 @@ class BibleFileset extends Model
                     'audio_drama_stream'
                 ];
                 break;
-            case 'video':
+            case self::VIDEO:
                 $result = ['video_stream'];
                 break;
-            case 'text':
+            case self::TEXT:
                 $result = [
                     'text_format',
                     'text_plain',

--- a/routes/api.php
+++ b/routes/api.php
@@ -147,10 +147,12 @@ Route::name('v4_bible_filesets_download.list')->get(
     'Bible\BibleFilesetsDownloadController@list'
 );
 
-Route::name('v4_bible_filesets_download.index')->get(
-    'download/{fileset_id}/{book?}/{chapter_id?}',
-    'Bible\BibleFilesetsDownloadController@index'
-);
+Route::name('v4_bible_filesets_download.index')
+    ->middleware('APIToken')
+    ->get(
+        'download/{fileset_id}/{book?}/{chapter_id?}',
+        'Bible\BibleFilesetsDownloadController@index'
+    );
 
 // VERSION 4 | Text
 // This is new, added Dec 28, to provide just the verses for a bible or chapter. Note that this does not have filesets in path


### PR DESCRIPTION
# Description
Extend the logic to store the user_downloads records to the new download endpoint:
- download/${filesetId}/${bookId}/
- download/${filesetId}/${bookId}/${chapterId}
- 
We divided the information to be stored in the cache into two parts: the `fileset` object and the content (audios) belonging to the `fileset`. This was done because having a single lambda method covered by cache and just pass to user object, it could result in a `user_download` record being created only once per day, regardless of the user. Adding the user ID as a cache parameter would also result in DBP executing the same SQL to fetch the `fileset` object for each user. Thus, we split the old method into two parts to both take advantage of caching and track user downloading activity.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-541

## How Do I QA This
- We must log in using a testing user
- Execute all postman test of the following folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-4a071b78-47ce-409d-815c-4e7bfeb61cbf
- We need to verify into the database that the above calls have created a record in `user_downloads` table referencing fileset ID: `ENGKJVN2DA` and the testing user id that we have used.
