### PR TITLE
Task-89367 Add whitelist logic for live.bible.is IPs in Public API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ GET_STARTED_URL=
 NODE_PATH=/usr/local
 LOG_CHANNEL=stack
 
+# Rate Limiting
+# -----------------------------------
+IP_TRUSTED_NO_RATE_LIMIT=
+
 # Database connections
 # -----------------------------------
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -73,7 +73,7 @@ class Kernel extends HttpKernel
         'can'                     => \Illuminate\Auth\Middleware\Authorize::class,
         'guest'                   => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'signed'                  => \Illuminate\Routing\Middleware\ValidateSignature::class,
-        'throttle'                => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttle'                => \App\Http\Middleware\ThrottleRequestsWithWhitelist::class,
         'verified'                => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'APIToken'                => \App\Http\Middleware\APIToken::class,
         'AccessControl'           => \App\Http\Middleware\AccessControl::class,

--- a/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
+++ b/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+
+class ThrottleRequestsWithWhitelist extends ThrottleRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Bypasses rate limiting for IPs listed in IP_TRUSTED_NO_RATE_LIMIT.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|string  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @param  string  $prefix
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
+    {
+        // Use REMOTE_ADDR (actual peer IP) instead of $request->ip() to prevent
+        // X-Forwarded-For spoofing when TrustProxies is set to '*'.
+        $peerIp = $request->server('REMOTE_ADDR');
+
+        if ($this->isIpWhitelisted($peerIp)) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes, $prefix);
+    }
+
+    /**
+     * Check if the given IP address is in the trusted no-rate-limit whitelist.
+     */
+    private function isIpWhitelisted(?string $ip): bool
+    {
+        if (empty($ip)) {
+            return false;
+        }
+
+        $trusted_ips = config('app.ip_trusted_no_rate_limit');
+
+        if ($trusted_ips === null || trim((string) $trusted_ips) === '') {
+            return false;
+        }
+
+        $allowed_ips = array_map('trim', explode(',', $trusted_ips));
+
+        return in_array($ip, $allowed_ips, true);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -114,6 +114,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Rate Limiting IP Whitelist
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated list of trusted IP addresses that bypass API rate
+    | limiting. Used for proxy servers (e.g. live.bible.is) that already
+    | have rate limiting enforced at the infrastructure level.
+    |
+    */
+
+    'ip_trusted_no_rate_limit' => env('IP_TRUSTED_NO_RATE_LIMIT', ''),
+
+    /*
+    |--------------------------------------------------------------------------
     | Autoloaded Service Providers
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/ThrottleWhitelistTest.php
+++ b/tests/Feature/ThrottleWhitelistTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ThrottleWhitelistTest extends TestCase
+{
+    private const TEST_ROUTE = '/test-throttle';
+
+    // Test-only IP addresses (RFC 5737 documentation range — not routable)
+    private const TRUSTED_IP_1 = '192.0.2.1';
+    private const TRUSTED_IP_2 = '192.0.2.2';
+    private const TRUSTED_IP_3 = '192.0.2.3';
+    private const UNTRUSTED_IP = '198.51.100.1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(['throttle:60,1'])->get(self::TEST_ROUTE, function () {
+            return response()->json(['status' => 'ok']);
+        });
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_ip_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted IP should not have rate limit headers'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function non_whitelisted_ip_is_rate_limited()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::UNTRUSTED_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Non-whitelisted IP should have rate limit headers'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function empty_whitelist_applies_rate_limiting_to_all()
+    {
+        config(['app.ip_trusted_no_rate_limit' => '']);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Empty whitelist should rate limit all IPs'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function multiple_ips_in_whitelist()
+    {
+        $whitelist = implode(', ', [self::TRUSTED_IP_1, self::TRUSTED_IP_2, self::TRUSTED_IP_3]);
+        config(['app.ip_trusted_no_rate_limit' => $whitelist]);
+
+        foreach ([self::TRUSTED_IP_1, self::TRUSTED_IP_2, self::TRUSTED_IP_3] as $ip) {
+            $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+                'REMOTE_ADDR' => $ip,
+            ]);
+
+            $response->assertStatus(200);
+            $this->assertFalse(
+                $response->headers->has('X-RateLimit-Limit'),
+                "Whitelisted IP {$ip} should not have rate limit headers"
+            );
+        }
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::UNTRUSTED_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'IP not in whitelist should have rate limit headers'
+        );
+    }
+}


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 89367](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/89367): Add whitelist logic for live.bible.is IPs in Public API


## Summary

All traffic from the live.bible.is website reaches the DBP API through 3 proxy IPs. Laravel's `ThrottleRequests` middleware (`throttle:1500,5`) groups rate limits by IP, so the 1500 requests/5min limit is shared across all live.bible.is users behind each proxy, causing the entire site to be blocked once the limit is hit. This PR adds an IP-based whitelist so trusted proxy IPs bypass the API rate limit entirely.

## Changes

### New files

- **`app/Http/Middleware/ThrottleRequestsWithWhitelist.php`**
  Custom middleware extending Laravel's `ThrottleRequests`. Checks `$request->ip()` against a configurable whitelist before applying rate limiting. Whitelisted IPs skip throttling and proceed directly to the next middleware.

- **`tests/Feature/ThrottleWhitelistTest.php`**
  PHPUnit feature tests covering:
  - Whitelisted IP bypasses rate limit (no `X-RateLimit-*` headers)
  - Non-whitelisted IP is rate limited normally
  - Empty whitelist applies rate limiting to all IPs
  - Multiple comma-separated IPs in the whitelist

## Configuration

Set the environment variable with comma-separated trusted proxy IPs:

```
IP_TRUSTED_NO_RATE_LIMIT=192.168.1.77,192.168.2.78,192.168.2.90
```

The HiQo Cloud Team will configure this variable in AWS with the actual live.bible.is proxy IPs.

## How it works

1. Every API request passes through the `throttle` middleware (registered in `Kernel.php`).
2. `ThrottleRequestsWithWhitelist::handle()` checks if `$request->ip()` is in the whitelist loaded from `config('app.ip_trusted_no_rate_limit')`.
3. If the IP matches: the request bypasses throttling entirely (`return $next($request)`).
4. If the IP does not match: normal rate limiting applies via `parent::handle()`.

## Test plan

- [ ] Run PHPUnit tests: `php vendor/bin/phpunit --filter=ThrottleWhitelistTest`
- [ ] Verify no regressions on existing endpoints ([M] postman tests) without the env variable set (empty whitelist = normal rate limiting for all)