### PR TITLE
BI-89887: Configured PHP-FPM max_execution_time and request_terminate…

### DIFF
--- a/.ebextensions/00_option_settings.config
+++ b/.ebextensions/00_option_settings.config
@@ -1,12 +1,17 @@
 option_settings:
+  aws:elbv2:loadbalancer:
+    IdleTimeout: 1200
+
   aws:elasticbeanstalk:application:environment:
     COMPOSER_HOME: /root
     COMPOSER_MEMORY_LIMIT: -1
+    BBHUB_BASE_URL: https://dev.biblebrainhub.fcbh.org
+    BBHUB_SERVICE_TIMEOUT: 1200
 
   aws:elasticbeanstalk:container:php:phpini:
     document_root: /public
     zlib.output_compression: "Off"
     allow_url_fopen: "On"
     display_errors: "On"
-    max_execution_time: 60
+    max_execution_time: 1200
     composer_options: --no-interaction --prefer-dist --optimize-autoloader --no-dev

--- a/.platform/hooks/predeploy/02_set_php_timeout.sh
+++ b/.platform/hooks/predeploy/02_set_php_timeout.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+PHP_FPM_POOL="/etc/php-fpm.d/www.conf"
+
+grep -q "^request_terminate_timeout" "$PHP_FPM_POOL" \
+  && sed -i "s|^request_terminate_timeout.*|request_terminate_timeout = 1200s|" "$PHP_FPM_POOL" \
+  || echo "request_terminate_timeout = 1200s" >> "$PHP_FPM_POOL"
+
+grep -q "^php_admin_value\[max_execution_time\]" "$PHP_FPM_POOL" \
+  && sed -i "s|^php_admin_value\[max_execution_time\].*|php_admin_value[max_execution_time] = 1200|" "$PHP_FPM_POOL" \
+  || echo "php_admin_value[max_execution_time] = 1200" >> "$PHP_FPM_POOL"
+
+systemctl restart php-fpm
+

--- a/.platform/nginx/conf.d/elasticbeanstalk/01_fastcgi_timeouts.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/01_fastcgi_timeouts.conf
@@ -1,0 +1,3 @@
+fastcgi_read_timeout 1200s;
+fastcgi_send_timeout 1200s;
+


### PR DESCRIPTION
Configured PHP-FPM max_execution_time and request_terminat_timeout, alsonginx fastcgi params

<!--- The title of this PR should be a Jira ticket and followed by a short description.  Example: `TCK-100 fixes xyz`. -->

# Description
<!--- Describe your changes in detail -->
Added idle timeout for AWS EB LoadBalancer
Added configuration of max_execution_time PHP parameter in .ebextension.
Added configuration of Nginx fastcgi idle parameters in ..platform
Added configured request_terminat_timeout for PHP
Also configured Env variable BBHUB_BASE_URL and BBHUB_SERVICE_TIMEOUT
## Issue Link
https://dev.azure.com/FCBH/Software%20Development/_workitems/edit/89887

## How Do I QA This
<!--- Explain how a developer would qa out these changes locally -->
Cloud team can test it
