### PR TITLE
Tasks 2125 and 2006. The scopeIsContentAvailable method has been upda…

### DIFF
--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -437,6 +437,14 @@ class Bible extends Model
             return $query->select(\DB::raw(1))
                 ->from('access_group_filesets as agf')
                 ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
+                ->join(
+                    'bible_filesets as abf',
+                    function ($join) {
+                        $join->on('abf.hash_id', '=', 'bfc.hash_id')
+                            ->where('abf.content_loaded', true)
+                            ->where('abf.archived', false);
+                    }
+                )
                 ->whereColumn('bibles.id', '=', 'bfc.bible_id')
                 ->whereIn('agf.access_group_id', $access_group_ids);
         });

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -240,17 +240,15 @@ class BibleFileset extends Model
         Builder $query,
         \Illuminate\Support\Collection $access_group_ids
     ) : Builder {
-        return $query->whereExists(function (QueryBuilder $query) use ($access_group_ids) {
-            return $query->select(\DB::raw(1))
-                ->from('access_group_filesets as agf')
-                ->whereColumn('agf.hash_id', '=', 'bible_filesets.hash_id')
-                ->whereExists(function (QueryBuilder $subquery) use ($access_group_ids) {
-                    return $subquery->select(\DB::raw(1))
-                        ->from('access_group_filesets as agf2')
-                        ->whereColumn('agf.hash_id', '=', 'agf2.hash_id')
-                        ->whereIn('agf2.access_group_id', $access_group_ids);
-                });
-        });
+        return $query
+            ->where('bible_filesets.content_loaded', true)
+            ->where('bible_filesets.archived', false)
+            ->whereExists(function (QueryBuilder $query) use ($access_group_ids) {
+                return $query->select(\DB::raw(1))
+                    ->from('access_group_filesets as agf')
+                    ->whereColumn('agf.hash_id', '=', 'bible_filesets.hash_id')
+                    ->whereIn('agf.access_group_id', $access_group_ids);
+            });
     }
 
     public static function getsetTypeCodeFromMedia($media)

--- a/app/Models/Bible/BibleFilesetConnection.php
+++ b/app/Models/Bible/BibleFilesetConnection.php
@@ -80,6 +80,15 @@ class BibleFilesetConnection extends Model
         return $query->whereExists(function ($query) use ($access_group_ids) {
             return $query->select(\DB::raw(1))
                 ->from('access_group_filesets as agf')
+                ->join(
+                    'bible_filesets as abf',
+                    function ($join) {
+                        $join->on('abf.hash_id', '=', 'agf.hash_id')
+                            ->where('abf.content_loaded', true)
+                            ->where('abf.archived', false)
+                            ;
+                    }
+                )
                 ->whereColumn('agf.hash_id', '=', 'bible_fileset_connections.hash_id')
                 ->whereIn('agf.access_group_id', $access_group_ids);
         });

--- a/app/Models/Bible/BibleFilesetLookup.php
+++ b/app/Models/Bible/BibleFilesetLookup.php
@@ -132,8 +132,7 @@ class BibleFilesetLookup extends Model
             ->whereIn('id', $access_group_by_user_key)
             ->whereIn('id', getDownloadAccessGroupList())
             ->get()
-            ->pluck('id')
-            ->toArray();
+            ->pluck('id');
 
         return BibleFileset::select([
             'bible_filesets.id AS filesetid',
@@ -162,7 +161,7 @@ class BibleFilesetLookup extends Model
         })
         ->whereNotIn('bible_filesets.set_type_code', ['text_format'])
         ->where('bible_filesets.id', 'NOT LIKE', '%DA16')
-        ->hasAccessGroup($download_access_group_array_ids)
+        ->isContentAvailable($download_access_group_array_ids)
         ->orderBy('bible_filesets.id')
         ->paginate($limit);
     }

--- a/app/Models/Bible/BibleVerse.php
+++ b/app/Models/Bible/BibleVerse.php
@@ -195,8 +195,16 @@ class BibleVerse extends Model
         return $query->whereExists(function ($sub_query) use ($access_group_ids) {
             return $sub_query->select(\DB::raw(1))
                 ->from('access_group_filesets AS agf')
+                ->join(
+                    'bible_filesets as abf',
+                    function ($join) {
+                        $join->on('abf.hash_id', '=', 'agf.hash_id')
+                            ->where('abf.content_loaded', true)
+                            ->where('abf.archived', false);
+                    }
+                )
                 ->whereIn('agf.access_group_id', $access_group_ids)
-                ->whereColumn('agf.hash_id', '=', 'bible_filesets.hash_id');
+                ->whereColumn('agf.hash_id', '=', 'bible_verses.hash_id');
         });
     }
 

--- a/app/Models/Language/LanguageTranslation.php
+++ b/app/Models/Language/LanguageTranslation.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-use App\Models\Bible\BibleFileset;
+use App\Models\Language\Language;
 
 /**
  * App\Models\Language\LanguageTranslation
@@ -180,19 +180,7 @@ class LanguageTranslation extends Model
 
         return $query->whereExists(
             function (QueryBuilder $query) use ($access_group_ids, $from_table, $bible_fileset_filters) {
-                $query->select(\DB::raw(1))
-                    ->from('access_group_filesets as agf')
-                    ->join('bible_fileset_connections as bfc', 'agf.hash_id', 'bfc.hash_id')
-                    ->join('bibles as b', 'bfc.bible_id', 'b.id');
-
-                if (!empty($bible_fileset_filters)) {
-                    $query->addWhereExistsQuery(
-                        BibleFileset::from('bible_filesets', 'bfst')
-                            ->select(\DB::raw(1))
-                            ->filterBy($bible_fileset_filters)
-                            ->whereColumn('bfst.hash_id', 'bfc.hash_id')->getQuery()
-                    );
-                }
+                $query = Language::buildContentAvailabilityQuery($query, $access_group_ids, $bible_fileset_filters);
 
                 return $query->whereColumn(
                     $from_table.'.language_source_id',


### PR DESCRIPTION
# Description
The scopeIsContentAvailable method has been updated to take into account the content_loaded flag. Filesets will be excluded if the content has not been loaded and the content_loaded flag is set to false. Additionally, filesets will be excluded if the archived flag is true.

## Issue Link
[User Story 2125](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2125): Public API: modify scopeIsContentAvailable to exclude filesets for which no content is loaded

[User Story 2006](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2006): Media should not be returned from the Public API when archived

## How Do I QA This
Run all [M] postman test

## Notes 1
The following postman test return a total of record different but I have validated and the records that the API was considered before don't have content loaded and so I consider that the current response is ok: https://web.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b7c5cc2e-3170-466a-b04d-668d42fbfbf2?active-environment=810fd94b-9392-43e2-9f13-943e8d323135

## Notes 2
The following SQL statement have to be executed to update the bible_filesets entity

```sql
-- Alter table
ALTER TABLE `bible_filesets` ADD COLUMN `content_loaded` TINYINT(1) NOT NULL DEFAULT 0;

ALTER TABLE `bible_filesets` ADD COLUMN `archived` TINYINT(1) NOT NULL DEFAULT 0;
```
```sql
-- Set the flag content_loaded if the fileset has content loaded
UPDATE bible_filesets SET content_loaded = TRUE 
WHERE EXISTS (
	SELECT bf.hash_id
	FROM bible_files bf
	WHERE bible_filesets.hash_id = bf.hash_id 
) OR EXISTS (
	SELECT bv.hash_id
	FROM bible_verses bv
	WHERE bible_filesets.hash_id = bv.hash_id
);
```