### PR TITLE
FCBHDBP-537 Require book_id in bible-filesets-show

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -180,10 +180,14 @@ class BibleFileSetsController extends APIController
             'verse_start' => $verse_start,
             'verse_end'   => $verse_end,
             'chapter_id'  => $chapter_id,
+            'book_id'  => $book_id,
+            'fileset_id'  => $fileset_id,
         ], [
             'verse_start'=> 'alpha_num',
             'verse_end'  => 'nullable|alpha_num',
             'chapter_id' => 'integer',
+            'book_id' => 'alpha_num|regex:/^[a-zA-Z0-9]*$/', // allow alpha num format but without accent
+            'fileset_id' => 'alpha_dash', // allow alpha num format + (-) and (_)
         ]);
 
         if ($validator->fails()) {


### PR DESCRIPTION
# Description
Add constraint to validate that book_id query parameter must be alphanumeric without accent characters.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-537

## How Do I QA This
- We should run all postman test of the following folder and they should pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-a34a808f-1ee8-4e9b-a80d-1790d76077af
