### PR TITLE
FCBHDBP-544 Refactor Access Control into Laravel provider

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -738,3 +738,15 @@ if (!function_exists('isUserLoggedIn')) {
         return !empty($user) && optional($user)->id > 0;
     }
 }
+
+if (!function_exists('getAliasOrTableName')) {
+    function getAliasOrTableName(string $table_name) : string
+    {
+        $alias = \explode('as', $table_name);
+        if (sizeof($alias) === 1) {
+            $alias = \explode('AS', $table_name);
+        }
+
+        return \trim($alias[sizeof($alias) - 1]);
+    }
+}

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -3,7 +3,22 @@
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
-use App\Models\User\User;
+use Symfony\Component\HttpFoundation\Response;
+
+function getAccessGroups() : \Illuminate\Support\Collection
+{
+    $group_ids = request()->input('middleware_access_group_ids');
+
+    if (empty($group_ids)) {
+        \Log::channel('errorlog')->error(["Missing access group ids", Response::HTTP_UNPROCESSABLE_ENTITY]);
+        abort(
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            "Missing parameter access group ids."
+        );
+    }
+
+    return $group_ids;
+}
 
 /**
  * Get param from request object and check that the param is set if param is required

--- a/app/Http/Controllers/APIController.php
+++ b/app/Http/Controllers/APIController.php
@@ -135,6 +135,7 @@ class APIController extends Controller
     protected $preset_v;
     protected $v;
     protected $key;
+    protected $access_group_ids;
     protected $user;
 
     public function __construct()

--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -96,9 +96,9 @@ class BibleFileSetsController extends APIController
                     );
                 }
 
-                $access_blocked = $this->blockedByAccessControl($fileset);
-                if ($access_blocked) {
-                    return $access_blocked;
+                $access_allowed = $this->allowedByAccessControl($fileset);
+                if ($access_allowed !== true) {
+                    return $access_allowed;
                 }
                 $asset_id = $fileset->asset_id;
                 $bible = optional($fileset->bible)->first();
@@ -234,9 +234,9 @@ class BibleFileSetsController extends APIController
                     );
                 }
 
-                $access_blocked = $this->blockedByAccessControl($fileset);
-                if ($access_blocked) {
-                    return $access_blocked;
+                $access_allowed = $this->allowedByAccessControl($fileset);
+                if ($access_allowed !== true) {
+                    return $access_allowed;
                 }
                 $asset_id = $fileset->asset_id;
                 $bible = optional($fileset->bible)->first();

--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -217,6 +217,7 @@ class BibleFilesetsDownloadController extends APIController
         $type = checkParam('type');
         $limit = min($limit, 50);
         $key = $this->getKey();
+        $access_group_ids = getAccessGroups();
 
         $cache_params = $this->removeSpaceFromCacheParameters([$key, $limit, $page, $type]);
 
@@ -224,8 +225,12 @@ class BibleFilesetsDownloadController extends APIController
             $cache_key,
             $cache_params,
             now()->addHours(12),
-            function () use ($key, $limit, $type) {
-                return BibleFilesetLookup::getContentAvailableByKey($key, $limit, $type);
+            function () use ($limit, $access_group_ids, $type) {
+                return BibleFilesetLookup::getDownloadContentByKey(
+                    $limit,
+                    $access_group_ids,
+                    $type
+                );
             }
         );
 

--- a/app/Http/Controllers/Bible/BibleVersesController.php
+++ b/app/Http/Controllers/Bible/BibleVersesController.php
@@ -73,17 +73,17 @@ class BibleVersesController extends APIController
         $limit          = (int) (checkParam('limit') ?? 15);
         $limit          = min($limit, 50);
         $page           = checkParam('page') ?? 1;
-        $key = $this->key;
 
-        $cache_params = [$limit, $page, $language_code, $key, $book_id, $chapter_id, $verse_number];
+        $access_group_ids = getAccessGroups();
+        $cache_params = [$limit, $page, $language_code, $this->key, $book_id, $chapter_id, $verse_number];
         $cache_key = generateCacheSafeKey('bible_verses_by_language', $cache_params);
         $verses = cacheRememberByKey(
             $cache_key,
             now()->addDay(),
-            function () use ($key, $limit, $language_code, $verse_number, $book_id, $chapter_id) {
+            function () use ($access_group_ids, $limit, $language_code, $verse_number, $book_id, $chapter_id) {
                 return BibleVerse::withBibleFilesets($book_id, $chapter_id, $verse_number)
                     ->filterByLanguage($language_code)
-                    ->isContentAvailable($key)
+                    ->isContentAvailable($access_group_ids)
                     ->paginate($limit);
             }
         );
@@ -147,17 +147,17 @@ class BibleVersesController extends APIController
         $limit          = (int) (checkParam('limit') ?? 15);
         $limit          = min($limit, 50);
         $page           = checkParam('page') ?? 1;
-        $key = $this->key;
+        $access_group_ids = getAccessGroups();
 
-        $cache_params = [$limit, $page, $bible_id, $key, $book_id, $chapter_id, $verse_number];
+        $cache_params = [$limit, $page, $bible_id, $this->key, $book_id, $chapter_id, $verse_number];
         $cache_key = generateCacheSafeKey('bible_verses_by_bible', $cache_params);
         $verses = cacheRememberByKey(
             $cache_key,
             now()->addDay(),
-            function () use ($key, $limit, $bible_id, $verse_number, $book_id, $chapter_id) {
+            function () use ($access_group_ids, $limit, $bible_id, $verse_number, $book_id, $chapter_id) {
                 return BibleVerse::withBibleFilesets($book_id, $chapter_id, $verse_number)
                     ->filterByBible($bible_id)
-                    ->isContentAvailable($key)
+                    ->isContentAvailable($access_group_ids)
                     ->paginate($limit);
             }
         );

--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -82,9 +82,9 @@ class TextController extends APIController
         }
         $bible = optional($fileset->bible)->first();
 
-        $access_blocked = $this->blockedByAccessControl($fileset);
-        if ($access_blocked) {
-            return $access_blocked;
+        $access_allowed = $this->allowedByAccessControl($fileset);
+        if ($access_allowed !== true) {
+            return $access_allowed;
         }
         $asset_id = $fileset->asset_id;
         $cache_params = [$asset_id, $fileset_id, $book_id, $chapter, $verse_start, $verse_end];

--- a/app/Http/Controllers/Bible/TextControllerV2.php
+++ b/app/Http/Controllers/Bible/TextControllerV2.php
@@ -74,9 +74,9 @@ class TextControllerV2 extends APIController
         }
         $bible = optional($fileset->bible)->first();
 
-        $access_blocked = $this->blockedByAccessControl($fileset);
-        if ($access_blocked) {
-            return $access_blocked;
+        $access_allowed = $this->allowedByAccessControl($fileset);
+        if ($access_allowed !== true) {
+            return $access_allowed;
         }
         $asset_id = $fileset->asset_id;
         $cache_params = [$asset_id, $fileset_id, $book_id, $chapter, $verse_start, $verse_end];

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -132,7 +132,8 @@ class LanguagesController extends APIController
                 $media,
                 $set_type_code
             ) {
-                $languages = Language::includeCurrentTranslation()
+                $languages = Language::isContentAvailable($access_group_ids)
+                    ->includeCurrentTranslation()
                     ->includeAutonymTranslation()
                     ->includeExtraLanguageTranslations($include_translations)
                     ->includeCountryPopulation($country)
@@ -140,7 +141,7 @@ class LanguagesController extends APIController
                     ->filterableByCountry($country)
                     ->filterableByIsoCode($code)
                     ->filterableByName($name)
-                    ->isContentAvailableAndfilterableByMedia($access_group_ids, $media)
+                    ->filterableByMedia($media)
                     ->filterableBySetTypeCode($set_type_code)
                     ->select([
                         'languages.id',
@@ -237,11 +238,20 @@ class LanguagesController extends APIController
             $cache_key,
             now()->addDay(),
             function () use ($formatted_search, $limit, $access_group_ids, $set_type_code, $media) {
-                $languages = Language::filterableByNameAndKey(
+                $bible_fileset_filters = [];
+
+                if ($set_type_code) {
+                    $bible_fileset_filters['set_type_code'] = $set_type_code;
+                }
+
+                if ($media) {
+                    $bible_fileset_filters['media'] = $media;
+                }
+
+                $languages = Language::filterableByNameAndAccessGroup(
                     $formatted_search,
                     $access_group_ids,
-                    $set_type_code,
-                    $media
+                    $bible_fileset_filters
                 )
                     ->select([
                         'languages.id',

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -9,6 +9,7 @@ use App\Transformers\LanguageTransformer;
 use App\Traits\AccessControlAPI;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use App\Models\User\Key;
+use Symfony\Component\HttpFoundation\Response;
 
 class LanguagesController extends APIController
 {
@@ -98,8 +99,8 @@ class LanguagesController extends APIController
         // note: this two commented changes can be removed when bibleis and gideons no longer require a non-paginated response
         // remove pagination for bibleis and gideons (temporal fix)
         list($limit, $is_bibleis_gideons) = forceBibleisGideonsPagination($this->key, $limit);
+        $access_group_ids = getAccessGroups();
 
-        $key = $this->key;
         $cache_params = $this->removeSpaceFromCacheParameters([
             $this->v,
             $country,
@@ -107,7 +108,7 @@ class LanguagesController extends APIController
             $GLOBALS['i18n_id'],
             $name,
             $include_translations,
-            $key,
+            $this->key,
             $limit,
             $page,
             $is_bibleis_gideons,
@@ -116,43 +117,58 @@ class LanguagesController extends APIController
         ]);
 
         $select_country_population = $country ? 'country_population.population' : 'null';
-        $languages = cacheRemember('languages_all', $cache_params, now()->addDay(), function () use ($country, $include_translations, $code, $name, $key, $select_country_population, $limit, $media, $set_type_code) {
-            $languages = Language::includeCurrentTranslation()
-                ->includeAutonymTranslation()
-                ->includeExtraLanguageTranslations($include_translations)
-                ->includeCountryPopulation($country)
-                ->includeOrderByCountryPopulation()
-                ->filterableByCountry($country)
-                ->filterableByIsoCode($code)
-                ->filterableByName($name)
-                ->isContentAvailableAndfilterableByMedia($key, $media)
-                ->filterableBySetTypeCode($set_type_code)
-                ->select([
-                    'languages.id',
-                    'languages.glotto_id',
-                    'languages.iso',
-                    'languages.name as backup_name',
-                    'current_translation.name as name',
-                    'autonym.name as autonym',
-                    'languages.rolv_code',
-                    \DB::raw($select_country_population . ' as country_population')
-                ])
-                ->with(['bibles' => function ($query) {
-                    $query->whereHas('filesets');
-                }])
-                ->withCount([
-                    'filesets'
-                ]);
+        $languages = cacheRemember(
+            'languages_all',
+            $cache_params,
+            now()->addDay(),
+            function () use (
+                $country,
+                $include_translations,
+                $code,
+                $name,
+                $access_group_ids,
+                $select_country_population,
+                $limit,
+                $media,
+                $set_type_code
+            ) {
+                $languages = Language::includeCurrentTranslation()
+                    ->includeAutonymTranslation()
+                    ->includeExtraLanguageTranslations($include_translations)
+                    ->includeCountryPopulation($country)
+                    ->includeOrderByCountryPopulation()
+                    ->filterableByCountry($country)
+                    ->filterableByIsoCode($code)
+                    ->filterableByName($name)
+                    ->isContentAvailableAndfilterableByMedia($access_group_ids, $media)
+                    ->filterableBySetTypeCode($set_type_code)
+                    ->select([
+                        'languages.id',
+                        'languages.glotto_id',
+                        'languages.iso',
+                        'languages.name as backup_name',
+                        'current_translation.name as name',
+                        'autonym.name as autonym',
+                        'languages.rolv_code',
+                        \DB::raw($select_country_population . ' as country_population')
+                    ])
+                    ->with(['bibles' => function ($query) {
+                        $query->whereHas('filesets');
+                    }])
+                    ->withCount([
+                        'filesets'
+                    ]);
 
-            $languages = $languages->paginate($limit);
-            $languages_return = fractal(
-                $languages->getCollection(),
-                LanguageTransformer::class,
-                $this->serializer
-            );
+                $languages = $languages->paginate($limit);
+                $languages_return = fractal(
+                    $languages->getCollection(),
+                    LanguageTransformer::class,
+                    $this->serializer
+                );
 
-            return $languages_return->paginateWith(new IlluminatePaginatorAdapter($languages));
-        });
+                return $languages_return->paginateWith(new IlluminatePaginatorAdapter($languages));
+            }
+        );
 
         return $this->reply($languages);
     }
@@ -196,6 +212,7 @@ class LanguagesController extends APIController
         $limit = min($limit, 50);
         $set_type_code = checkParam('set_type_code');
         $media = checkParam('media');
+        $access_group_ids = checkParam('middleware_access_group_ids', true);
         $formatted_search = $this->transformQuerySearchText($search_text);
         $formatted_search_cache = str_replace(' ', '', $search_text);
 
@@ -203,14 +220,13 @@ class LanguagesController extends APIController
             return $this->setStatusCode(400)->replyWithError(trans('api.search_errors_400'));
         }
 
-        $key = $this->key;
         $cache_params = [
                 $this->v,
                 $formatted_search_cache,
                 $limit,
                 $page,
                 $GLOBALS['i18n_id'],
-                $key,
+                $this->key,
                 $media,
                 $set_type_code
             ]
@@ -220,8 +236,13 @@ class LanguagesController extends APIController
         $languages = cacheRememberByKey(
             $cache_key,
             now()->addDay(),
-            function () use ($formatted_search, $limit, $key, $set_type_code, $media) {
-                $languages = Language::filterableByNameAndKey($formatted_search, $key, $set_type_code, $media)
+            function () use ($formatted_search, $limit, $access_group_ids, $set_type_code, $media) {
+                $languages = Language::filterableByNameAndKey(
+                    $formatted_search,
+                    $access_group_ids,
+                    $set_type_code,
+                    $media
+                )
                     ->select([
                         'languages.id',
                         'languages.glotto_id',
@@ -279,14 +300,15 @@ class LanguagesController extends APIController
      */
     public function show($id)
     {
-        $key = $this->key;
-        $cache_params = [$id, $key];
-        $language = cacheRemember('language', $cache_params, now()->addDay(), function () use ($id, $key) {
+        $cache_params = [$id, $this->key];
+        $access_group_ids = getAccessGroups();
+
+        $language = cacheRemember('language', $cache_params, now()->addDay(), function () use ($id, $access_group_ids) {
             $language = Language::where('id', $id)->orWhere('iso', $id)
-                ->isContentAvailable($key)
+                ->isContentAvailable($access_group_ids)
                 ->first();
             if (!$language) {
-                return $this->setStatusCode(404)->replyWithError("Language not found for ID: $id");
+                return $this->setStatusCode(Response::HTTP_NOT_FOUND)->replyWithError("Language not found for ID: $id");
             }
             $language->load(
                 'translations',

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -80,6 +80,7 @@ class Kernel extends HttpKernel
         'throttle'            => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified'            => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'APIToken'            => \App\Http\Middleware\APIToken::class,
+        'AccessControl'       => \App\Http\Middleware\AccessControl::class,
     ];
 
     /**

--- a/app/Http/Middleware/AccessControl.php
+++ b/app/Http/Middleware/AccessControl.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Contracts\Auth\Factory as Auth;
+use Illuminate\Auth\AuthenticationException;
+use App\Models\User\AccessGroupKey;
+use App\Services\IAMAPI\IAMAPIClientService;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+use Closure;
+
+class AccessControl
+{
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Auth\Factory  $auth
+     * @return void
+     */
+    public function __construct(IAMAPIClientService $iam_client)
+    {
+        $this->iam_client = $iam_client;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string  $method
+     * @return mixed
+     *
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function handle($request, Closure $next)
+    {
+        $api_key = checkParam('key', true);
+
+        if ($this->iam_client->isEnabled()) {
+            try {
+                $access_group_ids = $this->iam_client->getAccessGroupIdsByUserKey($api_key);
+            } catch (\Exception $e) {
+                \Log::channel('errorlog')->error($e->getMessage());
+                return response('Service unavailable', HttpResponse::HTTP_SERVICE_UNAVAILABLE);
+            }
+        } else {
+            $access_group_ids = AccessGroupKey::getAccessGroupIdsByApiKey($api_key);
+        }
+
+        if (!empty($access_group_ids)) {
+            $request->merge([
+                'middleware_access_group_ids' => $access_group_ids
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -9,7 +9,7 @@ use App\Models\Language\NumeralSystem;
 use App\Models\Organization\Organization;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
 use App\Models\Language\Language;
 
 /**
@@ -341,14 +341,14 @@ class Bible extends Model
             }
 
             $q->select(\DB::raw(1));
-            $q->isContentAvailable($type_filters['key']);
+            $q->isContentAvailable($type_filters['access_group_ids']);
             $this->setConditionFilesets($q, $type_filters);
             $this->setConditionTagExclude($q, $type_filters);
         })->with(['filesets' => function ($q) use ($type_filters) {
             $q->with(['meta' => function ($subQuery) {
                 $subQuery->where('admin_only', 0);
             }]);
-            $q->isContentAvailable($type_filters['key'])
+            $q->isContentAvailable($type_filters['access_group_ids'])
                 ->conditionToExcludeOldTextFormat();
             $this->setConditionFilesets($q, $type_filters);
             $this->setConditionTagExclude($q, $type_filters);
@@ -416,21 +416,15 @@ class Bible extends Model
             );
     }
 
-    public function scopeIsContentAvailable($query, $key)
+    public function scopeIsContentAvailable(Builder $query, Collection $access_group_ids)
     {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
-        return $query->whereRaw(
-            'EXISTS (select 1
-                    from ' . $dbp_users . '.user_keys uk
-                    join ' . $dbp_users . '.access_group_api_keys agak on agak.key_id = uk.id
-                    join ' . $dbp_prod . '.access_group_filesets agf on agf.access_group_id = agak.access_group_id
-                    join ' . $dbp_prod . '.bible_fileset_connections bfc on agf.hash_id = bfc.hash_id
-                    where uk.key = ? and bibles.id = bfc.bible_id
-            )',
-            [$key]
-        );
+        return $query->whereExists(function ($query) use ($access_group_ids) {
+            return $query->select(\DB::raw(1))
+                ->from('access_group_filesets as agf')
+                ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
+                ->whereColumn('bibles.id', '=', 'bfc.bible_id')
+                ->whereIn('agf.access_group_id', $access_group_ids);
+        });
     }
     public function scopeIsTimingInformationAvailable($query)
     {

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -489,4 +489,18 @@ class BibleFileset extends Model
                     );
             });
     }
+
+    public function scopeFilterBy(Builder $query, array $filters) : Builder
+    {
+        $from_table = getAliasOrTableName($query->getQuery()->from);
+
+        return $query
+            ->when(isset($filters['set_type_code']), function ($query) use ($filters, $from_table) {
+                $query->where($from_table.'.set_type_code', $filters['set_type_code']);
+            })
+            ->when(isset($filters['media']), function ($query) use ($filters, $from_table) {
+                $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($filters['media']);
+                return $query->whereIn($from_table.'.set_type_code', $set_type_code_array);
+            });
+    }
 }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -288,20 +288,16 @@ class BibleFileset extends Model
         return (string) $client->createPresignedRequest($command, $expiry)->getUri();
     }
 
-    public function scopeIsContentAvailable($query, $key)
-    {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
-        return $query->whereRaw(
-            'EXISTS (select 1
-                    from ' . $dbp_users . '.user_keys uk
-                    join ' . $dbp_users . '.access_group_api_keys agak on agak.key_id = uk.id
-                    join ' . $dbp_prod . '.access_group_filesets agf on agf.access_group_id = agak.access_group_id
-                    where uk.key = ? and agf.hash_id = bible_filesets.hash_id
-            )',
-            [$key]
-        );
+    public function scopeIsContentAvailable(
+        Builder $query,
+        \Illuminate\Support\Collection $access_group_ids
+    ) : Builder {
+        return $query->whereExists(function ($query) use ($access_group_ids) {
+            return $query->select(\DB::raw(1))
+                ->from('access_group_filesets as agf')
+                ->whereColumn('agf.hash_id', '=', 'bible_filesets.hash_id')
+                ->whereIn('agf.access_group_id', $access_group_ids);
+        });
     }
 
     public static function getsetTypeCodeFromMedia($media)

--- a/app/Models/Language/Language.php
+++ b/app/Models/Language/Language.php
@@ -10,8 +10,10 @@ use App\Models\Country\CountryLanguage;
 use App\Models\Country\CountryRegion;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use App\Models\Country\Country;
+use App\Models\User\AccessGroupFileset;
 use App\Models\Resource\Resource;
 
 /**
@@ -462,100 +464,102 @@ class Language extends Model
         });
     }
 
-    private function getLanguagesAccessGroupQuery($key, $set_type_code = null, $media = null)
-    {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
+    private function getLanguagesAccessGroupQuery(
+        string $formatted_name,
+        Collection $access_group_ids,
+        string $set_type_code = null,
+        string $media = null
+    ) : QueryBuilder {
+        $access_group_query = AccessGroupFileset::doesLanguageHaveBibleContentAvailable('lang.id', $access_group_ids)
+            ->when($set_type_code, function ($query) use ($set_type_code) {
+                $query->filterBySetTypeCodeFileset($set_type_code);
+            })
+            ->when($media, function ($query) use ($media) {
+                $query->filterByMediaFileset($media);
+            });
 
         return \DB::table('languages as lang')
             ->select('lang.id as id')
-            ->whereRaw('MATCH (lang.name) against (? IN BOOLEAN MODE)')
-            ->whereExists(function ($query) use ($dbp_users, $dbp_prod, $key, $set_type_code, $media) {
-                return $query->select(\DB::raw(1))
-                    ->from($dbp_users . '.user_keys as uk')
-                    ->join($dbp_users . '.access_group_api_keys as agak', 'agak.key_id', 'uk.id')
-                    ->join($dbp_prod . '.access_group_filesets as agf', 'agf.access_group_id', 'agak.access_group_id')
-                    ->join($dbp_prod . '.bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-                    ->join($dbp_prod . '.bibles as b', 'bfc.bible_id', 'b.id')
-                    ->whereColumn('lang.id', '=', 'b.language_id')
-                    ->where('uk.key', $key)
-                    ->when($set_type_code || $media, function ($query) use ($dbp_prod) {
-                        $query->join($dbp_prod . '.bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
-                    })
-                    ->when($set_type_code, function ($query) use ($set_type_code) {
-                        $query->where('bfst.set_type_code', $set_type_code);
-                    })
-                    ->when($media, function ($query) use ($media) {
-                        $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
-                        $query->whereIn('bfst.set_type_code', $set_type_code_array);
-                    })
-                    ;
-            });
+            ->whereRaw('MATCH (lang.name) against (? IN BOOLEAN MODE)', [$formatted_name])
+            ->addWhereExistsQuery($access_group_query->getQuery());
     }
 
-    private function getLanguagesTranslationsAccessGroupQuery($key, $set_type_code = null, $media = null)
-    {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
+    private function getLanguagesTranslationsAccessGroupQuery(
+        string $formatted_name,
+        Collection $access_group_ids,
+        string $set_type_code = null,
+        string $media = null
+    ) : QueryBuilder {
+        $access_group_query = AccessGroupFileset::doesLanguageHaveBibleContentAvailable(
+            'lang_trans.language_source_id',
+            $access_group_ids
+        )
+            ->where('lang_trans.priority', '=', function ($query) {
+                $query->select(\DB::raw('MAX(`priority`)'))
+                    ->from('language_translations as lang_trans_prior')
+                    ->whereColumn('lang_trans_prior.language_source_id', '=', 'lang_trans.language_source_id')
+                    ->whereColumn(
+                        'lang_trans_prior.language_translation_id',
+                        '=',
+                        'lang_trans.language_translation_id'
+                    )
+                    ->limit(1);
+            })
+            ->when($set_type_code, function ($query) use ($set_type_code) {
+                $query->filterBySetTypeCodeFileset($set_type_code);
+            })
+            ->when($media, function ($query) use ($media) {
+                $query->filterByMediaFileset($media);
+            })
+            ;
         return \DB::table('language_translations as lang_trans')
             ->select('lang_trans.language_source_id as id')
-            ->whereRaw('MATCH (lang_trans.name) against (? IN BOOLEAN MODE)')
-            ->whereExists(function ($query) use ($dbp_users, $dbp_prod, $key, $set_type_code, $media) {
-                return $query->select(\DB::raw(1))
-                    ->from($dbp_users . '.user_keys as uk')
-                    ->join($dbp_users . '.access_group_api_keys as agak', 'agak.key_id', 'uk.id')
-                    ->join($dbp_prod . '.access_group_filesets as agf', 'agf.access_group_id', 'agak.access_group_id')
-                    ->join($dbp_prod . '.bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-                    ->join($dbp_prod . '.bibles as b', 'bfc.bible_id', 'b.id')
-                    ->whereColumn('lang_trans.language_source_id', '=', 'b.language_id')
-                    ->where('uk.key', $key)
-                    ->where('lang_trans.priority', '=', function ($query) {
-                        $query->select(\DB::raw('MAX(`priority`)'))
-                            ->from('language_translations as lang_trans_prior')
-                            ->whereColumn('lang_trans_prior.language_source_id', '=', 'lang_trans.language_source_id')
-                            ->whereColumn('lang_trans_prior.language_translation_id', '=', 'lang_trans.language_translation_id')
-                            ->limit(1);
-                    })
-                    ->when($set_type_code || $media, function ($query) use ($dbp_prod) {
-                        $query->join($dbp_prod . '.bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
-                    })
-                    ->when($set_type_code, function ($query) use ($set_type_code) {
-                        $query->where('bfst.set_type_code', $set_type_code);
-                    })
-                    ->when($media, function ($query) use ($media) {
-                        $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
-                        $query->whereIn('bfst.set_type_code', $set_type_code_array);
-                    })
-                    ;
-            });
+            ->whereRaw('MATCH (lang_trans.name) against (? IN BOOLEAN MODE)', [$formatted_name])
+            ->addWhereExistsQuery($access_group_query->getQuery());
     }
 
-    public function scopeFilterableByNameAndKey($query, $name, $key, $set_type_code = null, $media = null)
-    {
+    public function scopeFilterableByNameAndKey(
+        Builder $query,
+        string $name,
+        Collection $access_group_ids,
+        string $set_type_code = null,
+        string $media = null
+    ) : Builder {
         $formatted_name = "+$name*";
 
-        $lang = $this->getLanguagesAccessGroupQuery($key, $set_type_code, $media);
-        $lang_trans = $this->getLanguagesTranslationsAccessGroupQuery($key, $set_type_code, $media);
+        $lang = $this->getLanguagesAccessGroupQuery(
+            $formatted_name,
+            $access_group_ids,
+            $set_type_code,
+            $media
+        );
+        $lang_trans = $this->getLanguagesTranslationsAccessGroupQuery(
+            $formatted_name,
+            $access_group_ids,
+            $set_type_code,
+            $media
+        );
 
         $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
 
-        $lang_union_sql = \DB::table($lang)
-            ->unionAll($lang_trans)
-            ->toSql();
+        $lang_union_query = \DB::table($lang)
+            ->unionAll($lang_trans);
 
-        return $query->join(
-            \DB::raw(
-                "(
-                    SELECT lang_and_trans_group.id
-                    FROM ($lang_union_sql) as lang_and_trans_group
-                    GROUP BY lang_and_trans_group.id
-                ) as languages_and_translations"
-            ),
-            'languages_and_translations.id',
-            '=',
-            'languages.id'
-        )->leftJoin('language_translations as autonym', function ($join) {
+        $lang_union_all_group = \DB::table($lang_union_query, 'lang_and_trans_group')
+            ->groupBy('lang_and_trans_group.id');
+
+        return $query->joinSub(
+            $lang_union_all_group,
+            'languages_and_translations',
+            function ($join) {
+                $join->on(
+                    'languages_and_translations.id',
+                    '=',
+                    'languages.id'
+                );
+            }
+        )
+        ->leftJoin('language_translations as autonym', function ($join) {
             $join->on('autonym.language_source_id', '=', 'languages.id')
                 ->on('autonym.language_translation_id', '=', 'languages.id')
                 ->where('autonym.priority', '=', function ($autonym_query) {
@@ -567,55 +571,41 @@ class Language extends Model
                 });
         })->leftJoin('language_translations as current_translation', function ($join) {
             $join->on('current_translation.language_source_id', 'languages.id')
-                ->whereRaw('current_translation.language_translation_id = ?')
+                ->where('current_translation.language_translation_id', $GLOBALS['i18n_id'])
                 ->where('current_translation.priority', '=', function ($current_translation_query) {
                     $current_translation_query->select(\DB::raw('MAX(`priority`)'))
                         ->from('language_translations')
                         ->whereColumn('language_source_id', '=', 'languages.id')
                         ->limit(1);
                 });
-        })
-        ->addBinding($formatted_name)
-        ->addBinding($key)
-        ->when($set_type_code, function ($query) use ($set_type_code) {
-            $query->addBinding($set_type_code);
-        })
-        ->when($media, function ($query) use ($set_type_code_array) {
-            $query->addBinding($set_type_code_array);
-        })
-        ->addBinding($formatted_name)
-        ->addBinding($key)
-        ->when($set_type_code, function ($query) use ($set_type_code) {
-            $query->addBinding($set_type_code);
-        })
-        ->when($media, function ($query) use ($set_type_code_array) {
-            $query->addBinding($set_type_code_array);
-        })
-        ->addBinding($GLOBALS['i18n_id']);
+        });
     }
 
-    public function scopeWithRequiredFilesets($query, $type_filters)
+    public function scopeWithRequiredFilesets(Builder $query, array $type_filters) : Builder
     {
         $organization_id = $type_filters['organization_id'];
         $media = $type_filters['media'];
-        $key = $type_filters['key'];
+        $access_group_ids = $type_filters['access_group_ids'];
 
-        return $query->whereHas('filesets', function ($query_filesets) use ($key, $organization_id, $media) {
-            if ($organization_id) {
-                $query_filesets->whereHas('copyright', function ($query_filesets) use ($organization_id) {
-                    $query_filesets->where('organization_id', $organization_id);
-                });
-            }
-            $query_filesets->join('bible_filesets', 'bible_filesets.hash_id', 'bible_fileset_connections.hash_id');
-            $query_filesets->where('bible_filesets.asset_id', 'dbp-prod');
-            if ($media) {
-                $query_filesets->where('bible_filesets.set_type_code', 'LIKE', $media . '%');
-            } else {
-                $query_filesets->where('bible_filesets.set_type_code', '!=', 'text_format');
-            }
+        return $query->whereHas(
+            'filesets',
+            function ($query_filesets) use ($access_group_ids, $organization_id, $media) {
+                if ($organization_id) {
+                    $query_filesets->whereHas('copyright', function ($query_filesets) use ($organization_id) {
+                        $query_filesets->where('organization_id', $organization_id);
+                    });
+                }
+                $query_filesets->join('bible_filesets', 'bible_filesets.hash_id', 'bible_fileset_connections.hash_id');
+                $query_filesets->where('bible_filesets.asset_id', 'dbp-prod');
+                if ($media) {
+                    $query_filesets->where('bible_filesets.set_type_code', 'LIKE', $media . '%');
+                } else {
+                    $query_filesets->where('bible_filesets.set_type_code', '!=', 'text_format');
+                }
 
-            $query_filesets->isContentAvailable($key);
-        });
+                $query_filesets->isContentAvailable($access_group_ids);
+            }
+        );
     }
     
     public function population()
@@ -731,29 +721,24 @@ class Language extends Model
     /**
      * Get the query to filter the languages by available bible fileset
      * @param Illuminate\Database\Query\Builder $query
-     * @param string $key
+     * @param Collection $access_group_ids
      *
      * @return Illuminate\Database\Query\Builder
      */
-    public function getQueryContentAvailable(QueryBuilder $query, string $key) : QueryBuilder
+    public function getQueryContentAvailable(QueryBuilder $query, Collection $access_group_ids) : QueryBuilder
     {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
-
         return $query->select(\DB::raw(1))
-            ->from($dbp_users . '.user_keys as uk')
-            ->join($dbp_users . '.access_group_api_keys as agak', 'agak.key_id', 'uk.id')
-            ->join($dbp_prod . '.access_group_filesets as agf', 'agf.access_group_id', 'agak.access_group_id')
-            ->join($dbp_prod . '.bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-            ->join($dbp_prod . '.bibles as b', 'bfc.bible_id', 'b.id')
+            ->from('access_group_filesets as agf')
+            ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
+            ->join('bibles as b', 'bfc.bible_id', 'b.id')
             ->whereColumn('languages.id', '=', 'b.language_id')
-            ->where('uk.key', $key);
+            ->whereIn('agf.access_group_id', $access_group_ids);
     }
 
-    public function scopeIsContentAvailable($query, $key)
+    public function scopeIsContentAvailable(Builder $query, Collection $access_group_ids) : Builder
     {
-        return $query->whereExists(function ($query) use ($key) {
-            return $this->getQueryContentAvailable($query, $key);
+        return $query->whereExists(function ($query) use ($access_group_ids) {
+            return $this->getQueryContentAvailable($query, $access_group_ids);
         });
     }
 
@@ -774,20 +759,21 @@ class Language extends Model
      * Filter the languages by available bible fileset and the given media parameter.
      *
      * @param Builder $query
-     * @param string $key
+     * @param Collection $access_group_ids
      * @param string $media
      *
      * @return Builder
      */
-    public function scopeIsContentAvailableAndfilterableByMedia(Builder $query, ?string $key, ?string $media) : Builder
-    {
-        $dbp_prod = config('database.connections.dbp.database');
-
-        return $query->whereExists(function ($query) use ($dbp_prod, $key, $media) {
-            return $this->getQueryContentAvailable($query, $key)
-                ->when($media, function ($query) use ($media, $dbp_prod) {
+    public function scopeIsContentAvailableAndfilterableByMedia(
+        Builder $query,
+        ?Collection $access_group_ids,
+        ?string $media
+    ) : Builder {
+        return $query->whereExists(function ($query) use ($access_group_ids, $media) {
+            return $this->getQueryContentAvailable($query, $access_group_ids)
+                ->when($media, function ($query) use ($media) {
                     $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
-                    $query->join($dbp_prod . '.bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id')
+                    $query->join('bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id')
                         ->whereIn('bfst.set_type_code', $set_type_code_array);
                 });
         });

--- a/app/Models/Language/LanguageTranslation.php
+++ b/app/Models/Language/LanguageTranslation.php
@@ -3,6 +3,10 @@
 namespace App\Models\Language;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use App\Models\Bible\BibleFileset;
 
 /**
  * App\Models\Language\LanguageTranslation
@@ -147,5 +151,55 @@ class LanguageTranslation extends Model
     public function sourceIso()
     {
         return $this->belongsTo(Language::class, 'language_source_id', 'id')->select(['iso','id']);
+    }
+
+    public function scopeHasPriority(Builder $query) : Builder
+    {
+        $from_table = getAliasOrTableName($query->getQuery()->from);
+
+        return $query->where($from_table.'.priority', '=', function ($query) use ($from_table) {
+            $query->select(\DB::raw('MAX(`priority`)'))
+                ->from('language_translations as lang_trans_prior')
+                ->whereColumn('lang_trans_prior.language_source_id', '=', $from_table.'.language_source_id')
+                ->whereColumn(
+                    'lang_trans_prior.language_translation_id',
+                    '=',
+                    $from_table.'.language_translation_id'
+                )
+                ->limit(1);
+        })
+        ;
+    }
+
+    public function scopeIsContentAvailable(
+        Builder $query,
+        Collection $access_group_ids,
+        array $bible_fileset_filters = []
+    ) : Builder {
+        $from_table = getAliasOrTableName($query->getQuery()->from);
+
+        return $query->whereExists(
+            function (QueryBuilder $query) use ($access_group_ids, $from_table, $bible_fileset_filters) {
+                $query->select(\DB::raw(1))
+                    ->from('access_group_filesets as agf')
+                    ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
+                    ->join('bibles as b', 'bfc.bible_id', 'b.id');
+
+                if (!empty($bible_fileset_filters)) {
+                    $query->addWhereExistsQuery(
+                        BibleFileset::from('bible_filesets', 'bfst')
+                            ->select(\DB::raw(1))
+                            ->filterBy($bible_fileset_filters)
+                            ->whereColumn('bfst.hash_id', 'bfc.hash_id')->getQuery()
+                    );
+                }
+
+                return $query->whereColumn(
+                    $from_table.'.language_source_id',
+                    '=',
+                    'b.language_id'
+                )->whereIn('agf.access_group_id', $access_group_ids);
+            }
+        );
     }
 }

--- a/app/Models/User/AccessGroupFileset.php
+++ b/app/Models/User/AccessGroupFileset.php
@@ -3,6 +3,9 @@
 namespace App\Models\User;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use App\Models\Bible\BibleFileset;
 
 /**
  * App\Models\User\AccessGroupFileset
@@ -45,5 +48,84 @@ class AccessGroupFileset extends Model
     public function access()
     {
         return $this->belongsTo(AccessGroup::class, 'access_group_id');
+    }
+
+    /**
+     * Validate if Language or Bible has bible content available
+     *
+     * @param Builder $query
+     * @param string $where_column
+     *
+     * @return Builder
+     */
+    public function scopeDoesLanguageHaveBibleContentAvailable(
+        Builder $query,
+        string $where_column,
+        Collection $access_group_ids
+    ) {
+        return $query->from('access_group_filesets as agf')
+            ->select(\DB::raw(1))
+            ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
+            ->join('bibles as b', 'bfc.bible_id', 'b.id')
+            // ->whereColumn('lang.id', '=', 'b.language_id')
+            ->whereColumn($where_column, '=', 'b.language_id')
+            ->whereIn('agf.access_group_id', $access_group_ids);
+    }
+
+    /**
+     * Filter records by media value using set_type_code column that belongs to the bible fileset relationship
+     *
+     * @param Builder $query
+     * @param string $media
+     *
+     * @return Builder
+     */
+    public function scopeFilterByMediaFileset(Builder $query, string $media) : Builder
+    {
+        if (!$this->hasBibleFilesetsJoin($query)) {
+            $query->join('bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
+        }
+
+        $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
+        return $query->whereIn('bfst.set_type_code', $set_type_code_array);
+    }
+
+    /**
+     * Filter records by set_type_code column that belongs to the bible fileset relationship
+     *
+     * @param Builder $query
+     * @param string $set_type_code
+     *
+     * @return Builder
+     */
+    public function scopeFilterBySetTypeCodeFileset(Builder $query, string $set_type_code) : Builder
+    {
+        if (!$this->hasBibleFilesetsJoin($query)) {
+            $query->join('bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
+        }
+
+        return $query->where('bfst.set_type_code', $set_type_code);
+    }
+
+    public function hasBibleFilesetsJoin(Builder $query) : bool
+    {
+        $joins = $query->getQuery()->joins;
+
+        if (is_null($joins)) {
+            return false;
+        }
+
+        $fileset_table_name = with(new BibleFileset)->getTable();
+        $fileset_table_name_alias = "$fileset_table_name as bfst";
+
+        foreach ($joins as $join_clause) {
+            if ($join_clause->table === $fileset_table_name ||
+                $join_clause->table === $fileset_table_name_alias
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Models/User/AccessGroupFileset.php
+++ b/app/Models/User/AccessGroupFileset.php
@@ -3,9 +3,6 @@
 namespace App\Models\User;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Collection;
-use App\Models\Bible\BibleFileset;
 
 /**
  * App\Models\User\AccessGroupFileset
@@ -48,84 +45,5 @@ class AccessGroupFileset extends Model
     public function access()
     {
         return $this->belongsTo(AccessGroup::class, 'access_group_id');
-    }
-
-    /**
-     * Validate if Language or Bible has bible content available
-     *
-     * @param Builder $query
-     * @param string $where_column
-     *
-     * @return Builder
-     */
-    public function scopeDoesLanguageHaveBibleContentAvailable(
-        Builder $query,
-        string $where_column,
-        Collection $access_group_ids
-    ) {
-        return $query->from('access_group_filesets as agf')
-            ->select(\DB::raw(1))
-            ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-            ->join('bibles as b', 'bfc.bible_id', 'b.id')
-            // ->whereColumn('lang.id', '=', 'b.language_id')
-            ->whereColumn($where_column, '=', 'b.language_id')
-            ->whereIn('agf.access_group_id', $access_group_ids);
-    }
-
-    /**
-     * Filter records by media value using set_type_code column that belongs to the bible fileset relationship
-     *
-     * @param Builder $query
-     * @param string $media
-     *
-     * @return Builder
-     */
-    public function scopeFilterByMediaFileset(Builder $query, string $media) : Builder
-    {
-        if (!$this->hasBibleFilesetsJoin($query)) {
-            $query->join('bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
-        }
-
-        $set_type_code_array = BibleFileset::getsetTypeCodeFromMedia($media);
-        return $query->whereIn('bfst.set_type_code', $set_type_code_array);
-    }
-
-    /**
-     * Filter records by set_type_code column that belongs to the bible fileset relationship
-     *
-     * @param Builder $query
-     * @param string $set_type_code
-     *
-     * @return Builder
-     */
-    public function scopeFilterBySetTypeCodeFileset(Builder $query, string $set_type_code) : Builder
-    {
-        if (!$this->hasBibleFilesetsJoin($query)) {
-            $query->join('bible_filesets as bfst', 'bfst.hash_id', 'bfc.hash_id');
-        }
-
-        return $query->where('bfst.set_type_code', $set_type_code);
-    }
-
-    public function hasBibleFilesetsJoin(Builder $query) : bool
-    {
-        $joins = $query->getQuery()->joins;
-
-        if (is_null($joins)) {
-            return false;
-        }
-
-        $fileset_table_name = with(new BibleFileset)->getTable();
-        $fileset_table_name_alias = "$fileset_table_name as bfst";
-
-        foreach ($joins as $join_clause) {
-            if ($join_clause->table === $fileset_table_name ||
-                $join_clause->table === $fileset_table_name_alias
-            ) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/app/Models/User/AccessType.php
+++ b/app/Models/User/AccessType.php
@@ -82,4 +82,25 @@ class AccessType extends Model
     {
         return $this->belongsToMany(AccessGroup::class, 'access_group_types');
     }
+
+    /**
+     * Get an only one record filtering by country_id and continent_id
+     *
+     * @param $country_code
+     * @param $continent
+     *
+     * @return AccessType
+     */
+    public static function findOneByCountryCodeAndContinent(?string $country_code, ?string $continent) : AccessType
+    {
+        return AccessType::where('name', 'api')
+            ->where(function ($query) use ($country_code) {
+                $query->where('country_id', $country_code);
+            })
+            ->where(function ($query) use ($continent) {
+                $query->where('continent_id', $continent);
+            })
+            ->select('id', 'name')
+            ->first();
+    }
 }

--- a/app/Models/User/Study/UserAnnotationTrait.php
+++ b/app/Models/User/Study/UserAnnotationTrait.php
@@ -4,39 +4,65 @@ namespace App\Models\User\Study;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
+use App\Models\Playlist\PlaylistItems;
 
 use App\Models\Bible\BibleFilesetConnection;
 
 trait UserAnnotationTrait
 {
     /**
-     * Get bookmarks related the playlist items that belong to playlist and a given book ID
+     * Scope a query to only include playlist items that belong to a specific playlist and book.
      *
-     * @param Illuminate\Database\Query\Builder $query
-     * @param int $playlist_id
-     * @param string $book_id
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  int $playlist_id
+     * @param  string $book_id
      *
-     * @return Illuminate\Database\Query\Builder
+     * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWhereBelongPlaylistAndBook(Builder $query, int $playlist_id, string $book_id) : Builder
     {
-        $dbp_users = config('database.connections.dbp_users.database');
-        $dbp_prod = config('database.connections.dbp.database');
+        // Select the fileset_id and chapter_start for the playlist items that belong to
+        // the specified playlist and book.
+        $items = PlaylistItems::select(['fileset_id', 'chapter_start'])
+            ->where('playlist_items.playlist_id', $playlist_id)
+            ->where('playlist_items.book_id', $book_id)
+            ->groupBy('playlist_items.fileset_id', 'playlist_items.chapter_start')
+            ->get();
 
+        $fileset_ids = [];
+        $fileset_and_chapters = [];
+
+        foreach ($items as $item) {
+            $fileset_ids[$item->fileset_id] = true;
+        }
+
+        // Select the bible_id and fileset_id for the bible fileset connections that match the fileset_ids.
+        $bible_ids = BibleFilesetConnection::select('bible_id', 'bf.id as fileset_id')
+            ->join('bible_filesets AS bf', 'bible_fileset_connections.hash_id', 'bf.hash_id')
+            ->whereIn('bf.id', array_keys($fileset_ids))
+            ->groupBy('bible_fileset_connections.bible_id', 'bible_fileset_connections.bible_id')
+            ->get();
+
+        // Create an array of fileset_ids and their corresponding bible_ids.
+        $fileset_and_bible = [];
+        foreach ($bible_ids as $bible_fileset) {
+            $fileset_and_bible[$bible_fileset->fileset_id] = $bible_fileset->bible_id;
+        }
+
+        // Create an array of bible_ids and chapter_starts for the playlist items that have a corresponding
+        // bible fileset connection.
+        $bible_per_chapter = [];
+        foreach ($items as $item) {
+            if (isset($fileset_and_bible[$item->fileset_id])) {
+                $bible_id = $fileset_and_bible[$item->fileset_id];
+                $bible_per_chapter[] = $bible_id.$item->chapter_start;
+            }
+        }
+
+        // Return the query builder with additional where clauses for the book_id and the bible_id and
+        // chapter combination.
         return $query
             ->where($this->table.'.book_id', $book_id)
-            ->whereExists(function (QueryBuilder $subquery) use ($dbp_users, $dbp_prod, $book_id, $playlist_id) {
-                return $subquery->select(\DB::raw(1))
-                    ->from($dbp_prod . '.bible_fileset_connections AS bfc')
-                    ->join($dbp_prod . '.bible_filesets AS bf', 'bfc.hash_id', 'bf.hash_id')
-                    ->join($dbp_users . '.playlist_items', function (QueryBuilder $join) use ($book_id) {
-                        $join
-                            ->on('bf.id', '=', 'playlist_items.fileset_id')
-                            ->where('playlist_items.book_id', $book_id)
-                            ->whereColumn($this->table.'.chapter', '=', 'playlist_items.chapter_start')
-                            ->whereColumn($this->table.'.bible_id', '=', 'bfc.bible_id');
-                    })
-                    ->where('playlist_items.playlist_id', $playlist_id);
-            });
+            ->whereIn(\DB::raw("CONCAT($this->table.bible_id, '', $this->table.chapter)"), $bible_per_chapter);
     }
 }

--- a/app/Providers/IAMAPIProvider.php
+++ b/app/Providers/IAMAPIProvider.php
@@ -1,0 +1,25 @@
+<?php
+ 
+namespace App\Providers;
+ 
+use App\Services\IAMAPI\IAMAPIClientService as Client;
+use Illuminate\Support\ServiceProvider;
+ 
+class IAMAPIProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(Client::class, function () {
+            return new Client(
+                config('services.iam.url'),
+                config('services.iam.enabled'),
+                config('services.iam.service_timeout')
+            );
+        });
+    }
+}

--- a/app/Services/IAMAPI/IAMAPIClientInterface.php
+++ b/app/Services/IAMAPI/IAMAPIClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Services\IAMAPI;
+
+interface IAMAPIClientInterface
+{
+    public function getAccessGroupIdsByUserKey(string $user_key): mixed;
+    public function getName(): string;
+}

--- a/app/Services/IAMAPI/IAMAPIClientService.php
+++ b/app/Services/IAMAPI/IAMAPIClientService.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Services\IAMAPI;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\Exception\TransportException;
+
+class IAMAPIClientService implements IAMAPIClientInterface
+{
+    protected string $api_url;
+    protected string $is_enabled;
+    protected CurlHttpClient $client;
+
+    public function __construct(string $api_url, bool $is_enabled = false, int $service_timeout = 5)
+    {
+        $this->client = HttpClient::create();
+        $this->api_url = $api_url;
+        $this->is_enabled = $is_enabled;
+        $this->service_timeout = $service_timeout;
+    }
+
+    public function isEnabled() : bool
+    {
+        return $this->is_enabled === true || (int) $this->is_enabled === 1;
+    }
+
+    private function createPath(
+        string $base_url,
+        string $path,
+        string $user_key
+    ) : string {
+        $new_path = $base_url.$path.'?userKey='.$user_key;
+
+        return $new_path;
+    }
+
+    public function getAccessGroupIdsByUserKey(string $user_key) : mixed
+    {
+        try {
+            $new_path = $this->createPath($this->api_url, 'access', $user_key);
+            $content = $this->client->request(
+                'GET',
+                $new_path,
+                ['timeout' => $this->service_timeout]
+            );
+
+            \Log::channel('single')->notice(['GET request', $new_path]);
+
+            $response = $content->getContent();
+
+            return collect(json_decode($response));
+        } catch (TransportException $e) {
+            \Log::channel('errorlog')->error($e->getMessage());
+            throw $e;
+        }
+    }
+
+    public function getName() : string
+    {
+        return "IAMAPIClient";
+    }
+}

--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -2,10 +2,12 @@
 
 namespace App\Traits;
 
-use App\Models\User\AccessGroupKey;
+use App\Models\User\AccessGroup;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use App\Models\User\AccessGroupFileset;
 use App\Models\User\AccessType;
 use App\Models\User\Key;
+use App\Models\Bible\BibleFileset;
 use App\Exceptions\ResponseException as Response;
 use DB;
 
@@ -19,13 +21,13 @@ trait AccessControlAPI
      *
      * @return object
      */
-    public function accessControl($api_key, $control_table = 'filesets')
+    public function accessControl(?string $api_key, $control_table = 'filesets')
     {
         return cacheRemember(
             'access_control:',
             [$control_table, $api_key],
             now()->addDay(),
-            function () use ($api_key, $control_table) {
+            function () use ($api_key) {
                 $user_location = geoip(request()->ip());
                 $country_code = (!isset($user_location->iso_code)) ? $user_location->iso_code : null;
                 $continent = (!isset($user_location->continent)) ? $user_location->continent : null;
@@ -38,58 +40,17 @@ trait AccessControlAPI
                     return (object) ['identifiers' => [], 'string' => ''];
                 }
 
-                $key = Key::select('id')->where('key', $api_key)->first();
-                $accessGroups = AccessGroupKey::where('key_id', $key->id)
-                ->with([
-                    'access' => function ($query) {
-                        $query->where('name', '!=', 'RESTRICTED');
-                    }
-                ])
-                ->get()
-                ->pluck('access')
-                ->map(function ($access) {
-                    return !is_null($access)
-                        ? collect($access->toArray())
-                            ->only(['id', 'name'])
-                            ->all()
-                        : collect([]);
-                })->filter(function ($access) {
-                    return !empty($access) && isset($access['id']);
-                });
-
                 // Access Control has historically been tied to fileset hashes.
-                // As the number of filesets grows, this has been affected query
-                // performance for endpoints such as Languages (and similarly for  Bibles),
-                // which return a list of Languages associated with any fileset
-                // content associated with the API key. For this case, the query has been optimized,
-                // and returns a list of language ids instead of a list of fileset hashes
                 $access_group_ids = getAccessGroups();
 
-                switch ($control_table) {
-                    case 'languages':
-                        $identifiers = \DB::table('access_group_filesets as agf')
-                            ->select(DB::raw('distinct l.id AS identifier'))
-                            ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-                            ->join('bibles as b', 'bfc.bible_id', 'b.id')
-                            ->join('languages as l', 'l.id', 'b.language_id')
-                            ->whereIn('agf.access_group_id', $access_group_ids)
-                            ->get()
-                            ->pluck('identifier');
-                        break;
-                    case 'bibles':
-                        $identifiers = \DB::table('access_group_filesets as agf')
-                            ->select(DB::raw('distinct bfc.bible_id identifier'))
-                            ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-                            ->whereIn('agf.access_group_id', $access_group_ids)
-                            ->get()
-                            ->pluck('identifier');
-                        break;
-                    default:
-                        // Use Eloquent everywhere except for this giant request
-                        $identifiers = AccessGroupFileset::select('hash_id as identifier')
-                            ->whereIn('access_group_id', $accessGroups->pluck('id'))->distinct()->get();
-                        break;
-                }
+                $accessGroups = AccessGroup::select('id', 'name')
+                    ->whereIn('id', $access_group_ids)
+                    ->where('name', '!=', 'RESTRICTED')
+                    ->get()
+                ;
+                // Use Eloquent everywhere except for this giant request
+                $identifiers = AccessGroupFileset::select('hash_id as identifier')
+                    ->whereIn('access_group_id', $access_group_ids)->distinct()->get();
 
                 return (object) [
                     'identifiers' => collect($identifiers)->pluck('identifier')->toArray(),
@@ -99,7 +60,7 @@ trait AccessControlAPI
         );
     }
 
-    private function genericAccessControl($api_key, $fileset_hash, $access_group_ids = [])
+    private function genericAccessControl(?string $api_key, ?string $fileset_hash, array $access_group_ids = [])
     {
 
         $cache_params = [$api_key, $fileset_hash, join('', $access_group_ids)];
@@ -117,25 +78,22 @@ trait AccessControlAPI
                 $access_type = AccessType::findOneByCountryCodeAndContinent($country_code, $continent);
 
                 if (!$access_type) {
-                    return (object) ['identifiers' => [], 'string' => ''];
+                    return [];
                 }
 
-                $dbp_database = config('database.connections.dbp.database');
+                $access_groups_by_api_key_user = getAccessGroups();
 
-                return AccessGroupKey::join('user_keys', function ($join) use ($api_key) {
-                    $join->on('user_keys.id', '=', 'access_group_api_keys.key_id')
-                        ->where('user_keys.key', $api_key);
-                })->join(
-                    $dbp_database . '.access_group_filesets as acc_filesets',
-                    function ($join) use ($fileset_hash, $access_group_ids) {
-                        $join->on('access_group_api_keys.access_group_id', '=', 'acc_filesets.access_group_id')
-                            ->where('hash_id', $fileset_hash);
+                if (empty($access_groups_by_api_key_user)) {
+                    return [];
+                }
 
-                        if (!empty($access_group_ids)) {
-                            $join->whereIn('acc_filesets.access_group_id', $access_group_ids);
-                        }
-                    }
-                )->select('user_keys.id')->get();
+                return AccessGroupFileset::select('hash_id')
+                    ->whereIn('access_group_id', $access_groups_by_api_key_user)
+                    ->when(!empty($access_group_ids), function ($query) use ($access_group_ids) {
+                        $query->whereIn('access_group_id', $access_group_ids);
+                    })
+                    ->where('hash_id', $fileset_hash)
+                    ->get();
             }
         );
     }
@@ -152,35 +110,35 @@ trait AccessControlAPI
         return config('auth.compat_users.api_keys.bibleis') === $api_key;
     }
 
-    public function blockedByAccessControl($fileset)
+    public function allowedByAccessControl(BibleFileset $fileset)
     {
-        $access_control = $this->accessControl($this->key);
-        if (!\in_array($fileset->hash_id, $access_control->identifiers, true)) {
-            return $this->setStatusCode(403)->replyWithError(trans('api.bible_fileset_errors_401'));
-        }
-        return false;
-    }
-
-    public function allowedByBulkAccessControl($fileset)
-    {
-        $allowed_fileset = $this->genericAccessControl($this->key, $fileset->hash_id);
-        if (sizeof($allowed_fileset) === 0) {
-            return $this->setStatusCode(404)->replyWithError('Not found');
+        $access_control = $this->genericAccessControl($this->key, $fileset->hash_id);
+        if (sizeof($access_control) === 0) {
+            return $this->setStatusCode(HttpResponse::HTTP_FORBIDDEN)
+                ->replyWithError(trans('api.bible_fileset_errors_401'));
         }
         return true;
     }
 
-    public function allowedForDownload($fileset)
+    public function allowedByBulkAccessControl(BibleFileset $fileset)
     {
-        // If the API key belongs to bible.is DBP will utilize the bible.is access group list else,
-        // the system will utilize the generic access group list instead.
+        $allowed_fileset = $this->genericAccessControl($this->key, $fileset->hash_id);
+        if (sizeof($allowed_fileset) === 0) {
+            return $this->setStatusCode(HttpResponse::HTTP_NOT_FOUND)->replyWithError('Not found');
+        }
+        return true;
+    }
 
+    public function allowedForDownload(BibleFileset $fileset)
+    {
         // Note that in the future, this constraint should be updated to account for
         // whether the user is logged in or not.
         // if ($this->doesApiKeyBelongToBibleis($this->key) && isUserLoggedIn()) {
 
+        // If the API key belongs to bible.is DBP will utilize the bible.is access group list else,
+        // the system will utilize the generic access group list instead.
         if ($this->doesApiKeyBelongToBibleis($this->key)) {
-            $download_access_group_array_ids = AccessGroupKey::getAccessGroupIdsByApiKey($this->key)->toArray();
+            $download_access_group_array_ids = optional(getAccessGroups())->toArray();
         } else {
             $download_access_group_array_ids = getDownloadAccessGroupList();
         }

--- a/config/app.php
+++ b/config/app.php
@@ -163,6 +163,7 @@ return [
         App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        App\Providers\IAMAPIProvider::class,
         SocialiteProviders\Manager\ServiceProvider::class,
         SocialiteProviders\Generators\GeneratorsServiceProvider::class,
         Illuminate\Notifications\NotificationServiceProvider::class,

--- a/config/services.php
+++ b/config/services.php
@@ -75,6 +75,11 @@ return [
         // arclight service timeout in seconds
         'service_timeout' => env('ARCLIGHT_SERVICE_TIMEOUT', 5)
     ],
+    'iam' => [
+        'url' => env('IAM_API_URL', ''),
+        'enabled' => env('IAM_ENABLED', false),
+        'service_timeout' => env('IAM_SERVICE_TIMEOUT', 5)
+    ],
 
     // Testing
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -94,8 +94,7 @@ Route::name('v4_bible.copyright')->get(
     'Bible\BiblesController@copyright'
 ); // used
 Route::name('v4_internal_bible.chapter')
-    ->middleware('APIToken')
-    ->middleware('AccessControl')
+    ->middleware(['APIToken', 'AccessControl'])
     ->get('bibles/{bible_id}/chapter', 'Bible\BiblesController@chapter'); //used
 Route::name('v4_internal_bible.chapter.annotations')
     ->middleware('APIToken:check')
@@ -164,13 +163,15 @@ Route::name('v4_bible_verses.verse_by_bible')->get(
 
 // BibleFileSet download version 4
 
-Route::name('v4_bible_filesets_download.list')->get(
+Route::name('v4_bible_filesets_download.list')
+->middleware('AccessControl')
+->get(
     'download/list',
     'Bible\BibleFilesetsDownloadController@list'
 );
 
 Route::name('v4_bible_filesets_download.index')
-    ->middleware('APIToken')
+    ->middleware(['APIToken', 'AccessControl'])
     ->get(
         'download/{fileset_id}/{book?}/{chapter_id?}',
         'Bible\BibleFilesetsDownloadController@index'

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,15 +15,21 @@ Route::name('v4_countries.search')->get(
 );
 
 // VERSION 4 | Languages
-Route::name('v4_languages.all')->get(
+Route::name('v4_languages.all')
+->middleware('AccessControl')
+->get(
     'languages',
     'Wiki\LanguagesController@index'
 );
-Route::name('v4_languages.one')->get(
+Route::name('v4_languages.one')
+->middleware('AccessControl')
+->get(
     'languages/{language_id}',
     'Wiki\LanguagesController@show'
 );
-Route::name('v4_languages.search')->get(
+Route::name('v4_languages.search')
+->middleware('AccessControl')
+->get(
     'languages/search/{search_text}',
     'Wiki\LanguagesController@search'
 );
@@ -56,23 +62,32 @@ Route::name('v4_bible.defaults')->get(
     'bibles/defaults/types',
     'Bible\BiblesController@defaults'
 ); // used
-Route::name('v4_bible.books')->get(
+Route::name('v4_bible.books')
+->middleware('AccessControl')
+->get(
     'bibles/{bible_id}/book',
     'Bible\BiblesController@books'
 ); // used by bible.is, but book is not specified. suggest unifying on this one. (fixed)The signature looks wrong - the code doesn't accept book_id as a path param, only a query param
-Route::name('v4_bible_by_id.search')->get(
+Route::name('v4_bible_by_id.search')
+->middleware('AccessControl')
+->get(
     'bibles/search',
     'Bible\BiblesController@searchByBibleVersion'
 );
-Route::name('v4_bible.one')->get(
+Route::name('v4_bible.one')
+->middleware('AccessControl')
+->get(
     'bibles/{bible_id}',
     'Bible\BiblesController@show'
 ); // see note in Postman. the content is suspect
-Route::name('v4_bible.search')->get(
+Route::name('v4_bible.search')
+->middleware('AccessControl')
+->get(
     'bibles/search/{search_text}',
     'Bible\BiblesController@search'
 );
 Route::name('v4_bible.all')
+    ->middleware('AccessControl')
     ->get('bibles', 'Bible\BiblesController@index'); // used
 Route::name('v4_bible.copyright')->get(
     'bibles/{bible_id}/copyright',
@@ -80,6 +95,7 @@ Route::name('v4_bible.copyright')->get(
 ); // used
 Route::name('v4_internal_bible.chapter')
     ->middleware('APIToken')
+    ->middleware('AccessControl')
     ->get('bibles/{bible_id}/chapter', 'Bible\BiblesController@chapter'); //used
 Route::name('v4_internal_bible.chapter.annotations')
     ->middleware('APIToken:check')
@@ -103,7 +119,9 @@ Route::name('v4_internal_filesets.checkTypes')->post(
 Route::name('v4_internal_bible_filesets.copyright')->get('bibles/filesets/{fileset_id}/copyright', 'Bible\BibleFileSetsController@copyright');
 
 // DEPRECATED. Prefer instead v4_filesets.chapter. Reasons: It takes book and chapter as query parameters.
-Route::name('v4_internal_filesets.show')->get(
+Route::name('v4_internal_filesets.show')
+->middleware('AccessControl')
+->get(
     'bibles/filesets/{fileset_id?}',
     'Bible\BibleFileSetsController@show'
 );
@@ -119,7 +137,9 @@ Route::name('v4_filesets.bulk')->get(
     'bibles/filesets/bulk/{fileset_id}/{book?}',
     'Bible\BibleFileSetsController@showBulk'
 );
-Route::name('v4_filesets.chapter')->get(
+Route::name('v4_filesets.chapter')
+->middleware('AccessControl')
+->get(
     'bibles/filesets/{fileset_id}/{book}/{chapter}',
     'Bible\BibleFileSetsController@showChapter'
 );
@@ -127,7 +147,8 @@ Route::name('v4_filesets.chapter')->get(
 Route::name('v4_bible_verses.verse_by_language')->get(
     '/bibles/verses/{language_code}/{book_id}/{chapter_id}/{verse_number?}',
     'Bible\BibleVersesController@showVerseByLanguage'
-)->whereAlphaNumeric('language_code')
+)->middleware('AccessControl')
+->whereAlphaNumeric('language_code')
 ->whereAlphaNumeric('book_id')
 ->whereNumber('chapter_id')
 ->whereAlphaNumeric('verse_number');
@@ -135,7 +156,8 @@ Route::name('v4_bible_verses.verse_by_language')->get(
 Route::name('v4_bible_verses.verse_by_bible')->get(
     '/bible/{bible_id}/verses/{book_id}/{chapter_id}/{verse_number?}',
     'Bible\BibleVersesController@showVerseByBible'
-)->whereAlphaNumeric('bible_id')
+)->middleware('AccessControl')
+->whereAlphaNumeric('bible_id')
 ->whereAlphaNumeric('book_id')
 ->whereNumber('chapter_id')
 ->whereAlphaNumeric('verse_number');
@@ -156,7 +178,9 @@ Route::name('v4_bible_filesets_download.index')
 
 // VERSION 4 | Text
 // This is new, added Dec 28, to provide just the verses for a bible or chapter. Note that this does not have filesets in path
-Route::name('v4_bible.verseinfo')->get(
+Route::name('v4_bible.verseinfo')
+->middleware('AccessControl')
+->get(
     'bibles/{bible_id}/{book}/{chapter?}',
     'Bible\TextController@index'
 );

--- a/routes/apiV2.php
+++ b/routes/apiV2.php
@@ -15,13 +15,13 @@ Route::name('v2_library_chapter')->get('library/chapter',                       
 // VERSION 2 | Languages
 Route::name('v2_library_language')->get('library/language',                        'Wiki\LanguageControllerV2@languageListing');
 Route::name('v2_library_volumeLanguage')->get('library/volumelanguage',            'Wiki\LanguageControllerV2@volumeLanguage');
-Route::name('v2_library_volumeLanguageFamily')->get('library/volumelanguagefamily', 'Wiki\LanguageControllerV2@volumeLanguageFamily');
-Route::name('v2_country_lang')->get('country/countrylang',                         'Wiki\LanguageControllerV2@countryLang');
+Route::name('v2_library_volumeLanguageFamily')->middleware('AccessControl')->get('library/volumelanguagefamily', 'Wiki\LanguageControllerV2@volumeLanguageFamily');
+Route::name('v2_country_lang')->middleware('AccessControl')->get('country/countrylang',                         'Wiki\LanguageControllerV2@countryLang');
 
 // VERSION 2 | Library
 Route::name('v2_library_version')->get('library/version',                          'Bible\LibraryController@version');
 Route::name('v2_library_metadata')->get('library/metadata',                        'Bible\LibraryController@metadata');
-Route::name('v2_library_volume')->get('library/volume',                            'Bible\LibraryController@volume');
+Route::name('v2_library_volume')->middleware('AccessControl')->get('library/volume','Bible\LibraryController@volume');
 Route::name('v2_library_verse')->get('library/verse',                              'Bible\TextControllerV2@index');
 Route::name('v2_library_verseInfo')->get('library/verseinfo',                      'Bible\TextController@info');
 Route::name('v2_library_numbers')->get('library/numbers',                          'Wiki\NumbersController@customRange');
@@ -31,7 +31,7 @@ Route::name('v2_volume_organization_list')->get('library/volumeorganization',   
 
 // VERSION 2 | Text
 Route::name('v2_text_font')->get('text/font',                                      'Bible\TextController@fonts');
-Route::name('v2_text_verse')->get('text/verse',                                    'Bible\TextControllerV2@index');
+Route::name('v2_text_verse')->middleware('AccessControl')->get('text/verse',                                    'Bible\TextControllerV2@index');
 Route::name('v2_verseInfo')->get('text/verseinfo',                                 'Bible\TextController@info'); // I cannot see a difference between library/verseinfo and text/verseinfo
 Route::name('v2_text_search')->get('text/search',                                  'Bible\TextControllerV2@search');
 Route::name('v2_text_search_group')->get('text/searchgroup',                       'Bible\TextController@searchGroup');


### PR DESCRIPTION
# Description
To improve access control in the API, we took several steps. First, we refactored the access control code and added a new access control middleware (AccessControl). This middleware has several options that are determined by the .env parameters, including `IAM_ENABLED` and `IAM_API_URL`. These parameters allow us to determine whether the access group ids will be provided from an external API or fetched from the dbp_user databases.

In addition, we added the `IAMAPIProvider` and `IAMAPIService` to the API. The IAMAPIProvider allows us to inject an IAMAPIService object using dependency injection, which is then used by the middleware to interact with the external IAM API. The `IAMAPIService` provides a way for the middleware to communicate with the external IAM API and retrieve access group ids.

We removed the db_users tables from the Models Class. This ensures that access control is properly separated.

Finally, we integrated the new access control middleware with API and refactored the UserAnnotationTrait to avoid using both databases in the same query. 

# NOTE 1
We need to add the following new .env parameters:
```
IAM_API_URL=https://f3394a53-e214-4af4-ac75-6c6893ce14e6.mock.pstmn.io/
IAM_ENABLED=false
IAM_SERVICE_TIMEOUT=5
```

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-544

## How Do I QA This
All postman tests of folder: `Acces Control` have to pass.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-7b281e90-36a9-464d-aab0-feac43793bee
