### PR TITLE
FCBHDBP-541-hotfix Extend the logic to store the user_downloads records to the new download endpoints

### DIFF
--- a/app/Traits/AccessControlAPI.php
+++ b/app/Traits/AccessControlAPI.php
@@ -190,9 +190,14 @@ trait AccessControlAPI
 
     public function allowedForDownload($fileset)
     {
-        // If the API key belongs to bible.is but the user is not currently logged in,
+        // If the API key belongs to bible.is DBP will utilize the bible.is access group list else,
         // the system will utilize the generic access group list instead.
-        if ($this->doesApiKeyBelongToBibleis($this->key) && isUserLoggedIn()) {
+
+        // Note that in the future, this constraint should be updated to account for
+        // whether the user is logged in or not.
+        // if ($this->doesApiKeyBelongToBibleis($this->key) && isUserLoggedIn()) {
+
+        if ($this->doesApiKeyBelongToBibleis($this->key)) {
             $download_access_group_array_ids = AccessGroupKey::getAccessGroupIdsByApiKey($this->key)->toArray();
         } else {
             $download_access_group_array_ids = getDownloadAccessGroupList();


### PR DESCRIPTION
# Description
Disable the latest change in which we validate whether the API key belongs to bible.is and the user is not currently logged in. Instead of returning the generic access group list, the API would return the bible.is access group list as it did before.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-541

## How Do I QA This
-All the following postman test have to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-fb2b1824-5f60-4d96-83bd-2648c7bd00c2
