### PR TITLE
FCBHDBP-579 bibleis-web: invalid CDN request

### DIFF
--- a/app/Http/Controllers/Bible/StreamController.php
+++ b/app/Http/Controllers/Bible/StreamController.php
@@ -103,7 +103,7 @@ class StreamController extends APIController
                 ->select('hash_id', 'id', 'asset_id')
                 ->first();
 
-            $fileset_type = 'audio';
+            $fileset_type = BibleFileset::AUDIO;
 
             if (empty($fileset)) {
                 $fileset = BibleFileset::uniqueFileset($fileset_id, 'video_stream')
@@ -111,10 +111,12 @@ class StreamController extends APIController
                     ->first();
 
                 if (empty($fileset)) {
-                    return $this->setStatusCode(404)->replyWithError('No fileset found for the provided params');
+                    return $this
+                        ->setStatusCode(HttpResponse::HTTP_NOT_FOUND)
+                        ->replyWithError('No fileset found for the provided params');
                 }
 
-                $fileset_type = 'video';
+                $fileset_type = BibleFileset::VIDEO;
             }
 
             $file = $this->getFileFromLocation($fileset, $file_id_location);
@@ -127,7 +129,9 @@ class StreamController extends APIController
 
             $currentBandwidth = $file->streamBandwidth->where('file_name', $file_name)->first();
             if (!$currentBandwidth) {
-                return $this->setStatusCode(404)->replyWithError(trans('api.file_errors_404_size'));
+                return $this
+                    ->setStatusCode(HttpResponse::HTTP_NOT_FOUND)
+                    ->replyWithError(trans('api.file_errors_404_size'));
             }
             $transaction_id = random_int(0, 10000000);
 

--- a/app/Http/Controllers/Organization/FilmsController.php
+++ b/app/Http/Controllers/Organization/FilmsController.php
@@ -53,7 +53,7 @@ class FilmsController extends APIController
     {
         return $this->reply([
             [
-                'server'    => config('services.cdn.video_server'),
+                'server'    => config('services.cdn.server'),
                 'root_path' => 'video',
                 'protocol'  => 'https',
                 'CDN'       => 0,

--- a/config/services.php
+++ b/config/services.php
@@ -89,9 +89,8 @@ return [
 
     // CDN server
     'cdn' => [
-        'server' => env('CDN_SERVER', 'content.cdn.dbp-prod.dbp4.org'),
+        'server' => env('CDN_SERVER', 'd1gd73roq7kqw6.cloudfront.net'),
         'server_v2' => env('CDN_SERVER_V2', 'cloud.faithcomesbyhearing.com'),
-        'video_server' => env('CDN_VIDEO_SERVER', 'content.cdn.dbp-vid.dbp4.org'),
         'video_server_v2' => env('CDN_VIDEO_SERVER_V2', 'video.dbt.io'),
         'fonts_server' => env('CDN_FONTS_SERVER', 'cdn.bible.build'),
         'country_image_server' => env('MCDN_COUNTRY_IMAGE', 'dbp-mcdn.s3.us-west-2.amazonaws.com')


### PR DESCRIPTION
# Description
Update CDN url to replace the old `content.cdn.dbp-prod.dbp4.org` and `content.cdn.dbp-vid.dbp4.org` values.

This PR is related with the dbp-web PR:
- https://github.com/faithcomesbyhearing/dbp-web/pull/72

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-580

## NOTE :warning:
We will need to update some postman test to replace the new CDN URL: `d1gd73roq7kqw6.cloudfront.net`

## How Do I QA This
Run all [M] postman tests and they have to pass.
