### PR TITLE
Task-2758 Add a new attribute called custom_font_required to the Bibl…

### DIFF
--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -214,6 +214,35 @@ class Bible extends Model
      */
     public $incrementing = false;
 
+    /**
+     * @var array
+     */
+    protected $appends = ['custom_font_required'];
+
+    /**
+     * @OA\Property(
+     *   property="custom_font_required",
+     *   title="custom_font_required",
+     *   type="boolean",
+     *   description="Flag to mark if the bible has a custom font"
+     * )
+     */
+    public function getCustomFontRequiredAttribute() : bool
+    {
+        if (array_key_exists('custom_font_required', $this->attributes)) {
+            return (bool) $this->attributes['custom_font_required'];
+        }
+
+        $access_group_ids = getAccessGroups();
+
+        $requires_font = $this->filesets()
+            ->isContentAvailable($access_group_ids)
+            ->whereHas('fonts')
+            ->exists();
+
+        return $this->attributes['custom_font_required'] = $requires_font;
+    }
+
     public function translations()
     {
         return $this->hasMany(BibleTranslation::class)->where('name', '!=', '');

--- a/app/Transformers/BibleTransformer.php
+++ b/app/Transformers/BibleTransformer.php
@@ -162,6 +162,7 @@ class BibleTransformer extends BaseTransformer
      *              @OA\Property(property="books",         ref="#/components/schemas/Book/properties/id"),
      *              @OA\Property(property="links",         ref="#/components/schemas/BibleLink"),
      *              @OA\Property(property="filesets",      ref="#/components/schemas/BibleFileset"),
+     *              @OA\Property(property="custom_font_required",      ref="#/components/schemas/Bible/properties/custom_font_required"),
      *     )
      *   )
      * )
@@ -293,6 +294,7 @@ class BibleTransformer extends BaseTransformer
                     'filesets'     => $bible->filesets->mapToGroups(function ($item) {
                         return [$item['asset_id'] => $this->filesetWithMeta($item)];
                     }),
+                    'custom_font_required' => $bible->custom_font_required,
                     'fonts' => $fonts
                 ];
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2032,6 +2032,11 @@
                 "title": "Bible",
                 "description": "Bible",
                 "properties": {
+                    "custom_font_required": {
+                        "title": "custom_font_required",
+                        "description": "Flag to mark if the bible has a custom font",
+                        "type": "boolean"
+                    },
                     "id": {
                         "title": "id",
                         "description": "The Archivist created Bible ID string. This will be between six and twelve letters usually starting with the iso639-3 code and ending with the acronym for the Bible",
@@ -4965,6 +4970,9 @@
                         },
                         "filesets": {
                             "$ref": "#/components/schemas/BibleFileset"
+                        },
+                        "custom_font_required": {
+                            "$ref": "#/components/schemas/Bible/properties/custom_font_required"
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
# Description
Added a new attribute, `custom_font_required`, to the Bible endpoint. The value is derived from the bible_fileset_fonts table, if any filesets linked to the Bible reference a custom font, the attribute is set to true.

This new attribute is independent of the include_font request parameter. Recommended workflow:

- Send an initial request with include_font=false.
- If the response contains custom_font_required=true, send a second request with include_font=true.

@bradflood , currently, the Bible endpoint includes the font by default—unless the request parameter include_font=false is provided. This behavior was designed as part of the following old ticket: https://fullstacklabs.atlassian.net/browse/FCBHDBP-307

## Issue Link
[User Story 2758](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2758): Public API: support for custom fonts

## How Do I QA This
I have created a Postman folder with 7 tests. Please run the folder, all tests should pass.
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-ff62dc42-c164-4b3d-ae5f-c11d9c648b29?action=share&source=copy-link&creator=17122915&active-environment=810fd94b-9392-43e2-9f13-943e8d323135