### PR TITLE
Task-2136 API: ENGKJV text plain not returning data

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -199,8 +199,13 @@ class BibleFileset extends Model
             });
     }
 
-    public function scopeUniqueFileset($query, $id = null, $fileset_type = null, $ambigious_fileset_type = false, $testament_filter = null)
-    {
+    public function scopeUniqueFileset(
+        $query,
+        $id = null,
+        $fileset_type = null,
+        $ambigious_fileset_type = false,
+        $testament_filter = null
+    ) {
         $version = (int) checkParam('v');
         return $query->when($id, function ($query) use ($id, $version) {
             $query->where(function ($query) use ($id, $version) {
@@ -210,15 +215,7 @@ class BibleFileset extends Model
                         ->orWhere('bible_filesets.id', 'like', substr($id, 0, 6))
                         ->orWhere('bible_filesets.id', 'like', substr($id, 0, -2) . '%');
                 } else {
-                    $query->where('bible_filesets.id', $id)
-                        ->orWhere(function ($query) use ($id) {
-                            $query->whereIn('bible_filesets.hash_id', function ($sub_query) use ($id) {
-                                $sub_query
-                                    ->select('hash_id')
-                                    ->from('bible_fileset_connections')
-                                    ->where('bible_id', 'LIKE', $id . '%');
-                            });
-                        });
+                    $query->where('bible_filesets.id', $id);
                 }
             });
         })
@@ -233,7 +230,9 @@ class BibleFileset extends Model
             } else {
                 $query->where('bible_filesets.set_type_code', $fileset_type);
             }
-        });
+        })
+        ->where('bible_filesets.content_loaded', true)
+        ->where('bible_filesets.archived', false);
     }
 
     public function scopeIsContentAvailable(


### PR DESCRIPTION
# Description
It has added feature to support the new columns: content_loaded and archived.

# Issue
I can recreate the issue when I create a new record with id = ENGKJVN_ET and content_loaded=true. The problem come about because the current logic does not filter by the content_loaded and archived flags, and it retrieves the first row returned by the database. However, I think the old logic can be removed because it could return incorrect data in the future when the database has content loaded for both types of filesets: six characters and 10 characters. This method is specific and should return the attached information to the given fileset ID, it should not attempt to return a 10-character fileset when the given fileset ID is a six-character fileset. Based on this, I think we can remove this code:

```php

->orWhere(function ($query) use ($id) {
    $query->whereIn('bible_filesets.hash_id', function ($sub_query) use ($id) {
        $sub_query
            ->select('hash_id')
            ->from('bible_fileset_connections')
            ->where('bible_id', 'LIKE', $id . '%');
    });
});
```

We have another method to prevent returning the six-character fileset when the 10-character fileset exists (e.g. when you use the endpoint to retrieve the filesets for a specific Bible) so, I think this method should not support this feature

## Issue Link
[Bug 2136](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2136): API: ENGKJV text plain not returning data

## How Do I QA This
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-8f633d94-6b16-47e3-ad36-26d69f109b07?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
