### PR TITLE
FCBHDBP-569 Update v4_video_jesus_film_chapters and v4_video_jesus_film_chapter endpoints to catch all http errors from arclight API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "dbp",
             "dependencies": {
                 "babel-preset-es2015": "^6.24.1",
                 "babel-preset-stage-2": "^6.24.1",
@@ -10510,9 +10511,9 @@
             "dev": true
         },
         "node_modules/socket.io-parser": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-            "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
             "dev": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
# Description
Improve the handling of exceptions in concurrent requests when retrieving Jesus films from the Arclight API.

# Change Log
1. Implemented the `stream()` method from HTTP, as it is recommended for [Multiplexing Responses](https://symfony.com/doc/6.0/http_client.html#multiplexing-responses) according to the Symfony documentation.
2. To handle 300-599 status codes on our side when we are using multiplexing responses, we are now passing 'false' as an optional argument to all calls of methods like `getHeaders` and `getContent`.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-569

## How Do I QA This
We should execute the following 3 postman tests and they have to pass.

1. jesus-film LUK/7: https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-775def18-7408-401f-b399-74698172a53b
3. jesus-film dan LUK/18: https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0a2d10c2-fd8e-45f8-8c0b-734a254bdfd3
4. jesus-film eng LUK/18: https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-0b2646bb-d92d-418d-a8a2-6bdc59b14d70
