### PR TITLE
Task-2847 text not displaying 

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Bible;
 
 use Symfony\Component\HttpFoundation\Response;
+use Illuminate\Support\Str;
 use App\Models\Bible\Bible;
 use App\Models\Bible\BibleBook;
 use App\Models\Bible\BibleFilesetType;
@@ -578,15 +579,19 @@ class BiblesController extends APIController
                                 ->first();
 
                             if (!$text_fileset) {
-                                $text_fileset = $text_filesets
-                                    ->where('set_size_code', 'LIKE', '%'.$book_testament.'%')
-                                    ->first();
+                                $text_fileset = $text_filesets->first(function($item) use ($book_testament) {
+                                    return Str::contains($item->set_size_code, $book_testament);
+                                });
 
                                 if (!$text_fileset) {
                                     $text_fileset = $text_filesets
                                         ->where('set_size_code', BibleFilesetSize::SIZE_COMPLETE)
                                         ->first();
                                 }
+                            }
+
+                            if (!$text_fileset) {
+                                return $book;
                             }
 
                             $verses_by_book = BibleVerse::where('hash_id', $text_fileset->hash_id)


### PR DESCRIPTION
# Description
Correct how the Eloquent Collection is filtered, because the current filter is not working properly and is not returning the complete filesets for a specific Bible.

When you call ->where(…) on an Eloquent Collection, you are using the Collection filter, not the database, and the only operators it understands are the basic PHP ones (=, !=, >, <, >=, <=, ===, !==). It doesn’t do SQL‐style wildcards.

## Issue Link
[Bug 2847](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2847): Abaza text not displaying in newdata.bible.is

## How Do I QA This
- You have to run all [M] postman test and they have to pass.

- You can check the specific postman test for the bible **ADYIBT**
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-dadf74a4-a78e-48c3-aea7-8c00626f8a3c?action=share&source=copy-link&creator=17122915&active-environment=810fd94b-9392-43e2-9f13-943e8d323135
