### PR TITLE
2136-text-plain-content-loaded-flag

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -430,6 +430,8 @@ class BibleFileset extends Model
                 return $subquery->select(\DB::raw(1))
                     ->from('bible_filesets', 'bfctext')
                     ->where('bfctext.set_type_code', BibleFileset::TYPE_TEXT_PLAIN)
+                    ->where('bfctext.content_loaded', true)
+                    ->where('bfctext.archived', false)
                     ->whereColumn('bfctext.set_type_code', '=', $from_table.'.set_type_code')
                     ->where(
                         DB::raw(\sprintf('CHAR_LENGTH(%s.id)', $from_table)),


### PR DESCRIPTION
In production, for text_plain, there is only the six character ENGKJV

in NEWDATA, there is now a ten character ENGKJVN_ET, which is not loaded.

The logic to prefer the ten character text fileset did not consider the possibility that the ten character fileset was not loaded