### PR TITLE
Task-2820 Public API: error with user note endpoint

### DIFF
--- a/app/Models/Bible/Bible.php
+++ b/app/Models/Bible/Bible.php
@@ -217,7 +217,7 @@ class Bible extends Model
     /**
      * @var array
      */
-    protected $appends = ['custom_font_required'];
+    protected $appends = [];
 
     /**
      * @OA\Property(


### PR DESCRIPTION
# Description
Remove custom_font_required from model's  so it is not calculated on every serialization. The issue is not necessary that the endpoint api/users/:user_id/notes/:note_id load the custom_font_required from the bible model.

## Issue Link
[Bug 2820](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2820): Public API: error with user note endpoint

## How Do I QA This
You should execute the following postman test and it has to pass:
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-38d684db-0eca-41c0-9cf1-6dc6d3103360?action=share&source=copy-link&creator=17122915&active-environment=810fd94b-9392-43e2-9f13-943e8d323135
