### PR TITLE
FCBHDBP-596 GET Plan by ID - Update days array to include an empty key

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -292,6 +292,8 @@ class PlansController extends APIController
             if ($show_text) {
                 $this->plan_service->setVerseTextToEachPlaylistItem($plan);
             }
+        } else {
+            $this->plan_service->setFlagEmptyPlaylistForEachPlanDay($plan);
         }
 
         return $this->reply(fractal(

--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -396,6 +396,31 @@ class PlanService
     }
 
     /**
+     * Assigns a flag to each plan day within a given Plan to indicate if its associated playlist has any items.
+     *
+     * This method iterates over all days of the given Plan. For each day, it checks if the associated playlist
+     * contains any items. If the playlist is empty, it attaches a flag (`playlist_is_empty`) to the plan day.
+     *
+     * @param Plan $plan The Plan model instance for which the days' playlists need to be checked.
+     *
+     * @return void
+     */
+    public function setFlagEmptyPlaylistForEachPlanDay(Plan $plan) : void
+    {
+        $day_playlist_ids = [];
+
+        foreach ($plan->days as $day) {
+            $day_playlist_ids[] = $day->playlist_id;
+        }
+
+        $playlists = Playlist::findPlaylistWithAttachedItems($day_playlist_ids);
+
+        foreach ($plan->days as $day) {
+            $day->playlist_is_empty = !isset($playlists[$day->playlist_id]);
+        }
+    }
+
+    /**
      * For each play list item that belong to a Plan, it will create the verse_text property for the given Plan Object
      *
      * @param Plan $plan

--- a/app/Transformers/PlanDayPlaylistItemsTransformer.php
+++ b/app/Transformers/PlanDayPlaylistItemsTransformer.php
@@ -31,6 +31,8 @@ class PlanDayPlaylistItemsTransformer extends PlanTransformerBase
 
                 if ($this->params['show_details']) {
                     $day_result["playlist"] = $this->parsePlaylistData($day->playlist);
+                } else {
+                    $day_result["playlist_is_empty"] = $day->playlist_is_empty;
                 }
 
                 return $day_result;


### PR DESCRIPTION
# Description
Update The `GET /plans/:id` endpoint to Add a flag to each plan day within a specific plan to indicate if its associated playlist has any items.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-596

## How Do I QA This
- You should run the following postman test and it has to pass
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-05e22cf4-7a58-4f4e-93d7-541cdeb6e8d3
