### PR TITLE
FCBHDBP-577 Check the method to translate a plan because the value of playlist item duration is not being filled

### DIFF
--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -301,7 +301,7 @@ class PlaylistItems extends Model implements Sortable
         int $chapter_end,
         int $verse_start,
         int $verse_end,
-        Collection $transportStream,
+        SupCollection $transportStream,
         BibleFile $bible_file
     ) : Collection | array {
         if ($chapter_end === $chapter_start) {


### PR DESCRIPTION
# Description
Fix type parameter of method processVersesOnTransportStream.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-577

## How Do I QA This
We should run the following postman test and it have to pass
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-057468b4-8a06-4747-aa91-55261f9d7fe0
