### PR TITLE
FCBHDBP-550 Translate endpoint must validate if the user api key is a…

### DIFF
--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -62,7 +62,13 @@ class PlanService
         $translated_percentage = 0;
         $play_day_data = [];
         $audio_fileset_types = collect(['audio_stream', 'audio_drama_stream', 'audio', 'audio_drama']);
-        $bible_audio_filesets = $bible->filesets->whereIn('set_type_code', $audio_fileset_types);
+        $bible_id = $bible->id;
+        $access_group_ids = getAccessGroups();
+        $bible_audio_filesets = PlaylistService::getFilesetsByBibleTypeAndAccessGroup(
+            $bible_id,
+            $audio_fileset_types,
+            $access_group_ids
+        );
         $count_plan_days = 0;
         $playlist_ids = [];
         $valid_bible_audio_filesets = $this->playlist_service->getValidAudioStreamFilesets($bible_audio_filesets);

--- a/routes/api.php
+++ b/routes/api.php
@@ -348,7 +348,7 @@ Route::name('v4_internal_playlists_items.complete')
         'Playlist\PlaylistsController@completeItem'
     );
 Route::name('v4_internal_playlists.translate')
-    ->middleware('APIToken:check')
+    ->middleware(['APIToken:check', 'AccessControl'])
     ->get('playlists/{playlist_id}/translate', 'Playlist\PlaylistsController@translate');
 Route::name('v4_internal_playlists.hls')
     ->get('playlists/{playlist_id}/hls', 'Playlist\PlaylistsController@hls');
@@ -405,7 +405,7 @@ Route::name('v4_internal_plans.stop')
     ->middleware('APIToken:check')
     ->delete('plans/{plan_id}/stop', 'Plan\PlansController@stop');
 Route::name('v4_internal_plans.translate')
-    ->middleware('APIToken:check')
+    ->middleware(['APIToken:check', 'AccessControl'])
     ->get('plans/{plan_id}/translate', 'Plan\PlansController@translate');
 Route::name('v4_internal_plans_days.store')
     ->middleware('APIToken:check')


### PR DESCRIPTION
# Description
Translate endpoint must validate if the user api key is allowed to see the filesets records. We need to use the method isContentAvailable when we need to fetch filesets records.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-550

## How Do I QA This
- We should run all postman test of the following folder and they have to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-0699dbfa-e8d5-4f0a-9d3e-92c7cfc6ef34

- We should run the following postman test for dev env and it have to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-c86cbd40-3fdb-4e64-bc7b-7a01aeaca103
