### PR TITLE
FCBHDBP-541 Extend the logic to store the user_downloads records to the new download endpoints

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
+use App\Models\User\User;
 
 /**
  * Get param from request object and check that the param is set if param is required
@@ -707,5 +708,18 @@ if (!function_exists('getDownloadAccessGroupList')) {
     function getDownloadAccessGroupList(): array
     {
         return array_map('intval', explode(',', config('settings.download_access_group_list')));
+    }
+}
+
+/**
+ * Retrieve the user object from the request and verify if it has been initialized or set.
+ *
+ * @return bool
+ */
+if (!function_exists('isUserLoggedIn')) {
+    function isUserLoggedIn() : bool
+    {
+        $user = request()->user();
+        return !empty($user) && optional($user)->id > 0;
     }
 }

--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -190,7 +190,9 @@ trait AccessControlAPI
 
     public function allowedForDownload($fileset)
     {
-        if ($this->doesApiKeyBelongToBibleis($this->key)) {
+        // If the API key belongs to bible.is but the user is not currently logged in,
+        // the system will utilize the generic access group list instead.
+        if ($this->doesApiKeyBelongToBibleis($this->key) && isUserLoggedIn()) {
             $download_access_group_array_ids = AccessGroupKey::getAccessGroupIdsByApiKey($this->key)->toArray();
         } else {
             $download_access_group_array_ids = getDownloadAccessGroupList();


### PR DESCRIPTION
# Description
Add constraint that if the API key belongs to bible.is but the user is not currently logged in, the API will utilize the generic access group list instead.

# NOTE 1
@bradflood , we have an edge case where: `non-bibleis user but user logged in`,  currently, the API is adding entry into `user_downloads` with userid and fileset, is it ok?

You can test the case using the following postman test:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-eda75d1f-08b4-4426-9447-a6d6e45806bd


## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-541

## How Do I QA This
We should run the following test and they have to pass.

-  non-bibleis user, content cannot be downloaded
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-789a6bb8-fd9b-4631-861e-f5089dccb219

-    non-bibleis user, content can be downloaded
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-633d6633-f371-4d91-a5cd-b3eea768f404

-    bibleis user, user not logged in
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-3903b959-7e9f-4c34-a6d7-8ee5e2883247

-    bibleis user, user logged in - add entry into user_downloads with userid and fileset
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9402d45e-b97b-4624-a108-8e31de38d573

-    bibleis user, user logged in, content not accessible
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-33365cbb-35b0-4d6b-be16-eff11f75a412
