### PR TITLE
FCBHDBP-609, The playlist endpoint is not returning the verse text when both the new (10-character) and old (6-character) plain text filesets exist

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -174,20 +174,29 @@ class BibleFileset extends Model
      */
     public static function filesetTypeTextPlainAssociated(?string $fileset_id) : BibleFileset|null
     {
-        $filset_associated = BibleFileset::select(['hash_id', 'id', 'set_size_code'])
+        $fileset_associated = BibleFileset::select(['hash_id', 'id', 'set_size_code'])
             ->with('bible')
             ->where("id", $fileset_id)
             ->first();
 
         $query = BibleFileset::select('bible_filesets.*')
             ->join('bible_fileset_connections as connection', 'connection.hash_id', 'bible_filesets.hash_id')
-            ->where('connection.bible_id', $filset_associated->bible->first()->id)
+            ->where('connection.bible_id', $fileset_associated->bible->first()->id)
             ->where('set_type_code', BibleFileset::TYPE_TEXT_PLAIN)
             ->where('archived', false)
             ->where('content_loaded', true);
 
         $fileset = $query
-            ->where('set_size_code', $filset_associated["set_size_code"])
+            ->where('set_size_code', $fileset_associated["set_size_code"])
+            ->first();
+
+        if ($fileset && $fileset["id"]) {
+            return $fileset;
+        }
+
+        // E.g fileset_associated = NT and text plain = NTP
+        $fileset = $query
+            ->whereLike('set_size_code', 'LIKE', '%'.$fileset_associated["set_size_code"].'%')
             ->first();
 
         if ($fileset && $fileset["id"]) {

--- a/app/Models/Playlist/PlaylistItems.php
+++ b/app/Models/Playlist/PlaylistItems.php
@@ -790,9 +790,9 @@ class PlaylistItems extends Model implements Sortable
     /**
      * Get unique filesets using given playlist ids
      *
-     * @param Illuminate\Support\Collection $playlist_ids
+     * @param \Illuminate\Support\Collection $playlist_ids
      *
-     * @return Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection
      */
     public static function getUniqueFilesetsByPlaylistIds(Array|SupCollection $playlist_ids) : SupCollection
     {

--- a/app/Services/Plans/PlaylistService.php
+++ b/app/Services/Plans/PlaylistService.php
@@ -207,7 +207,7 @@ class PlaylistService
     }
 
     /**
-     * Check a given playlist items if each items has a valid filset ID and return a valid playlist items array
+     * Check a given playlist items if each items has a valid fileset ID and return a valid playlist items array
      *
      * @param array $playlist_items
      * @return array


### PR DESCRIPTION
# Description
It has improved the logic for retrieving the fileset of the plain text type when the playlist item needs to return the text associated with the audio fileset.

## Issue Link
https://fullstacklabs.atlassian.net/browse/FCBHDBP-609

## How Do I QA This
- You should run the postman tests in the following folder and they have to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-98d4bf15-9922-4a23-a876-2ec50fdd0f77?active-environment=2465063f-c35d-430f-839c-7cbb993d3a47

- You should run the following postman test in dev and it have to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b52b3ec5-88b5-40a4-8e32-db43e79cbfe1?active-environment=2465063f-c35d-430f-839c-7cbb993d3a47
