### PR TITLE
FCBHDBP-605 HotFix - Fix values for verse_start and verses parameter in the translate endpoint

### DIFF
--- a/app/Services/Plans/PlaylistItemService.php
+++ b/app/Services/Plans/PlaylistItemService.php
@@ -209,6 +209,8 @@ class PlaylistItemService
                 foreach ($bible_verses_indexed[$item_to_create['book_id']] as $chapter => $verse_count) {
                     if ((int) $chapter >= $item_to_create['chapter_start'] &&
                         (int) $chapter <= $item_to_create['chapter_end'] &&
+                        !is_null($item_to_create['verse_start']) &&
+                        !is_null($item_to_create['verse_end']) &&
                         (int) $item_to_create['verse_start'] <= (int) $verse_count &&
                         (int) $item_to_create['verse_end'] <= (int) $verse_count &&
                         (int) $item_to_create['verse_end'] >= (int) $item_to_create['verse_start']


### PR DESCRIPTION
# Description
It must ensure that the 'verse_start' and 'verse_end' are not empty in order to accurately calculate the verse count using the start and end limits.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-605

## How Do I QA This
We need to run the following two postman test and they have to pass:

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-5efdb481-2849-4dc9-bc44-0c44fd5f56d6?active-environment=810fd94b-9392-43e2-9f13-943e8d323135

- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e3ffd74c-9afe-47be-a116-2af7b20d832a?active-environment=810fd94b-9392-43e2-9f13-943e8d323135