### PR TITLE
Limit newrelic/php_agent.log

### DIFF
--- a/.platform/hooks/prebuild/install_newrelic.sh
+++ b/.platform/hooks/prebuild/install_newrelic.sh
@@ -20,6 +20,6 @@ cd .. && rm newrelic-php5.tar.gz
 # Configure newrelic.ini
 echo extension=newrelic.so | tee /etc/php.d/newrelic.ini
 echo newrelic.enabled=true | tee -a /etc/php.d/newrelic.ini
-echo newrelic.loglevel=debug | tee -a /etc/php.d/newrelic.ini
+echo newrelic.loglevel=info | tee -a /etc/php.d/newrelic.ini
 echo newrelic.license=\"$NEW_RELIC_LICENSE_KEY\" | tee -a /etc/php.d/newrelic.ini
 echo newrelic.appname=\"$NEW_RELIC_APP_NAME\" | tee -a /etc/php.d/newrelic.ini


### PR DESCRIPTION
Fix for Bug 2018

# Description
This change simply changes the newrelic.loglevel from "debug" to "info".
The "debug" level is producing an immense amount of logs, that don't appear to be useful beyhond debugging the php agent itself.

## Issue Link
[Bug 2018](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2018)

## How Do I QA This
Once deployed, look at connect to a beanstalk ec2 instance, and tail the /var/log/newrelic/php_agent.log.  You should only see info level and up.

## Note - we may want to put a logrotation cron in place after this, but want to get a feel for the log behavior after this change.