### PR TITLE
FCBHDBP-609 The playlist endpoint is not returning the verse text when both the new (10-character) and old (6-character) plain text filesets exist

### DIFF
--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -164,6 +164,15 @@ class BibleFileset extends Model
         return $this->hasManyThrough(Font::class, BibleFilesetFont::class, 'hash_id', 'id', 'hash_id', 'font_id');
     }
 
+    protected static function subqueryFilesetTypeTextPlainAssociated(?string $bible_id) : Builder
+    {
+        return BibleFileset::select('bible_filesets.*')
+            ->join('bible_fileset_connections as connection', 'connection.hash_id', 'bible_filesets.hash_id')
+            ->where('connection.bible_id', $bible_id)
+            ->where('set_type_code', BibleFileset::TYPE_TEXT_PLAIN)
+            ->where('archived', false)
+            ->where('content_loaded', true);
+    }
     /**
      * Retrieves an associated fileset of type 'text plain' based on set size codes.
      *
@@ -179,12 +188,9 @@ class BibleFileset extends Model
             ->where("id", $fileset_id)
             ->first();
 
-        $query = BibleFileset::select('bible_filesets.*')
-            ->join('bible_fileset_connections as connection', 'connection.hash_id', 'bible_filesets.hash_id')
-            ->where('connection.bible_id', $fileset_associated->bible->first()->id)
-            ->where('set_type_code', BibleFileset::TYPE_TEXT_PLAIN)
-            ->where('archived', false)
-            ->where('content_loaded', true);
+        $bible_id = $fileset_associated->bible->first()->id;
+
+        $query = self::subqueryFilesetTypeTextPlainAssociated($bible_id);
 
         $fileset = $query
             ->where('set_size_code', $fileset_associated["set_size_code"])
@@ -195,8 +201,9 @@ class BibleFileset extends Model
         }
 
         // E.g fileset_associated = NT and text plain = NTP
+        $query = self::subqueryFilesetTypeTextPlainAssociated($bible_id);
         $fileset = $query
-            ->whereLike('set_size_code', 'LIKE', '%'.$fileset_associated["set_size_code"].'%')
+            ->where('set_size_code', 'LIKE', '%'.$fileset_associated["set_size_code"].'%')
             ->first();
 
         if ($fileset && $fileset["id"]) {
@@ -204,6 +211,7 @@ class BibleFileset extends Model
         }
 
         // If no specific fileset is found, default to SIZE_COMPLETE (six character fileset)
+        $query = self::subqueryFilesetTypeTextPlainAssociated($bible_id);
         return $query
             ->where('set_size_code', BibleFilesetSize::SIZE_COMPLETE)
             ->first();
@@ -500,7 +508,7 @@ class BibleFileset extends Model
                 // the 10-character fileset.
                 return $this->subqueryConditionToExcludeOldTextFormat($subquery, $from_table)
                     ->whereColumn('bfctext.set_size_code', '=', $from_table.'.set_size_code');
-            })->whereNot(function (\Illuminate\Database\Eloquent\Builder $subquery) use ($from_table) {
+            })->whereNot(function (Builder $subquery) use ($from_table) {
                 // Check for the existence of a complete text format for the six-character fileset, which
                 // includes NT and OT sizes of the 10-character fileset. It will ensure that both NT and
                 // OT exist to avoid returning the six-character fileset.
@@ -513,7 +521,7 @@ class BibleFileset extends Model
                         ->where($from_table.'.set_size_code', '=', BibleFilesetSize::SIZE_COMPLETE)
                         ->where('bfctext.set_size_code', 'LIKE', '%'.BibleFilesetSize::SIZE_OLD_TESTAMENT.'%');
                 });
-            })->whereNot(function (\Illuminate\Database\Eloquent\Builder $subquery) use ($from_table) {
+            })->whereNot(function (Builder $subquery) use ($from_table) {
                 // Check for the existence of partial text formats for the six-character fileset
                 // (e.g., size_type=NTOTP) with NT and OT sizes of the 10-character fileset. It will ensure
                 // that both NT and OT exist to avoid returning the six-character fileset.


### PR DESCRIPTION
# Description
Fixed the method filesetTypeTextPlainAssociated to reuse the common query when retrieving the plain text fileset associated with an audio fileset.

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->

## How Do I QA This

## How Do I QA This
Run the following postman test
1. Bible ID BULBOB: Return fileset BULBOB (6 character) and BULBOBN_ET (10 character)
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-7d50c3c3-2522-4816-bbd5-054931d4497d?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
2. Bible ID ENGWEB: Don't return ENGWEBN  (6 character)  and Return new filesets: ENGWEBN_ET and ENGWEBO_ET
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ee20de37-90e3-488a-b68b-412cb6a81f13?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
3. Bibles: AKEBSS, AHKTBS and AHABLG
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6d43e4db-3850-4eea-a7f1-29bf025f2f35?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-e76dddfd-b0ac-4a13-aa1a-b3914895ba07?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-7bcbc20c-93b2-4770-b4ba-ffceb70295ed?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
4. Playlist Prayer:
- https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-89906814-41d0-4d13-b8e6-d2a58a3fbf21?active-environment=810fd94b-9392-43e2-9f13-943e8d323135
