### PR TITLE
Task-70027 Public API: all endpoints should return no data when content_loaded is false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ tools/permissionValidation/results/**
 tools/permissionValidation/myconfig.py
 tools/permissionValidation/runlog*
 
+# Generated backup files
+scripts/
+
 # Codebuild
 /artifacts/
 codebuild_build.sh

--- a/app/Http/Controllers/Bible/TextController.php
+++ b/app/Http/Controllers/Bible/TextController.php
@@ -411,6 +411,8 @@ class TextController extends APIController
         $verses = \DB::connection('dbp')->table('bible_verses')
             ->where('bible_verses.hash_id', $fileset->hash_id)
             ->join('bible_filesets', 'bible_filesets.hash_id', 'bible_verses.hash_id')
+            ->where('bible_filesets.content_loaded', true)
+            ->where('bible_filesets.archived', false)
             ->join('books', 'bible_verses.book_id', 'books.id')
             ->select(
                 DB::raw(

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -40,6 +40,11 @@ use Illuminate\Support\Str;
  */
 class BibleFileset extends Model
 {
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new \App\Scopes\ContentAvailableScope());
+    }
+
     public const AUDIO = 'audio';
     public const VIDEO = 'video';
     public const TEXT = 'text';
@@ -200,9 +205,7 @@ class BibleFileset extends Model
         return BibleFileset::select('bible_filesets.*')
             ->join('bible_fileset_connections as connection', 'connection.hash_id', 'bible_filesets.hash_id')
             ->where('connection.bible_id', $bible_id)
-            ->where('set_type_code', BibleFileset::TYPE_TEXT_PLAIN)
-            ->where('archived', false)
-            ->where('content_loaded', true);
+            ->where('set_type_code', BibleFileset::TYPE_TEXT_PLAIN);
     }
     /**
      * Retrieves an associated fileset of type 'text plain' based on set size codes.
@@ -322,9 +325,7 @@ class BibleFileset extends Model
             } else {
                 $query->where('bible_filesets.set_type_code', $fileset_type);
             }
-        })
-        ->where('bible_filesets.content_loaded', true)
-        ->where('bible_filesets.archived', false);
+        });
     }
 
     public function scopeIsContentAvailable(
@@ -333,8 +334,6 @@ class BibleFileset extends Model
         ?array $access_group_ids = [],
     ) : Builder {
         return $query
-            ->where('bible_filesets.content_loaded', true)
-            ->where('bible_filesets.archived', false)
             ->leftJoin('license_group as lg', 'lg.id', '=', 'bible_filesets.license_group_id')
             ->where(function (Builder $q) use ($access_groups, $access_group_ids) {
                 $q
@@ -655,7 +654,6 @@ class BibleFileset extends Model
     {
         return $query
             ->where('id', $fileset_id)
-            ->where('archived', false)
             ->orderByRaw("CASE WHEN set_type_code = ? THEN 0 ELSE 1 END", [BibleFileset::TYPE_TEXT_PLAIN])
             ->orderBy('set_type_code');
     }

--- a/app/Models/Bible/BibleVerse.php
+++ b/app/Models/Bible/BibleVerse.php
@@ -159,6 +159,8 @@ class BibleVerse extends Model
                 return $query->orderBy('verse_sequence');
             })
             ->join('bible_filesets', 'bible_filesets.hash_id', 'bible_verses.hash_id')
+            ->where('bible_filesets.content_loaded', true)
+            ->where('bible_filesets.archived', false)
             ->join('bible_fileset_connections', 'bible_filesets.hash_id', 'bible_fileset_connections.hash_id')
             ->join('bibles', 'bibles.id', 'bible_fileset_connections.bible_id')
             ->with(["fileset.bible.filesetsWithoutMeta" => function ($query) use ($book_id, $chapter_id) {

--- a/app/Models/User/Study/UserAnnotationTrait.php
+++ b/app/Models/User/Study/UserAnnotationTrait.php
@@ -55,6 +55,8 @@ trait UserAnnotationTrait
         // Select the bible_id and fileset_id for the bible fileset connections that match the fileset_ids.
         $bible_ids = BibleFilesetConnection::select('bible_id', 'bf.id as fileset_id')
             ->join('bible_filesets AS bf', 'bible_fileset_connections.hash_id', 'bf.hash_id')
+            ->where('bf.content_loaded', true)
+            ->where('bf.archived', false)
             ->whereIn('bf.id', array_keys($fileset_ids))
             ->groupBy('bible_fileset_connections.bible_id', 'bible_fileset_connections.bible_id')
             ->get();

--- a/app/Scopes/ContentAvailableScope.php
+++ b/app/Scopes/ContentAvailableScope.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ContentAvailableScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('bible_filesets.content_loaded', true)
+                ->where('bible_filesets.archived', false);
+    }
+}

--- a/database/factories/Bible/BibleFactory.php
+++ b/database/factories/Bible/BibleFactory.php
@@ -64,7 +64,9 @@ $factory->define(\App\Models\Bible\BibleFileset::class, function (Faker $faker) 
         'asset_id'      => factory(\App\Models\Organization\Asset::class)->create()->id,
         'set_type_code' => factory(\App\Models\Bible\BibleFilesetType::class)->create()->id,
         'set_size_code' => factory(\App\Models\Bible\BibleFilesetSize::class)->create()->id,
-        'hidden'        => $faker->boolean(10)
+        'hidden'        => $faker->boolean(10),
+        'content_loaded' => true,
+        'archived'       => false,
     ];
 });
 

--- a/database/factories/BibleVerse.php
+++ b/database/factories/BibleVerse.php
@@ -5,7 +5,7 @@ use App\Models\Bible\Book;
 
 $factory->define(\App\Models\Bible\BibleVerse::class, function (Faker $faker) {
     return [
-        'hash_id'     => \App\Models\Bible\BibleFileset::where('set_type_code', 'text_plain')->inRandomOrder()->first()->hash_id,
+        'hash_id'     => \App\Models\Bible\BibleFileset::withoutGlobalScope(\App\Scopes\ContentAvailableScope::class)->where('set_type_code', 'text_plain')->inRandomOrder()->first()->hash_id,
         'book_id'     => Book::inRandomOrder()->first()->id,
         'chapter'     => random_int(1, 150),
         'verse_start' => random_int(1, 176),

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -10,7 +10,7 @@ class DatabaseSeeder extends Seeder
         $this->call(RealDataSeeder::class);
 
         echo "Seeding Bible Verses \n";
-        $bible_filesets = \App\Models\Bible\BibleFileset::where('set_type_code', 'text_plain')->get();
+        $bible_filesets = \App\Models\Bible\BibleFileset::withoutGlobalScope(\App\Scopes\ContentAvailableScope::class)->where('set_type_code', 'text_plain')->get();
         foreach ($bible_filesets as $bible_fileset) {
             echo "\n attempting to seed: ". $bible_fileset->id;
             factory(\App\Models\Bible\BibleVerse::class, random_int(1, 10))->create(['hash_id' => $bible_fileset->hash_id]);

--- a/database/seeds/SeedBibleText.php
+++ b/database/seeds/SeedBibleText.php
@@ -16,7 +16,7 @@ class SeedBibleText extends Seeder
     {
         ini_set('memory_limit', '4000M');
 
-        $filesets = BibleFileset::where('set_type_code', 'text_plain')->get();
+        $filesets = BibleFileset::withoutGlobalScope(\App\Scopes\ContentAvailableScope::class)->where('set_type_code', 'text_plain')->get();
         $books  = Book::select('id', 'id_usfx')->get()->pluck('id', 'id_usfx');
         unset($books['']);
 


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 70027](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/70027): Public API: all endpoints should return no data when content_loaded is false

## Description

A new Eloquent global scope (`ContentAvailableScope`) has been added to the `BibleFileset` model to enforce `content_loaded = true` and `archived = false` filters automatically on every query that touches the `bible_filesets` table through Eloquent.

## Reason for the Change

Prior to this change, the `content_loaded` and `archived` filters were applied inconsistently across the codebase. Some scopes included both filters, one scope only had `archived`, and many endpoints had no filtering at all. A global scope eliminates this class of bug entirely by applying the filters at the model level, ensuring no query can accidentally omit them.

## What Changed

### New file: `app/Scopes/ContentAvailableScope.php`

```php
class ContentAvailableScope implements Scope
{
    public function apply(Builder $builder, Model $model): void
    {
        $builder->where('bible_filesets.content_loaded', true)
                ->where('bible_filesets.archived', false);
    }
}
```

### Modified: `app/Models/Bible/BibleFileset.php`

1. **Registered the global scope** via `booted()`:
   ```php
   protected static function booted(): void
   {
       static::addGlobalScope(new \App\Scopes\ContentAvailableScope());
   }
   ```

2. **Removed redundant explicit filters** from the following scopes (now handled automatically by the global scope):
   - `scopeUniqueFileset()` 
   - `scopeIsContentAvailable()` 
   - `scopePrioritizeTextPlainType()` 
   - `subqueryFilesetTypeTextPlainAssociated()` 

## Testing

A shell script (created only to test this change) was created to verify that the global scope correctly blocks all content when content_loaded = false. It operates in three steps:

### How it works

| Command | Description |
|---------|-------------|
| `backup` | Queries `SELECT hash_id FROM bible_filesets WHERE content_loaded = 1` and writes a restore SQL file to `scripts/content_loaded_backup.sql` |
| `disable` | Validates backup file exists, then runs `UPDATE bible_filesets SET content_loaded = 0`. Supports `--dry-run` flag. |
| `restore` | Executes the backup SQL file to restore `content_loaded = 1` for the original rows |

### Verification

- After `disable`: `SELECT COUNT(*) FROM bible_filesets WHERE content_loaded = 1;` should return **0**
- All API endpoints ([M]postman test) should return empty results or 404
- After `restore`: the count should match the original number shown during backup

## Gap Analysis

### Scopes that HAD the filters (before the global scope)

These scopes already enforced `content_loaded` and/or `archived` filters. The explicit filters were removed since the global scope now handles them.

| Scope | Had `content_loaded = true` | Had `archived = false` |
|-------|:---------------------------:|:----------------------:|
| `scopeUniqueFileset()` | Yes | Yes |
| `scopeIsContentAvailable()` | Yes | Yes |
| `subqueryFilesetTypeTextPlainAssociated()` | Yes | Yes |
| `scopePrioritizeTextPlainType()` | No | Yes |

### Gap endpoints (no filters at all before global scope)

These endpoints queried `BibleFileset` directly without going through any scope that had the filters. They were completely unfiltered for both `content_loaded` and `archived`:

| Endpoint | Controller |
|----------|-----------|
| `GET bibles/filesets/{fileset_id}/copyright` | `BibleFileSetsController@copyright()` |
| `POST bibles/filesets/check/types` | `BibleFileSetsController@checkTypes()` |
| `GET timestamps` | `AudioController@availableTimestamps()` |
| `GET library/metadata` | `LibraryController@metadata()` |
| `GET library/volumehistory` | `LibraryController@history()` |
| `GET playlists/...` (multiple) | `PlaylistsController`  |
| `GET bible/filesets/.../playlist.m3u8` | `MasterStreamController@index()`  |
| `GET bible/filesets/.../{file_name}` | `SubStreamController@index()` |
| `GET /annotations/*` (v2) | `UsersControllerV2` (multiple methods) |

### Partial gap: `scopePrioritizeTextPlainType`

This scope filtered `archived = false` but was **missing** `content_loaded = true`. The following endpoints could return filesets whose content had not been loaded:

| Endpoint | Controller |
|----------|-----------|
| `GET bibles/filesets/{fileset_id?}` | `BibleFileSetsController@show()` |
| `GET bibles/filesets/bulk/{fileset_id}/{book?}` | `BibleFileSetsController@showBulk()` |
| `GET download/{fileset_id}/{book?}/{chapter_id?}` | `BibleFilesetsDownloadController@index()` |

## How Do I QA This

All [M] Postman tests [passed/passed successfully], and additionally I have the following Postman test to validate that the gap does not exist:

- [GET bibles/filesets/{fileset_id}/copyright](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-ec171bf5-1c37-4291-81d4-307ec12354fb?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [POST bibles/filesets/check/types](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-b12c06dd-310e-4f83-89e4-0f58b1a050e4?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [timestamps](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-6f3c5408-d3af-4d52-a3a0-c9e0e1babd80?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [library/metadata](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-320eacad-a06d-4bc5-9590-aa5366b8ba82?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [playlists/...](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-4a684c5e-ad12-4928-bb12-3af586fa2f6f?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [bibles/filesets/{fileset_id?}](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-408baaa2-4c2f-4e57-946a-e429c422a361?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [bibles/filesets/bulk/{fileset_id}/{book?}](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-a95104da-51f1-49a1-9c74-92cf828c9f2a?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

- [download/{fileset_id}/{book?}/{chapter_id?}](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-f908e7a5-42f9-4eb8-81f1-d02c031409d2?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)