### PR TITLE
Task-2920 Hotfix - fix a cache serialization issue

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -423,7 +423,7 @@ class BibleFileSetsController extends APIController
 
         $cache_params = [$id, $iso];
         $fileset = cacheRemember(
-            'bible_fileset_copyright',
+            'bible_fileset_license_group_copyright',
             $cache_params,
             now()->addDay(),
             function () use ($iso, $id) {

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -746,7 +746,7 @@ class BiblesController extends APIController
         $iso = checkParam('iso') ?? 'eng';
 
         $cache_params = [$bible_id, $iso];
-        $copyrights = cacheRemember('bible_copyrights', $cache_params, now()->addDay(), function () use ($bible, $iso) {
+        $copyrights = cacheRemember('bible_license_group_copyrights', $cache_params, now()->addDay(), function () use ($bible, $iso) {
             $language_id = optional(Language::where('iso', $iso)->select('id')->first())->id;
             $filesets_hash_ids = $bible->filesets->pluck('hash_id')->toArray();
             return empty($filesets_hash_ids)


### PR DESCRIPTION
# Description
Fixed a cache serialization issue where cached data contains references to the obsolete BibleFilesetCopyright model. The cache key bible_fileset_copyright in BibleFileSetsController.php has been renamed to force regeneration with the current LicenseGrlup model.

## Issue Link
[User Story 2938](https://dev.azure.com/keyholesoftware/FCBH%20-%20Bible%20Brain/_workitems/edit/2938): Public API: use consolidated license tables

## How Do I QA This
You should run the following 2 postman test and they have to pass:

- Bible copyright
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-af4b3074-1a66-4e07-a6f2-b5fe3b1789d3?action=share&source=copy-link&creator=17122915&active-environment=810fd94b-9392-43e2-9f13-943e8d323135

- Bible Fileset copyright
https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-3050a61f-9e12-4c80-89d8-24b1b36bcb5b?action=share&source=copy-link&creator=17122915&active-environment=810fd94b-9392-43e2-9f13-943e8d323135