### PR TITLE
FCBHDBP-551 Audio-only playlists for filesets are returning multivariant playlists with video codecs

### DIFF
--- a/app/Models/Bible/StreamBandwidth.php
+++ b/app/Models/Bible/StreamBandwidth.php
@@ -6,6 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class StreamBandwidth extends Model
 {
+    public const CODEC_AUDIO = 'mp4a.40.2';
+    public const CODEC_VIDEO = 'avc1.4d001f';
+    public const CODEC_VIDEO_AND_AUDIO = 'avc1.4d001f,mp4a.40.2';
+
     protected $connection = 'dbp';
     protected $table = 'bible_file_stream_bandwidths';
     protected $fillable = ['file_id','file_name','bandwidth','resolution_width','resolution_height','codec','stream'];
@@ -23,5 +27,81 @@ class StreamBandwidth extends Model
     public function transportStreamBytes()
     {
         return $this->hasMany(StreamBytes::class)->orderBy('offset');
+    }
+
+    /**
+     * Removes the specified video codec from the list of codecs and returns the remaining codecs as a string
+     * for the current instance
+     *
+     * @return string
+     */
+    public function getCodecWithoutVideoCodec() : string
+    {
+        $codecs = \explode(",", $this->codec);
+        $newcodecs = [];
+
+        foreach ($codecs as $codec) {
+            if ($codec !== self::CODEC_VIDEO) {
+                $newcodecs[] = $codec;
+            }
+        }
+
+        if (!empty($newcodecs)) {
+            return \implode(",", $newcodecs);
+        }
+    
+        return $this->codec;
+    }
+
+    /**
+     * Check if current instance of stream bandwith belongs to audio stream
+     *
+     * @return bool
+     */
+    public function isAudio() : bool
+    {
+        return is_null($this->resolution_width) || empty($this->resolution_width);
+    }
+
+    /**
+     * Create a Playlist content using the current instance of StreamBandwidth class
+     *
+     * @param string $key
+     * @param string $asset_id
+     *
+     * @return string
+     */
+    public function getPlaylistContent(string $key, string $asset_id) : string
+    {
+        $content = "\n#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH={$this->bandwidth}";
+
+        $transportStream = sizeof($this->transportStreamBytes)
+            ? $this->transportStreamBytes
+            : $this->transportStreamTS;
+
+        $extrargs = '';
+
+        if (sizeof($transportStream) &&
+            isset($transportStream[0]->timestamp) &&
+            $transportStream[0]->timestamp->verse_start === 0
+        ) {
+            $extrargs = '&v0=0';
+        }
+
+        if ($this->resolution_width) {
+            $content .= ',RESOLUTION=' . $this->resolution_width . "x{$this->resolution_height}";
+        }
+
+        if ($this->codec) {
+            if ($this->isAudio()) {
+                $scodecs = $this->getCodecWithoutVideoCodec();
+            } else {
+                $scodecs = $this->codec;
+            }
+            $content .= ",CODECS=\"$scodecs\"";
+        }
+        $content .= "\n{$this->file_name}" . '?key=' . $key . '&v=4&asset_id=' . $asset_id . $extrargs;
+
+        return $content;
     }
 }


### PR DESCRIPTION
# Description
To improve the v4_media_stream endpoint, we need to ensure that the CODECS values are set appropriately for each fileset type. Specifically, when dealing with Multivariant playlists containing only audio Media, we should set the codecs value to only include audio codecs, such as 'mp4a.40.2'.

To clarify, the codec value is retrieved from the bible_file_stream_bandwidths entity in the database. Upon checking my local database, I have confirmed that all records in this entity have been assigned the same value of `avc1.4d001f,mp4a.40.2`. You can verify this by running the following SQL queries:

```sql
-- count = 286355
SELECT count(bfsb.id), bfsb.codec FROM bible_file_stream_bandwidths bfsb GROUP BY bfsb.codec;
```

```sql
-- count = 286355
SELECT count(bfsb.id) FROM bible_file_stream_bandwidths bfsb;
```

Based on my analysis, I have concluded that the best approach would be to remove the video codec from the controller when the stream content to be returned is audio-only. To determine if the content is not audio-only, we can check the `resolution_width` column of the `bible_file_stream_bandwidths` entity. This column will only be set for video streams, so if it is null, we know that the content is audio-only. 

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-551

## How Do I QA This
- We should run the following postman test about audio playlist and it has to pass. Also, we should check that the codecs values is equal to `CODECS="mp4a.40.2"`
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a9a54aab-7f38-4ce7-b1d4-c7fba364144e

- We should run the following postman test about video playlist and it also has to pass. We should validate that the codecs for video content should be equal to `CODECS="avc1.4d001f,mp4a.40.2"`
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-3363135f-9ff5-48c0-bf2c-20f925c9904a