### PR TITLE
 FCBHDBP-619 Add sort by last_interaction in getPlans

### DIFF
--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -514,6 +514,7 @@ class PlansController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\Parameter(name="days", in="query", required=true, @OA\Schema(type="integer"), description="Number of days to add to the plan"),
+     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="true"), description="If new days to add should be added to end of list of days")
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -566,10 +567,14 @@ class PlansController extends APIController
             ->where('plan_id', $plan->id)
             ->where('user_id', $user->id)
             ->get()->pluck('id');
-        $plan_days_data = $new_playlists->map(function ($item) use ($plan) {
+
+        $add_to_end = checkParam('add_to_end') ?? false;
+
+        $plan_days_data = $new_playlists->map(function ($item, $index) use ($plan, $add_to_end, $current_days_size) {
             return [
                 'plan_id'               => $plan->id,
                 'playlist_id'           => $item,
+                'order_column' => $add_to_end ? $current_days_size + ($index + 1) : 0,
             ];
         })->toArray();
         Playlist::whereIn('id', $new_playlists)->update(['name' => '', 'updated_at' => 'created_at']);


### PR DESCRIPTION
<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
We want to add a new way to sort  user plans in My Library for [Bible.is](http://bible.is/) to order according to the the plans that were last updated or had completed items (basically kind of search according to the last interacted plan).  We will use the current entities to deduce user activity. 

user_plans.updated_at → will be updated when the user starts, stops, or resets a plan.
user_playlists.updated_at → will be updated when the user reorders the plan days or adds a new day to the plan.
playlist_items_completed.created_at → will be updated when the user completes an item.

## Issue Link
<!--- Please link to the Jira issue here or delete this section -->
<!--- Ex[FCBHDBP-01](https://fullstacklabs.atlassian.net/browse/FCBHDBP-01) -->
[FCBHDBP-619](https://fullstacklabs.atlassian.net/browse/FCBHDBP-619)

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->
you can run the tests from the following folder
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-a2efd445-b6eb-4523-8e40-42614226b89e?action=share&source=copy-link&creator=18435954&ctx=documentation


[FCBHDBP-619]: https://fullstacklabs.atlassian.net/browse/FCBHDBP-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ