### PR TITLE
FCBHDBP-494 API bug: update user country

### DIFF
--- a/app/Models/Country/Country.php
+++ b/app/Models/Country/Country.php
@@ -45,6 +45,11 @@ class Country extends Model
     public $incrementing = false;
     public $keyType = 'string';
 
+
+    const COUNTRY_CODE_USA = 'USA';
+    const COUNTRY_CODE_US = 'US';
+    const COUNTRY_CODE_UNITEDSTATES = 'UNITEDSTATES';
+
     /**
      * @OA\Property(
      *     title="Country Iso 3166-1",

--- a/app/Models/User/Profile.php
+++ b/app/Models/User/Profile.php
@@ -3,6 +3,7 @@
 namespace App\Models\User;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Country\Country;
 
 /**
  * App\Models\User\Profile
@@ -173,5 +174,38 @@ class Profile extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Validates a given country code.
+     *
+     * This method receives a country ID as an argument and checks if it corresponds
+     * to a valid country in the database. If the input is either "USA" or contains "UNITEDSTATES",
+     * it gets normalized to "US". The country ID is also cleaned of non-alphabetic characters and
+     * converted to uppercase to avoid common data inconsistencies.
+     *
+     * If the country ID is found in the database, the ID of the corresponding Country model instance
+     * is returned. If not, false is returned.
+     *
+     * @param string $country_id The country ID to validate. This is expected to be a string
+     *                           of alphabetic characters.
+     *
+     * @return bool|string Returns the ID of the Country model instance if the country ID is valid,
+     *                     false otherwise.
+     */
+    public static function IsValidCountry(string $country_id): bool | string
+    {
+        $country_id = strtoupper($country_id);
+        $country_id = preg_replace('/[^a-zA-Z]+/', '', $country_id);
+        // checks for data issues to get US errors
+        if ($country_id === Country::COUNTRY_CODE_USA ||
+            str_contains($country_id, Country::COUNTRY_CODE_UNITEDSTATES)
+        ) {
+            $country_id = Country::COUNTRY_CODE_US;
+        }
+
+        $valid_country = Country::find($country_id);
+
+        return $valid_country ? $valid_country->id : false;
     }
 }


### PR DESCRIPTION
# Description
The SQL issue about Integrity constraint violation won't happen again because the foreign has been removed. Also, currently, the API DBP has a method to validate if the  country ID is validate when a user profile must be created but I have done a refactor to improve the way it has been implemented.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-494

## How Do I QA This

- Run the following postman test and they have to pass:

1. https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ed0fe392-9d9e-4a74-9313-61af904a21f8

2. https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-9958d6ad-a89d-4b0a-a769-40f85408e344