### PR TITLE
#74418 Support Download Link Retrieval for In-Field Updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -132,6 +132,13 @@ DEEPLINKING_WEBSITE=
 # Bible Organization APIs
 # -----------------------------------
 
+# BBHub (package creation by filesets). Base URL without the /package/... path.
+# If the API runs in Docker but BBHub runs on your machine, use host.docker.internal
+# instead of localhost (inside a container, localhost is the container itself).
+# Dev url for BBHub: https://dev.biblebrainhub.fcbh.org/
+BBHUB_BASE_URL=http://host.docker.internal:5044/
+BBHUB_SERVICE_TIMEOUT=60
+
 GLOBAL_BIBLE_CATALOGUE_KEY=
 ARCLIGHT_API_URL=
 ARCLIGHT_API=

--- a/.env.example
+++ b/.env.example
@@ -137,7 +137,7 @@ DEEPLINKING_WEBSITE=
 # instead of localhost (inside a container, localhost is the container itself).
 # Dev url for BBHub: https://dev.biblebrainhub.fcbh.org/
 BBHUB_BASE_URL=http://host.docker.internal:5044/
-BBHUB_SERVICE_TIMEOUT=60
+BBHUB_SERVICE_TIMEOUT=1200
 
 GLOBAL_BIBLE_CATALOGUE_KEY=
 ARCLIGHT_API_URL=

--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -236,6 +236,68 @@ class BibleFilesetsDownloadController extends APIController
     /**
      * Proxies package creation to BBHub (POST /package/create-by-filesets).
      * Same API key rules as v2 `/library/language`: `key` + `v`, no AccessControl.
+     *
+     * @OA\Post(
+     *     path="/download/package-create",
+     *     operationId="v4_download_package_create",
+     *     tags={"Bibles"},
+     *     summary="Create a download package from filesets",
+     *     description="Accepts a JSON payload containing fileset IDs and an encryption type, then proxies the request to BBHub package creation.",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"filesets","encryptionType"},
+     *             @OA\Property(
+     *                 property="filesets",
+     *                 type="array",
+     *                 minItems=1,
+     *                 uniqueItems=true,
+     *                 @OA\Items(type="string", minLength=1),
+     *                 example={"ENGESVN2DA","ENGESVO1DA"}
+     *             ),
+     *             @OA\Property(
+     *                 property="encryptionType",
+     *                 type="integer",
+     *                 example=1
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Response from the upstream BBHub service (status and body are proxied).",
+     *         @OA\MediaType(
+     *             mediaType="application/json",
+     *             @OA\Schema(
+     *                 type="object",
+     *                 additionalProperties=true
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Request body must be valid JSON.",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="error", type="string", example="Request body must be valid JSON.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation failed for the request body.",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="error", type="string", example="The filesets field is required.")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=503,
+     *         description="BBHub is unavailable.",
+     *         @OA\JsonContent(
+     *             type="object",
+     *             @OA\Property(property="error", type="string", example="BBHub is unavailable.")
+     *         )
+     *     )
+     * )
      */
     public function packageCreate(Request $request): Response|JsonResponse
     {
@@ -246,9 +308,9 @@ class BibleFilesetsDownloadController extends APIController
         }
 
         $validator = Validator::make($payload, [
-            'filesets'       => 'required|array',
-            'filesets.*'     => 'string',
-            'encryptionType' => 'required|integer',
+            'filesets'         => 'required|array|min:1',
+            'filesets.*'       => 'string|min:1|distinct',
+            'encryptionType'   => 'required|integer',
         ]);
         if ($validator->fails()) {
             $this->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);

--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -2,9 +2,12 @@
 
 namespace App\Http\Controllers\Bible;
 
-use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
 use App\Traits\AccessControlAPI;
 use App\Traits\CallsBucketsTrait;
 use App\Traits\BibleFileSetsTrait;
@@ -227,5 +230,51 @@ class BibleFilesetsDownloadController extends APIController
         );
 
         return $this->reply(fractal($filesets, new BibleFileSetsDownloadTransFormer));
+    }
+
+    /**
+     * Proxies package creation to BBHub (POST /package/create-by-filesets).
+     * Same API key rules as v2 `/library/language`: `key` + `v`, no AccessControl.
+     */
+    public function packageCreate(Request $request): Response|JsonResponse
+    {
+        $payload = json_decode($request->getContent(), true);
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($payload)) {
+            $this->setStatusCode(400);
+            return $this->replyWithError('Request body must be valid JSON.');
+        }
+
+        $validator = Validator::make($payload, [
+            'filesets'       => 'required|array',
+            'filesets.*'     => 'string',
+            'encryptionType' => 'required|integer',
+        ]);
+        if ($validator->fails()) {
+            $this->setStatusCode(422);
+            return $this->replyWithError($validator->errors()->first());
+        }
+
+        $baseUrl = rtrim((string) config('services.bbhub.url'), '/');
+        $url = $baseUrl . '/package/create-by-filesets';
+        $timeout = (int) config('services.bbhub.service_timeout', 60);
+
+        try {
+            $upstream = Http::timeout($timeout)
+                ->acceptJson()
+                ->asJson()
+                ->post($url, $payload);
+        } catch (ConnectionException $e) {
+            \Log::warning('BBHub connection failed', ['url' => $url, 'exception' => $e->getMessage()]);
+            $this->setStatusCode(503);
+            return $this->replyWithError('BBHub is unavailable.');
+        }
+
+        $response = response($upstream->body(), $upstream->status());
+        $contentType = $upstream->header('Content-Type');
+        if ($contentType) {
+            $response->header('Content-Type', $contentType);
+        }
+
+        return $response;
     }
 }

--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Validator;
 use App\Traits\AccessControlAPI;
@@ -240,7 +241,7 @@ class BibleFilesetsDownloadController extends APIController
     {
         $payload = json_decode($request->getContent(), true);
         if (json_last_error() !== JSON_ERROR_NONE || !is_array($payload)) {
-            $this->setStatusCode(400);
+            $this->setStatusCode(Response::HTTP_BAD_REQUEST);
             return $this->replyWithError('Request body must be valid JSON.');
         }
 
@@ -250,7 +251,7 @@ class BibleFilesetsDownloadController extends APIController
             'encryptionType' => 'required|integer',
         ]);
         if ($validator->fails()) {
-            $this->setStatusCode(422);
+            $this->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
             return $this->replyWithError($validator->errors()->first());
         }
 
@@ -259,13 +260,19 @@ class BibleFilesetsDownloadController extends APIController
         $timeout = (int) config('services.bbhub.service_timeout', 60);
 
         try {
-            $upstream = Http::timeout($timeout)
+            $upstream = Http::retry(3, 100, function ($exception, PendingRequest $request) {
+                return $exception instanceof ConnectionException;
+            })
+                ->timeout($timeout)
                 ->acceptJson()
                 ->asJson()
                 ->post($url, $payload);
         } catch (ConnectionException $e) {
-            \Log::warning('BBHub connection failed', ['url' => $url, 'exception' => $e->getMessage()]);
-            $this->setStatusCode(503);
+            \Log::warning('BBHub connection failed after retries', [
+                'url' => $url,
+                'exception' => $e->getMessage(),
+            ]);
+            $this->setStatusCode(Response::HTTP_SERVICE_UNAVAILABLE);
             return $this->replyWithError('BBHub is unavailable.');
         }
 

--- a/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
+++ b/app/Http/Controllers/Bible/BibleFilesetsDownloadController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\Client\ConnectionException;
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Validator;
 use App\Traits\AccessControlAPI;
@@ -322,7 +321,7 @@ class BibleFilesetsDownloadController extends APIController
         $timeout = (int) config('services.bbhub.service_timeout', 60);
 
         try {
-            $upstream = Http::retry(3, 100, function ($exception, PendingRequest $request) {
+            $upstream = Http::retry(3, 100, function ($exception) {
                 return $exception instanceof ConnectionException;
             })
                 ->timeout($timeout)

--- a/config/services.php
+++ b/config/services.php
@@ -71,4 +71,9 @@ return [
         'url' => env('BIBLEBRAIN_SERVICES_BASE_URL', 'https://qaqvosflpf.execute-api.us-west-2.amazonaws.com'),
         'service_timeout' => env('BIBLEBRAIN_SERVICE_TIMEOUT', 10)
     ],
+
+    'bbhub' => [
+        'url' => env('BBHUB_BASE_URL', 'https://dev.biblebrainhub.fcbh.org/'),
+        'service_timeout' => env('BBHUB_SERVICE_TIMEOUT', 1200),
+    ],
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,6 @@ services:
     depends_on:
       - db8
       - dbpusers8
-    environment:
-      # package-create API URL (override in .env if service runs on host)
-      - PACKAGE_CREATE_URL=${PACKAGE_CREATE_URL:-http://localhost:5044/package/create}
 
   server:
     image: nginx:stable-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
     depends_on:
       - db8
       - dbpusers8
+    environment:
+      # package-create API URL (override in .env if service runs on host)
+      - PACKAGE_CREATE_URL=${PACKAGE_CREATE_URL:-http://localhost:5044/package/create}
 
   server:
     image: nginx:stable-alpine

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,6 +178,11 @@ Route::name('v4_bible_filesets_download.list')
     'Bible\BibleFilesetsDownloadController@list'
 );
 
+Route::name('v4_bible_filesets_download.package_create')->post(
+    'download/package-create',
+    'Bible\BibleFilesetsDownloadController@packageCreate'
+);
+
 Route::name('v4_bible_filesets_download.index')
     ->middleware(['APIToken', 'AccessControl'])
     ->get(


### PR DESCRIPTION
## Issue Link
[Product Backlog Item 74418](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/74418): TECH | Downloader | Support Download Link Retrieval for In-Field Updates

## Description
- Introduced BBHub configuration in .env.example and services.php for package creation.
- Added a new endpoint in api.php for package creation via BibleFilesetsDownloadController.
- Refactored BibleFilesetsDownloadController to handle package creation requests with validation and error handling. Ticket: #74418

## Reason for the Change
The endpoint is required to support in-field updates by providing downloadable packages for selected filesets.
Previously, there was no straightforward way to generate and retrieve these packages, which complicated the update process. This change introduces a dedicated endpoint to create and return the necessary download links (ZIP archive (audio or video) and copyright

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->
1. Send a **POST** request in Postman (or similar).
url: `http://localhost:8080/api/download/package-create?v=4&key=****&t=1`
data:
```
{
  "filesets": [
    "SOMSIMN2DA"
  ],
  "encryptionType": 1
}
```
2. Confirm the response includes `zip`, `copyright`.

```
{
    "zip": "https://d2pdum9imziqyr.cloudfront.net/N2SOM_SIM__N2SOM_SIM.zip?Expires=1778756722&Signature=m0cDHcb2YRHcjRy9awDT5kZDB-1WB-N9tkPMM1ZFQxPFsfhLdqUaW0z55ivcqBBm~dP0uEuNK4k7MY1BB-eodJh3ydPg1NcuqKA7LrHoMh7hOA40TSYvJi0zS8ICCDMQDVgpeZ-RIm6m8f6Vq~1eakJhS4xt~a47hAevYij6K~o3bXZssMW~kGyAARJfLbK-GN4FMGJTRyP~t2tAbpbhgcaBWILQ6LLT~ycCrNX3N17Aq~s59kRrWctpjq4j0PzYQYyra95PwVr5MlDhPXZgB89NbO8~U12H6mKjtQ2lko-W~tCiTP~0o9dvULCcf-tm3rp9BHFjTp2--bDde6egiA__&Key-Pair-Id=K2ZY8EXHZ00S6O",
    "copyright": "https://d2pdum9imziqyr.cloudfront.net/N2SOM_SIM%2FN2SOM_SIM.pdf?Expires=1778756711&Signature=Q~0P7yuAtKCsru-HAApVdE7I7FH78M8C1PTfjbvKvThhjkMraK1aOBiPNzrTOqCAC-4VPrIY0fdP8~7-Qovuzhp8tJvKk6p56BIHxplPGARKyJDeNBEFQB6LRfPaJCinN001iEXU6IiQom0MBdOXyFAIcO8Utn5TGqx0o--s1V1sIVT8WDesXBl15SoN0mhpvU0cSovD661rxKv1SkIbt~Hr5KMPNPVCLCYpg7uSG-EhKwT29BqJcQCt6IO7GX84UlAP0mrD59RZk89fPU4-yoaFYZh6BLr8CRBnPtLp~FCuyau2hRqmiwOgpPYEEtWi~XutrYoZEqGPMPJLR03PVw__&Key-Pair-Id=K2ZY8EXHZ00S6O",
    "success": true,
    "error": ""
}
```
3. Verify that the returned URLs are valid and that the ZIP archive and copyright file can be downloaded.

## Screenshots (if appropriate)
<img width="1439" height="695" alt="image" src="https://github.com/user-attachments/assets/b7c293ed-88ce-4379-b99b-2928bbc7c97c" />

## Postman Tests
Add a new request to the DBP4 Postman workspace for this endpoint:

[https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/1765617-2e2d1e42-b427-4418-a8d2-7a6fc81f45e4?action=share&creator=54001971&ctx=documentation](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/1765617-2e2d1e42-b427-4418-a8d2-7a6fc81f45e4?action=share&creator=54001971&ctx=documentation)

