### PR TITLE
FCBHDBP-548 hotfix add AccessControl middleware to the countries endpoints

### DIFF
--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -153,7 +153,9 @@ class LanguagesController extends APIController
                         'languages.rolv_code',
                         \DB::raw($select_country_population . ' as country_population')
                     ])
-                    ->with('bibles')
+                    ->with(['bibles' => function ($query) {
+                        $query->whereHas('filesets');
+                    }])
                     ->withCount([
                         'filesets'
                     ]);


### PR DESCRIPTION
# Description
rollback `LanguageController` the feature to validate that bibles have filesets attached. @bradflood It was my bad because the method Language::isContentAvailable validates that a language has at least one bible with filesets attached and so we have found a language with 3 bibles attached but just one bible has filesets attached. So, when DBO should return the bibles we need to make sure that DBP will only return the bibles with  filesets attached.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-548

## How Do I QA This
- We should run the all test of the following folder and they must pass.

https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-f4001f93-3bac-4831-918c-29e8a7c518ea

