### PR TITLE
FCBHDBP-549 Hotfix - download endpoint and cache using user session

### DIFF
--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -209,5 +209,6 @@ trait AccessControlAPI
                 ->setStatusCode(Response::HTTP_FORBIDDEN)
                 ->replyWithError(Response::getStatusTextByCode(Response::HTTP_FORBIDDEN));
         }
+        return true;
     }
 }


### PR DESCRIPTION
# Description
Add a flag to the cache parameters that indicates whether the user has logged in the above because the access group list can change depending on whether the user is logged in or he is not.

# NOTE 1.
I think that we need to clean cache.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-549

## How Do I QA This
- The all postman test: Tack downloads have to pass
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-4a071b78-47ce-409d-815c-4e7bfeb61cbf

- fileset SPNTLAN2DA - it should return 200 when the api_token (user has logged in) is used.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-1aafaccc-3a6e-440a-8281-96a0a74e28a2