### PR TITLE
FCBHDBP-574 Update the country_id filter logic in the v4_bible.all en…

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -171,7 +171,6 @@ class BiblesController extends APIController
                 $size_exclude,
                 $tag_exclude,
                 $limit,
-                $page,
                 $order_by,
                 $audio_timing
             ) {
@@ -209,7 +208,7 @@ class BiblesController extends APIController
                     }
                 })
                 ->when($country, function ($q) use ($country) {
-                    $q->whereHas('country', function ($query) use ($country) {
+                    $q->whereHas('countryLanguage', function ($query) use ($country) {
                         $query->where('countries.id', $country);
                     });
                 })

--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -4,6 +4,7 @@ namespace App\Models\Bible;
 
 use DB;
 use App\Models\Country\Country;
+use App\Models\Country\CountryLanguage;
 use App\Models\Language\Alphabet;
 use App\Models\Language\NumeralSystem;
 use App\Models\Organization\Organization;
@@ -282,6 +283,18 @@ class Bible extends Model
     public function language()
     {
         return $this->belongsTo(Language::class);
+    }
+
+    public function countryLanguage()
+    {
+        return $this->hasManyThrough(
+            Country::class,
+            CountryLanguage::class,
+            'language_id',
+            'id',
+            'language_id',
+            'country_id'
+        )->select(['countries.id as country_id','countries.continent','countries.name']);
     }
 
     public function country()


### PR DESCRIPTION
# Description
Update the country_id filter logic in the v4_bible.all endpoint. For now on, it will use the countryLanguage relationship to filter the bible records by country_id.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-574

## How Do I QA This
We should run the following postman test and they have to pass.

- Bibles - filtering language_code and country (NG)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ca05b6ed-610f-4e2d-801d-7837ae4f7761
- Bibles - filtering language_code and country (BR)
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0e882702-7958-41bd-879a-756008900372