### PR TITLE
FCBHDBP-591 Specific issue to translate plan from "Psalm a Day" plan to "Spanish Languaje Actual" bible

### DIFF
--- a/app/Services/Plans/PlanService.php
+++ b/app/Services/Plans/PlanService.php
@@ -479,7 +479,7 @@ class PlanService
         $bible,
         $audio_fileset_types,
         $bible_audio_filesets
-    ) : Array {
+    ) : array {
         $translated_items = [];
         $metadata_items = [];
         $total_translated_items = 0;
@@ -505,7 +505,10 @@ class PlanService
                     $has_translation = isset($preferred_fileset);
                     $is_streaming = true;
 
-                    if ($has_translation && $books_target_bible->has($item->book_id)) {
+                    if ($has_translation &&
+                        $books_target_bible->has($item->book_id) &&
+                        $preferred_fileset->hasFileRelatedBookAndChapter($item->book_id, $item->chapter_start)
+                    ) {
                         $item->fileset_id = $preferred_fileset->id;
                         $is_streaming = $preferred_fileset->set_type_code === 'audio_stream'
                             || $preferred_fileset->set_type_code === 'audio_drama_stream';


### PR DESCRIPTION
# Description

Refine the plan translation logic to better validate the availability of a specific Bible file for a given book and chapter in a target audio fileset. This enhancement addresses a scenario where a user attempts to translate the 'Psalm a Day' plan into the "Spanish Languaje Actual" Bible (Bible ID: SPNTLA). Although the target Bible has an associated audio fileset (SPNTLAP2DA), this fileset is missing the Bible file for the book "PSA". Interestingly, a relationship does exist between the Bible and the book in the database, but it is only to the plain text fileset.

 ## NOTE 
@bradflood, can you confirm if there's an index created for the `plan_id` column in the `user_playlists` table of the `dbp_users` database? I ask because having this index significantly enhances the performance of the translate endpoint, especially when the API runs queries involving `user_playlists` and filters by the `plan_id` column.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-591

## How Do I QA This
- You should run the following postman test to Translate Psalm a Day To Spanish Languaje Actual and it has to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-68055a3c-189a-4ad0-a556-a6ba0a19b70c

- You should run the following postman test to Translate Psalm a Day To English KJV and it has to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e3ffd74c-9afe-47be-a116-2af7b20d832a