### PR TITLE
FCBHDBP-553 remove the api key from from all DBP cache keys.

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -4,8 +4,9 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\Response;
+use App\Support\AccessGroupsCollection;
 
-function getAccessGroups() : \Illuminate\Support\Collection
+function getAccessGroups() : AccessGroupsCollection
 {
     $group_ids = request()->input('middleware_access_group_ids');
 
@@ -17,7 +18,7 @@ function getAccessGroups() : \Illuminate\Support\Collection
         );
     }
 
-    return $group_ids;
+    return new AccessGroupsCollection($group_ids);
 }
 
 /**

--- a/app/Http/Controllers/Bible/BibleVersesController.php
+++ b/app/Http/Controllers/Bible/BibleVersesController.php
@@ -75,7 +75,15 @@ class BibleVersesController extends APIController
         $page           = checkParam('page') ?? 1;
 
         $access_group_ids = getAccessGroups();
-        $cache_params = [$limit, $page, $language_code, $this->key, $book_id, $chapter_id, $verse_number];
+        $cache_params = [
+            $limit,
+            $page,
+            $language_code,
+            $access_group_ids->toString(),
+            $book_id,
+            $chapter_id,
+            $verse_number
+        ];
         $cache_key = generateCacheSafeKey('bible_verses_by_language', $cache_params);
         $verses = cacheRememberByKey(
             $cache_key,
@@ -149,7 +157,15 @@ class BibleVersesController extends APIController
         $page           = checkParam('page') ?? 1;
         $access_group_ids = getAccessGroups();
 
-        $cache_params = [$limit, $page, $bible_id, $this->key, $book_id, $chapter_id, $verse_number];
+        $cache_params = [
+            $limit,
+            $page,
+            $bible_id,
+            $access_group_ids->toString(),
+            $book_id,
+            $chapter_id,
+            $verse_number
+        ];
         $cache_key = generateCacheSafeKey('bible_verses_by_bible', $cache_params);
         $verses = cacheRememberByKey(
             $cache_key,

--- a/app/Http/Controllers/Bible/LibraryController.php
+++ b/app/Http/Controllers/Bible/LibraryController.php
@@ -448,7 +448,15 @@ class LibraryController extends APIController
             return $arclight->volumes();
         }
 
-        $cache_params = [$dam_id, $media, $language_name, $iso, $updated, $organization, $version_code, $this->key];
+        $cache_params = [
+            $dam_id,
+            $media,
+            $language_name,
+            $iso, $updated,
+            $organization,
+            $version_code,
+            $access_group_ids->toString()
+        ];
         $cache_key = generateCacheSafeKey('v2_library_volume', $cache_params);
         $filesets = cacheRememberByKey(
             $cache_key,

--- a/app/Http/Controllers/Wiki/CountriesController.php
+++ b/app/Http/Controllers/Wiki/CountriesController.php
@@ -66,7 +66,7 @@ class CountriesController extends APIController
             $languages,
             $limit,
             $page, $is_bibleis_gideons,
-            $access_group_ids->implode(',')
+            $access_group_ids->toString()
         ];
         $cache_key = generateCacheSafeKey('countries_list', $cache_params);
 
@@ -143,7 +143,13 @@ class CountriesController extends APIController
 
         $access_group_ids = getAccessGroups();
 
-        $cache_params = [$GLOBALS['i18n_iso'], $limit, $page, $formatted_search_cache, $access_group_ids->implode(',')];
+        $cache_params = [
+            $GLOBALS['i18n_iso'],
+            $limit,
+            $page,
+            $formatted_search_cache,
+            $access_group_ids->toString()
+        ];
         $cache_key = generateCacheSafeKey('countries', $cache_params);
 
         $countries = cacheRememberByKey($cache_key, now()->addDay(), function () use ($limit, $formatted_search, $access_group_ids) {
@@ -231,7 +237,7 @@ class CountriesController extends APIController
     {
         $access_group_ids = getAccessGroups();
 
-        $cache_params = [$id, $GLOBALS['i18n_iso'], $access_group_ids->implode(',')];
+        $cache_params = [$id, $GLOBALS['i18n_iso'], $access_group_ids->toString()];
         $country = cacheRemember('countries', $cache_params, now()->addDay(), function () use ($id, $access_group_ids) {
             $country = Country::with(['languagesFiltered' => function ($query) use ($access_group_ids) {
                 $query->IsContentAvailable($access_group_ids)

--- a/app/Http/Controllers/Wiki/LanguageControllerV2.php
+++ b/app/Http/Controllers/Wiki/LanguageControllerV2.php
@@ -152,7 +152,7 @@ class LanguageControllerV2 extends APIController
             $img_size,
             $img_type,
             $additional,
-            $this->key
+            $access_group_ids->toString()
         ]);
 
         if ($sort_by === 'lang_code') {
@@ -399,7 +399,7 @@ class LanguageControllerV2 extends APIController
 
         $access_group_ids= getAccessGroups();
 
-        $cache_params = [$root, $iso, $media, $organization_id, $this->key];
+        $cache_params = [$root, $iso, $media, $organization_id, $access_group_ids->toString()];
         $languages = cacheRemember(
             'volumeLanguageFamily',
             $cache_params,

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -108,7 +108,7 @@ class LanguagesController extends APIController
             $GLOBALS['i18n_id'],
             $name,
             $include_translations,
-            $this->key,
+            $access_group_ids->toString(),
             $limit,
             $page,
             $is_bibleis_gideons,
@@ -213,7 +213,7 @@ class LanguagesController extends APIController
         $limit = min($limit, 50);
         $set_type_code = checkParam('set_type_code');
         $media = checkParam('media');
-        $access_group_ids = checkParam('middleware_access_group_ids', true);
+        $access_group_ids = getAccessGroups();
         $formatted_search = $this->transformQuerySearchText($search_text);
         $formatted_search_cache = str_replace(' ', '', $search_text);
 
@@ -227,7 +227,7 @@ class LanguagesController extends APIController
                 $limit,
                 $page,
                 $GLOBALS['i18n_id'],
-                $this->key,
+                $access_group_ids->toString(),
                 $media,
                 $set_type_code
             ]
@@ -310,8 +310,8 @@ class LanguagesController extends APIController
      */
     public function show($id)
     {
-        $cache_params = [$id, $this->key];
         $access_group_ids = getAccessGroups();
+        $cache_params = [$id, $access_group_ids->toString()];
 
         $language = cacheRemember('language', $cache_params, now()->addDay(), function () use ($id, $access_group_ids) {
             $language = Language::where('id', $id)->orWhere('iso', $id)

--- a/app/Models/User/AccessGroup.php
+++ b/app/Models/User/AccessGroup.php
@@ -87,11 +87,6 @@ class AccessGroup extends Model
         return $this->belongsToMany(AccessType::class, 'access_group_types')->whereIn('name', ['podcast'])->where('allowed', 1);
     }
 
-    public function keys()
-    {
-        return $this->hasMany(AccessGroupKey::class);
-    }
-
     public function user()
     {
         return $this->belongsTo(Key::class);

--- a/app/Models/User/AccessGroupKey.php
+++ b/app/Models/User/AccessGroupKey.php
@@ -77,7 +77,7 @@ class AccessGroupKey extends Model
      */
     public static function getAccessGroupIdsByApiKey(string $api_key) : Collection
     {
-        return  AccessGroupKey::select('access_group_id')
+        return AccessGroupKey::select('access_group_id')
             ->join('user_keys', function ($join) use ($api_key) {
                 $join->on('user_keys.id', '=', 'access_group_api_keys.key_id')
                     ->where('user_keys.key', $api_key);

--- a/app/Support/AccessGroupsCollection.php
+++ b/app/Support/AccessGroupsCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Collection;
+
+class AccessGroupsCollection extends Collection
+{
+    /**
+     * Get all of the items in the collection as a single string delimited by |.
+     *
+     * @return string
+     */
+    public function toString() : string
+    {
+        return $this->implode('|');
+    }
+}


### PR DESCRIPTION
# Description
To increase cache hits, we have removed the API key from all DBP cache keys. We now use the access_groups as a single string delimited by commas in the cache parameters. This approach will be effective because many API keys share the same access groups.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-553

## How Do I QA This
We should run the postman tests of the following folder and they have to pass.

- Access control tests:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-7b281e90-36a9-464d-aab0-feac43793bee
