### PR TITLE
FCBHDBP-590 Fix search/library endpoint related to the User Highlights

### DIFF
--- a/app/Models/User/Annotations.php
+++ b/app/Models/User/Annotations.php
@@ -20,4 +20,33 @@ class Annotations
         $this->bookmarks = $new_bookmarks;
         $this->highlights = $new_highlights;
     }
+
+    /**
+     * Filters a collection of annotations based on a search query.
+     *
+     * This method searches for the query string within the 'verse_text' and 'book_name' fields of each annotation in
+     * the provided collection. If the search query is found, the annotation is included in the returned collection.
+     *
+     * @param Collection|null $annotation_query The collection of annotations to be filtered. If null, the method will
+     * return false.
+     *
+     * @param string $search_query The string to search for within the 'verse_text' and 'book_name' of each annotation.
+     *
+     * @return bool|Collection Returns a filtered collection of annotations where the search query was found. If the
+     * input collection is null, the method will return false.
+     *
+     */
+    public static function filterAnnotations(?Collection $annotation_query, string $search_query) : bool|Collection
+    {
+        return $annotation_query->filter(function ($annotation) use ($search_query) {
+            $verse_text = $annotation->verse_text;
+            $book = $annotation->bibleBook;
+            $book_name = $book ? $book->name : null;
+
+            if (isset($verse_text, $book, $book_name)) {
+                return str_contains(strtolower($book_name . ' ' . $verse_text), $search_query);
+            }
+            return false;
+        });
+    }
 }

--- a/app/Models/User/Study/Highlight.php
+++ b/app/Models/User/Study/Highlight.php
@@ -269,4 +269,30 @@ class Highlight extends Model
 
         return $color;
     }
+
+    public function getVerseTextAttribute()
+    {
+        $chapter = $this['chapter'];
+        $verse_start = $this['verse_start'];
+        $verse_end = $this['verse_end'] ? $this['verse_end'] : $verse_start;
+        $bible = $this->bible;
+
+        if (!$bible) {
+            return '';
+        }
+
+        $text_fileset = $bible->filesets->firstWhere('set_type_code', 'text_plain');
+        if (!$text_fileset) {
+            return '';
+        }
+
+        return BibleFilesetService::getRangeVersesTextFilterBy(
+            $bible,
+            $text_fileset->hash_id,
+            $this['book_id'],
+            $verse_start,
+            $verse_end,
+            $chapter
+        );
+    }
 }

--- a/app/Models/User/Study/UserAnnotationTrait.php
+++ b/app/Models/User/Study/UserAnnotationTrait.php
@@ -3,7 +3,6 @@
 namespace App\Models\User\Study;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Schema;
 use App\Models\Playlist\PlaylistItems;

--- a/app/Transformers/UserBookmarksTransformer.php
+++ b/app/Transformers/UserBookmarksTransformer.php
@@ -42,6 +42,7 @@ class UserBookmarksTransformer extends TransformerAbstract
         return [
           'id' => (int) $bookmark->id,
           'bible_id' => (string) $bookmark->bible_id,
+          'bible_abbr' => (string) $bookmark->bible_id,
           'book_id' => (string) $bookmark->book_id,
           'book_name' => (string) optional($bookmark->bibleBook)->name,
           'chapter' => (int) $bookmark->chapter,


### PR DESCRIPTION
# Description
I have fixed the logic to retrieve highlight records, ensuring that the verse text is taken into account when retrieving highlights. Additionally, I have optimized the queries to retrieve bookmarks, highlights, and notes records, reducing the number of queries being invoked.

- Example with the current logic
![Screenshot from 2023-08-01 15-00-49](https://github.com/faithcomesbyhearing/dbp/assets/73488660/df4829b8-d07d-418e-87f8-ae18e1b005ea)

- Example with the changes of this PR
![Screenshot from 2023-08-01 15-00-53](https://github.com/faithcomesbyhearing/dbp/assets/73488660/0048590f-c6f4-4a8d-beab-710bbfc35415)

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-590

## How Do I QA This
We can execute the following postman tests and they have to pass:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-fa5533f5-0559-4712-ab83-b1bbfdd4875e

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-5da2cc82-7248-4fdb-a65a-fc69ceaef9ad
