### PR TITLE
FCBHDBP-608 Extend the sort feature of the endpoint to search the verse

### DIFF
--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -232,6 +232,7 @@ class TextController extends APIController
         if ($sort_by === 'book_order') {
             $select_columns[] = BibleBook::getBookOrderSelectColumnExpressionRaw($bible->versification, 'book_order');
             $verses->orderBy('book_order')
+                ->orderBy('bible_verses.chapter')
                 ->orderBy('bible_verses.verse_sequence');
         }
 


### PR DESCRIPTION
# Description
Fix the feature to sort the results of the verse search endpoint to include the chapter. This feature will only be enabled when the query parameter 'sort_by=book_order'.

This PR is related with the PR: https://github.com/faithcomesbyhearing/dbp/pull/976

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-608

## How Do I QA This
You should run the following postman request and it has to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e91b2ed7-a37d-476e-a32a-bf3674bbde05?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
