### PR TITLE
Task-2874 Public API (dev) - set cache expiration to be configurable based on deployment environment

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -81,4 +81,7 @@ return [
 
     'prefix' => env('CACHE_PREFIX'),
 
+    // Development mode TTL, it is not used in production and it is not
+    // mandatory that env parameter is set
+    'dev_ttl' => env('CACHE_DEV_TTL', 1),
 ];


### PR DESCRIPTION
# Description
Added feature where Cache expires after exactly 1 second in development. I used array cache for dev mode as Memcached has minimum TTL settings that prevent short expiration times (preventing 1-second cache expiration) and so, the solution is to use array cache store for dev environment. It only affects dev environment.

The array cache store keeps data in memory only (per request) and should respect 1-second TTL properly.

I have added a configurable environment variable (**CACHE_DEV_TTL**) to allow changing the dev TTL value in the future. Setting this new environment variable is optional.

## Issue Link
[User Story 2874](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2874): Public API (dev) - set cache expiration to be configurable based on deployment environment

## How Do I QA This
Using Postman and in dev, hit an endpoint to populate the cache. Then change some portion of the data. Then hit the same endpoint again. 
