### PR TITLE
75712: Random values accepted for parameters

### DIFF
--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -116,7 +116,7 @@ function checkParam(string $paramName, $required = false, $inPathValue = null)
 function checkBoolean(string $paramName, $required = false, $inPathValue = null)
 {
     $param = checkParam($paramName, $required, $inPathValue);
-    $param = (bool) $param &&  strtolower($param) !== 'false';
+    $param = (bool) $param && strtolower($param) === 'true';
     return $param;
 }
 

--- a/app/Helpers/Helpers.php
+++ b/app/Helpers/Helpers.php
@@ -116,6 +116,17 @@ function checkParam(string $paramName, $required = false, $inPathValue = null)
 function checkBoolean(string $paramName, $required = false, $inPathValue = null)
 {
     $param = checkParam($paramName, $required, $inPathValue);
+
+    // null treated as false.
+    if ($param === null) {
+        return false;
+    }
+
+    // if it's already a boolean, return it.
+    if (is_bool($param)) {
+        return $param;
+    }
+
     $param = (bool) $param && strtolower($param) === 'true';
     return $param;
 }

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -114,7 +114,7 @@ class BiblesController extends APIController
         $country            = checkParam('country');
         $media              = checkParam('media');
         $media_exclude      = checkParam('media_exclude');
-        $audio_timing       = checkParam('audio_timing') ?? false;
+        $audio_timing       = checkBoolean('audio_timing') ?? false;
         $show_country       = checkBoolean('show_country', false);
         $size               = checkParam('size'); #removed from API for initial release
         $size_exclude       = checkParam('size_exclude'); #removed from API for initial release

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -114,7 +114,7 @@ class BiblesController extends APIController
         $country            = checkParam('country');
         $media              = checkParam('media');
         $media_exclude      = checkParam('media_exclude');
-        $audio_timing       = checkBoolean('audio_timing') ?? false;
+        $audio_timing       = checkBoolean('audio_timing');
         $show_country       = checkBoolean('show_country', false);
         $size               = checkParam('size'); #removed from API for initial release
         $size_exclude       = checkParam('size_exclude'); #removed from API for initial release

--- a/app/Http/Controllers/Bible/Study/LexiconController.php
+++ b/app/Http/Controllers/Bible/Study/LexiconController.php
@@ -67,7 +67,7 @@ class LexiconController extends APIController
     {
         $word        = checkParam('word', true);
         $language    = checkParam('language');
-        $exact_match = checkParam('exact_match');
+        $exact_match = checkBoolean('exact_match');
         $limit       = checkParam('limit');
 
         return $this->reply(Lexicon::filterByLanguage($language)->filterByWord($word, $exact_match)->take($limit));

--- a/app/Http/Controllers/Organization/ResourcesController.php
+++ b/app/Http/Controllers/Organization/ResourcesController.php
@@ -24,7 +24,7 @@ class ResourcesController extends APIController
         $iso             = checkParam('iso');
         $limit           = checkParam('limit') ?? 2000;
         $organization    = checkParam('organization_id');
-        $dialects        = checkParam('include_dialects');
+        $dialects        = checkBoolean('include_dialects');
 
         $resources = Resource::with('translations', 'links', 'organization.translations', 'language')
             ->when($iso, function ($query) use ($iso, $dialects) {

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -577,7 +577,7 @@ class PlansController extends APIController
             ->where('user_id', $user->id)
             ->get()->pluck('id');
 
-        $add_to_end = checkParam('add_to_end') ?? false;
+        $add_to_end = checkBoolean('add_to_end');
 
         $plan_days_data = $new_playlists->map(function ($item, $index) use ($plan, $add_to_end, $current_days_size) {
             return [
@@ -649,8 +649,7 @@ class PlansController extends APIController
                 ->replyWithError('User Plan Not Found');
         }
 
-        $complete = checkParam('complete') ?? true;
-        $complete = $complete && $complete !== 'false';
+        $complete = checkBoolean('complete');
 
         $result = null;
         try {

--- a/app/Http/Controllers/Wiki/LanguagesController.php
+++ b/app/Http/Controllers/Wiki/LanguagesController.php
@@ -90,7 +90,7 @@ class LanguagesController extends APIController
 
         $country               = checkParam('country');
         $code                  = checkParam('code|iso|language_code');
-        $include_translations  = checkParam('include_translations|include_alt_names');
+        $include_translations  = checkBoolean('include_translations|include_alt_names');
         $name                  = checkParam('name|language_name');
         $limit                 = (int) (checkParam('limit') ?? 50);
         $limit                 = min($limit, 150);


### PR DESCRIPTION
# Description

Some endpoints were treating any random value as true; the fix was to invert the logic in the `checkBoolean` function to treat any random value as false. Also updated the following endpoints that were using `checkParam` instead of `checkBoolean`:

* `GET /languages`.
* `GET /bibles`.
* `POST /plans/:plan_id/day`
* `POST /plans/day/:day_id/complete`.
* `GET /resources`.
* `GET /lexicons`.

## Issue Link

[75712 - Public APL: [FD 15303]API calls - random values accepted for parameters](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/75712)

## How Do I QA This

New [Postman suit](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/47432095-a8f0c197-07c2-4b52-affa-d0b4348bb924?action=share&source=copy-link&creator=47432095)