### PR TITLE
FCBHDBP-570 Check and Validate endpoint to return the books and chapters for a specific fileset

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -5,6 +5,7 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\Response;
 use App\Support\AccessGroupsCollection;
+use App\Models\Bible\BibleFilesetSize;
 
 function getAccessGroups() : AccessGroupsCollection
 {
@@ -655,15 +656,22 @@ if (!function_exists('getTestamentString')) {
         }
         switch ($substring) {
             case 'O':
-                $testament = ['OT', 'C'];
+                $testament = [BibleFilesetSize::SIZE_OLD_TESTAMENT, BibleFilesetSize::SIZE_COMPLETE];
                 break;
 
             case 'N':
-                $testament = ['NT', 'C'];
+                $testament = [BibleFilesetSize::SIZE_NEW_TESTAMENT, BibleFilesetSize::SIZE_COMPLETE];
                 break;
 
             case 'P':
-                $testament = ['NTOTP', 'NTP', 'NTPOTP', 'OTNTP', 'OTP', 'P'];
+                $testament = [
+                    BibleFilesetSize::SIZE_NEW_TESTAMENT_OLD_TESTAMENT_PORTION,
+                    BibleFilesetSize::SIZE_NEW_TESTAMENT_PORTION,
+                    BibleFilesetSize::SIZE_NEW_TESTAMENT_PORTION_OLD_TESTAMENT_PORTION,
+                    BibleFilesetSize::SIZE_OLD_TESTAMENT_NEW_TESTAMENT_PORTION,
+                    BibleFilesetSize::SIZE_OLD_TESTAMENT_PORTION,
+                    BibleFilesetSize::SIZE_PORTION
+                ];
                 break;
             default:
                 $testament = [];

--- a/app/Http/Controllers/ApiMetadataController.php
+++ b/app/Http/Controllers/ApiMetadataController.php
@@ -4,11 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Models\Bible\Bible;
 use App\Models\Bible\BibleFileset;
-use App\Models\Organization\Asset;
 use App\Models\User\Changelog;
 use App\Traits\CallsBucketsTrait;
-use Carbon\Carbon;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Carbon;
 
 class ApiMetadataController extends APIController
 {

--- a/app/Models/Bible/BibleFilesetSize.php
+++ b/app/Models/Bible/BibleFilesetSize.php
@@ -30,6 +30,17 @@ use Illuminate\Database\Eloquent\Model;
  */
 class BibleFilesetSize extends Model
 {
+    public const SIZE_COMPLETE = 'C';
+    public const SIZE_NEW_TESTAMENT = 'NT';
+    public const SIZE_NEW_TESTAMENT_OLD_TESTAMENT_PORTION = 'NTOTP';
+    public const SIZE_NEW_TESTAMENT_PORTION = 'NTP';
+    public const SIZE_NEW_TESTAMENT_PORTION_OLD_TESTAMENT_PORTION = 'NTPOTP';
+    public const SIZE_OLD_TESTAMENT = 'OT';
+    public const SIZE_OLD_TESTAMENT_NEW_TESTAMENT_PORTION = 'OTNTP';
+    public const SIZE_OLD_TESTAMENT_PORTION = 'OTP';
+    public const SIZE_PORTION = 'P';
+    public const SIZE_STORIES = 'S';
+
     protected $connection = 'dbp';
     protected $table = 'bible_fileset_sizes';
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -540,3 +540,6 @@ Route::name('v4_bible.links')->get(
 
 # Podcast is not currently supported in DBP4, but will be in the near future.
 #Route::name('v4_internal_filesets.podcast')->get('bibles/filesets/{fileset_id}/podcast',    'Bible\BibleFilesetsPodcastController@index');
+
+// VERSION 4 | API status
+Route::name('status')->get('/status', 'ApiMetadataController@getStatus');


### PR DESCRIPTION
# Description
Return only the books associated with the column set_size_code of the fileset. We have added a constraint to validate that the `set_size_code` value in the `bible_fileset` column must be either equal to `C` (COMPLETE) or have the `book_testament` value from the `book` column contained within it. For example, if the `book_testament` value is `NT` and the `set_size_code` value is `NTP`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-570

## How Do I QA This
- We should execute the following postman test and it have to pass
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-cb709edf-b129-4d3e-83ba-9c29b5eeecf6
