### PR TITLE
FCBHDBP-589 Plans - Avoid that duplicated records when a day is Completed

### DIFF
--- a/app/Exceptions/MySQLErrorCode.php
+++ b/app/Exceptions/MySQLErrorCode.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Exceptions;
+
+class MySQLErrorCode 
+{
+    const DUPLICATE_ENTRY = 23000;
+}

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Plan;
 
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Spatie\Fractalistic\ArraySerializer;
 use App\Traits\AccessControlAPI;
 use App\Http\Controllers\APIController;
@@ -609,40 +610,54 @@ class PlansController extends APIController
         $user_is_member = $this->compareProjects($user->id, $this->key);
 
         if (!$user_is_member) {
-            return $this->setStatusCode(401)->replyWithError(trans('api.projects_users_not_connected'));
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_UNAUTHORIZED)
+                ->replyWithError(trans('api.projects_users_not_connected'));
         }
 
         $plan_day = PlanDay::where('id', $day_id)->first();
 
         if (!$plan_day) {
-            return $this->setStatusCode(404)->replyWithError('Plan Day Not Found');
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)
+                ->replyWithError('Plan Day Not Found');
         }
 
-        $user_plan = UserPlan::join('plans', function ($join) use ($user) {
-            $join->on('user_plans.plan_id', '=', 'plans.id')->where('user_plans.user_id', $user->id);
-        })->where('user_plans.plan_id', $plan_day->plan_id)
-            ->select('user_plans.*')
-            ->first();
+        $user_plan = UserPlan::getByPlanIdAndUserId($plan_day->plan_id, $user->id);
 
         if (!$user_plan) {
-            return $this->setStatusCode(404)->replyWithError('User Plan Not Found');
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)
+                ->replyWithError('User Plan Not Found');
         }
 
         $complete = checkParam('complete') ?? true;
         $complete = $complete && $complete !== 'false';
 
-        $user_plan = \DB::transaction(function () use ($complete, $plan_day, $user, $user_plan) {
-            if ($complete) {
-                $plan_day->complete($user->id);
-            } else {
-                $plan_day->unComplete($user->id);
-            }
+        $result = null;
+        try {
+            \DB::transaction(function () use ($complete, $plan_day, $user) {
+                if ($complete) {
+                    $plan_day->complete($user->id);
+                } else {
+                    $plan_day->unComplete($user->id);
+                }
 
-            $user_plan->calculatePercentageCompleted()->save();
-            return $user_plan;
-        });
+                return $plan_day;
+            });
+            $result = $complete ? 'completed' : 'not completed';
+        } catch (\Exception $e) {
+            \Log::error(
+                "Exception to complete Plan Day [user: {$user->id} plan ID: {$user_plan->id} plan day ID: {$day_id}]"
+            );
+            \Log::error($e);
+            return $this
+                ->setStatusCode(SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY)
+                ->replyWithError('The system is unable to process the completion of the plan day');
+        }
 
-        $result = $complete ? 'completed' : 'not completed';
+        $user_plan->calculatePercentageCompleted()->save();
+
         return $this->reply([
             'percentage_completed' => (int) $user_plan->percentage_completed,
             'message' => 'Plan Day ' . $result

--- a/app/Http/Controllers/Playlist/PlaylistsController.php
+++ b/app/Http/Controllers/Playlist/PlaylistsController.php
@@ -36,6 +36,7 @@ use League\Fractal\Pagination\IlluminatePaginatorAdapter;
 use App\Services\Plans\PlaylistService;
 use App\Services\Bibles\BibleFilesetService;
 
+
 class PlaylistsController extends APIController
 {
     use AccessControlAPI;
@@ -834,33 +835,37 @@ class PlaylistsController extends APIController
             $playlist_item = PlaylistItems::where('id', $item_id)->first();
 
             if (!$playlist_item) {
-                return $this->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)->replyWithError('Playlist Item Not Found');
+                return $this
+                    ->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)
+                    ->replyWithError('Playlist Item Not Found');
             }
 
-            $user_plan = UserPlan::join('plans', function ($join) use ($user) {
-                $join->on('user_plans.plan_id', '=', 'plans.id')->where('user_plans.user_id', $user->id);
-            })
-                ->join('plan_days', function ($join) use ($playlist_item) {
-                    $join
-                        ->on('plan_days.plan_id', '=', 'plans.id')
-                        ->where('plan_days.playlist_id', $playlist_item->playlist_id);
-                })
-                ->select('user_plans.*')
-                ->first();
+            $user_plan = UserPlan::getByPlaylistIdAndUserId($playlist_item->playlist_id, $user->id);
 
             if (!$user_plan) {
                 return $this->setStatusCode(SymfonyResponse::HTTP_NOT_FOUND)->replyWithError('User Plan Not Found');
             }
 
-            $complete = $complete && $complete !== 'false';
+            $result = null;
 
-            if ($complete) {
-                $playlist_item->complete();
-            } else {
-                $playlist_item->unComplete();
+            try {
+                $complete = $complete && $complete !== 'false';
+
+                if ($complete) {
+                    $playlist_item->complete();
+                } else {
+                    $playlist_item->unComplete();
+                }
+
+                $result = $complete ? 'completed' : 'not completed';
+            } catch(\Exception $e) {
+                \Log::error("Exception to complete Playlist Item [user: {$user->id} item id: {$item_id}]");
+                \Log::error($e);
+                return $this
+                    ->setStatusCode(SymfonyResponse::HTTP_UNPROCESSABLE_ENTITY)
+                    ->replyWithError('The system is unable to process the completion of the playlist item.');
             }
 
-            $result = $complete ? 'completed' : 'not completed';
             $user_plan->calculatePercentageCompleted()->save();
 
             return $this->reply([

--- a/app/Models/Plan/PlanDay.php
+++ b/app/Models/Plan/PlanDay.php
@@ -135,10 +135,16 @@ class PlanDay extends Model implements Sortable
         if (is_null($user_id)) {
             $user_id = Auth::user()->id;
         }
-        PlanDayComplete::updateOrCreate([
-            'user_id'     => $user_id,
-            'plan_day_id' => $this['id']
-        ]);
+
+        $days_complete_to_create = [
+            ['user_id' => $user_id, 'plan_day_id' => $this['id']]
+        ];
+
+        PlanDayComplete::upsert(
+            $days_complete_to_create,
+            ['user_id', 'plan_day_id'],
+            ['user_id', 'plan_day_id']
+        );
 
         $this->completePlaylistItems($this['id'], $user_id);
     }

--- a/app/Models/Plan/PlanDay.php
+++ b/app/Models/Plan/PlanDay.php
@@ -135,11 +135,10 @@ class PlanDay extends Model implements Sortable
         if (is_null($user_id)) {
             $user_id = Auth::user()->id;
         }
-        $completed_item = PlanDayComplete::firstOrNew([
+        PlanDayComplete::updateOrCreate([
             'user_id'     => $user_id,
             'plan_day_id' => $this['id']
         ]);
-        $completed_item->save();
 
         $this->completePlaylistItems($this['id'], $user_id);
     }
@@ -171,7 +170,11 @@ class PlanDay extends Model implements Sortable
         }
 
         if (!empty($inserts_items_completed)) {
-            return PlaylistItemsComplete::insert($inserts_items_completed);
+            return PlaylistItemsComplete::upsert(
+                $inserts_items_completed,
+                ['user_id', 'playlist_item_id'],
+                ['user_id', 'playlist_item_id']
+            );
         }
 
         return false;

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -616,11 +616,10 @@ class PlaylistItems extends Model implements Sortable
     public function complete()
     {
         $user = Auth::user();
-        $completed_item = PlaylistItemsComplete::firstOrNew([
+        PlaylistItemsComplete::updateOrCreate([
             'user_id'               => $user->id,
             'playlist_item_id'      => $this['id']
         ]);
-        $completed_item->save();
     }
 
     public function unComplete()

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -616,10 +616,16 @@ class PlaylistItems extends Model implements Sortable
     public function complete()
     {
         $user = Auth::user();
-        PlaylistItemsComplete::updateOrCreate([
-            'user_id'               => $user->id,
-            'playlist_item_id'      => $this['id']
-        ]);
+
+        $playlist_items_to_complete = [
+            ['user_id' => $user->id, 'playlist_item_id' => $this['id']]
+        ];
+
+        PlaylistItemsComplete::upsert(
+            $playlist_items_to_complete,
+            ['user_id', 'playlist_item_id'],
+            ['user_id', 'playlist_item_id']
+        );
     }
 
     public function unComplete()

--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -330,7 +330,11 @@ class PlanService
         }
 
         if (!empty($pitems_complete_to_create)) {
-            return PlaylistItemsComplete::insert($pitems_complete_to_create);
+            return PlaylistItemsComplete::upsert(
+                $pitems_complete_to_create,
+                ['user_id', 'playlist_item_id'],
+                ['user_id', 'playlist_item_id']
+            );
         }
 
         return false;


### PR DESCRIPTION
# Description
Prevent continuous storage of duplicate completed days in the `plan_days_completed` and `playlist_items_completed` tables. To accomplish this, we have taken the following steps:

1. Developed an SQL script to clean up data and thereafter, created unique key constraints on `plan_days_completed(user_id, plan_day_id)` and `playlist_items_completed(user_id, playlist_item_id) `:

```sql
-- playlist_items_completed
START TRANSACTION;

DROP TEMPORARY TABLE IF EXISTS playlist_items_completed_temp;

CREATE TEMPORARY TABLE playlist_items_completed_temp AS
SELECT pic.user_id, pic.playlist_item_id, COUNT(pic.user_id)
FROM playlist_items_completed pic
GROUP BY pic.user_id, pic.playlist_item_id 
HAVING COUNT(pic.user_id) > 1;

DELETE playlist_items_completed
FROM playlist_items_completed
INNER JOIN playlist_items_completed_temp
ON playlist_items_completed_temp.user_id = playlist_items_completed.user_id
AND playlist_items_completed_temp.playlist_item_id = playlist_items_completed.playlist_item_id;

INSERT INTO playlist_items_completed (user_id, playlist_item_id) SELECT user_id, playlist_item_id FROM playlist_items_completed_temp;

DROP TEMPORARY TABLE IF EXISTS playlist_items_completed_temp;

ALTER TABLE playlist_items_completed
ADD CONSTRAINT playlist_items_completed_user_id_playlist_item_id_unique UNIQUE (user_id, playlist_item_id);

COMMIT;
```

```sql
-- plan_days_completed
START TRANSACTION;

DROP TEMPORARY TABLE IF EXISTS plan_days_completed_temp;

CREATE TEMPORARY TABLE plan_days_completed_temp AS
SELECT pdc.user_id, pdc.plan_day_id, COUNT(pdc.user_id)
FROM plan_days_completed pdc
GROUP BY pdc.user_id, pdc.plan_day_id
HAVING COUNT(pdc.user_id) > 1;

DELETE plan_days_completed
FROM plan_days_completed
INNER JOIN plan_days_completed_temp
ON plan_days_completed_temp.user_id = plan_days_completed.user_id
AND plan_days_completed_temp.plan_day_id = plan_days_completed.plan_day_id;

INSERT INTO plan_days_completed (user_id, plan_day_id) SELECT user_id, plan_day_id FROM plan_days_completed_temp;

DROP TEMPORARY TABLE IF EXISTS plan_days_completed_temp;

ALTER TABLE plan_days_completed
ADD CONSTRAINT plan_days_completed_user_id_plan_day_id_unique UNIQUE (user_id, plan_day_id);

COMMIT;
```
1.1 plan_days_completed script
[plan_days_completed_remove_duplicate_records.sql.log](https://github.com/faithcomesbyhearing/dbp/files/12099819/plan_days_completed_remove_duplicate_records.sql.log)

1.2 [playlist_item_completed script
[playlist_item_completed_remove_duplicate_records.sql.log](https://github.com/faithcomesbyhearing/dbp/files/12099820/playlist_item_completed_remove_duplicate_records.sql.log)

2. Updated the API to allow multiple calls to complete the same plan day and playlist item without generating an error. To do this, I have utilized Laravel's upsert method. If the database throws a constraint error, we have added a try-catch block to handle the error, thereby preventing a 500 SQL error.

3. Removed logic that assumed a day was complete when the last item was completed. Consequently, I have also eliminated the logic to mark the plan day as complete when the last item is finished.


## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-589

## How Do I QA This
- You should run the bibleis with user session postman folder and it have to pass:

https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-7e8a4644-ee38-4d1d-abb5-24bb748ff57e
