### PR TITLE
Task-90116 Public API: Display Segmentation type

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -375,6 +375,12 @@ class BibleFileSetsController extends APIController
      *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id"),
      *          description="The fileset ID to retrieve the copyright information for"
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, the response includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -391,7 +397,60 @@ class BibleFileSetsController extends APIController
      *     @OA\Property(property="id", ref="#/components/schemas/BibleFileset/properties/id"),
      *     @OA\Property(property="type", ref="#/components/schemas/BibleFileset/properties/set_type_code"),
      *     @OA\Property(property="size", ref="#/components/schemas/BibleFileset/properties/set_size_code"),
-     *     @OA\Property(property="copyright", ref="#/components/schemas/LicenseGroup/properties/copyright"),
+     *     @OA\Property(property="segmentation_type", ref="#/components/schemas/BibleFileset/properties/segmentation_type"),
+     *     @OA\Property(property="asset_id", type="string", description="The S3 bucket / asset identifier the fileset is stored under"),
+     *     @OA\Property(property="copyright", ref="#/components/schemas/v4_bible_filesets.copyright_details"),
+     * )
+     *
+     * @OA\Schema (
+     *     type="object",
+     *     schema="v4_bible_filesets.copyright_details",
+     *     description="Structured copyright metadata returned by CopyrightTransformer",
+     *     title="v4_bible_filesets.copyright_details",
+     *     @OA\Property(property="copyright_date", type="string", format="date", nullable=true, description="Copyright date as recorded in the license group"),
+     *     @OA\Property(property="copyright", type="string", nullable=true, description="Copyright statement text"),
+     *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+     *     @OA\Property(property="updated_at", type="string", format="date-time", nullable=true),
+     *     @OA\Property(property="open_access", type="boolean", default=false, description="Whether the fileset is open access"),
+     *     @OA\Property(property="is_combined", type="boolean", default=false, description="Whether the copyright is combined across multiple licensors"),
+     *     @OA\Property(
+     *         property="organizations",
+     *         type="array",
+     *         description="Licensor organizations associated with this copyright (only present when at least one is attached)",
+     *         @OA\Items(ref="#/components/schemas/v4_bible_filesets.copyright_organization")
+     *     ),
+     * )
+     *
+     * @OA\Schema (
+     *     type="object",
+     *     schema="v4_bible_filesets.copyright_organization",
+     *     description="Organization shape used in the copyright details payload",
+     *     title="v4_bible_filesets.copyright_organization",
+     *     @OA\Property(property="id", type="integer", nullable=true),
+     *     @OA\Property(property="slug", type="string", nullable=true),
+     *     @OA\Property(property="abbreviation", type="string", nullable=true),
+     *     @OA\Property(property="description", type="string", nullable=true),
+     *     @OA\Property(property="description_short", type="string", nullable=true, description="Sourced from the organization's tagline"),
+     *     @OA\Property(property="phone", type="string", nullable=true),
+     *     @OA\Property(property="email", type="string", nullable=true),
+     *     @OA\Property(property="email_director", type="string", nullable=true),
+     *     @OA\Property(property="logos", type="array", @OA\Items(type="object")),
+     *     @OA\Property(property="primaryColor", type="string", nullable=true),
+     *     @OA\Property(property="secondaryColor", type="string", nullable=true),
+     *     @OA\Property(property="inactive", type="boolean", default=false),
+     *     @OA\Property(property="url_site", type="string", description="Sourced from the organization's url_website"),
+     *     @OA\Property(property="url_donate", type="string"),
+     *     @OA\Property(property="url_twitter", type="string"),
+     *     @OA\Property(property="url_facebook", type="string"),
+     *     @OA\Property(property="address", type="string", nullable=true),
+     *     @OA\Property(property="address2", type="string", nullable=true),
+     *     @OA\Property(property="city", type="string", nullable=true),
+     *     @OA\Property(property="state", type="string", nullable=true),
+     *     @OA\Property(property="country", type="string", nullable=true),
+     *     @OA\Property(property="zip", type="string", nullable=true),
+     *     @OA\Property(property="latitude", type="number", format="float", nullable=true),
+     *     @OA\Property(property="longitude", type="number", format="float", nullable=true),
+     *     @OA\Property(property="translations", type="array", @OA\Items(type="object")),
      * )
      *
      * @param string $id
@@ -400,6 +459,7 @@ class BibleFileSetsController extends APIController
     public function copyright($id)
     {
         $iso = checkParam('iso') ?? 'eng';
+        $verify_segmentation = checkBoolean('verify_segmentation');
 
         $cache_params = [$id, $iso];
         $fileset = cacheRemember(
@@ -423,12 +483,13 @@ class BibleFileSetsController extends APIController
                         'bible_filesets.mode_id as mode_id',
                         'bible_filesets.set_type_code as type',
                         'bible_filesets.set_size_code as size',
+                        'bible_filesets.segmentation_type',
                         'bible_filesets.license_group_id'
                     ])->first();
             }
         );
 
-        return $this->reply(fractal($fileset, CopyrightTransformer::class, new ArraySerializer()));
+        return $this->reply(fractal($fileset, new CopyrightTransformer($verify_segmentation), new ArraySerializer()));
     }
 
     /**

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -93,6 +93,12 @@ class BiblesController extends APIController
      *          description="Include country_id field in response. When true, adds country_id field containing the country ID from languages.country_id.",
      *          example="true"
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Parameter(ref="#/components/parameters/page"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      *     @OA\Response(
@@ -116,6 +122,7 @@ class BiblesController extends APIController
         $media_exclude      = checkParam('media_exclude');
         $audio_timing       = checkBoolean('audio_timing');
         $show_country       = checkBoolean('show_country', false);
+        $verify_segmentation = checkBoolean('verify_segmentation');
         $size               = checkParam('size'); #removed from API for initial release
         $size_exclude       = checkParam('size_exclude'); #removed from API for initial release
         $limit              = (int) (checkParam('limit') ?? 50);
@@ -165,7 +172,8 @@ class BiblesController extends APIController
             $order_cache_key,
             $access_group_ids->toString(),
             $audio_timing,
-            $show_country
+            $show_country,
+            $verify_segmentation
         ]);
 
         $bibles = cacheRemember(
@@ -185,7 +193,8 @@ class BiblesController extends APIController
                 $limit,
                 $order_by,
                 $audio_timing,
-                $show_country
+                $show_country,
+                $verify_segmentation
             ) {
                 $bibles = Bible::filterByLanguage($language_code)
                 ->withRequiredFilesets([
@@ -255,7 +264,7 @@ class BiblesController extends APIController
                 $bibles = $bibles->paginate($limit);
                 $bibles_return = fractal(
                     $bibles->getCollection(),
-                    BibleTransformer::class,
+                    new BibleTransformer($verify_segmentation),
                     new DataArraySerializer()
                 );
                 return $bibles_return->paginateWith(new IlluminatePaginatorAdapter($bibles));
@@ -402,6 +411,12 @@ class BiblesController extends APIController
      *          @OA\Schema(type="boolean", default=false),
      *          description="When true, each entry in books includes a filesets array of { id, type } for all filesets that have content for that book; same id can appear with different types."
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -419,6 +434,7 @@ class BiblesController extends APIController
 
         $include_font = is_null(checkParam('include_font')) ? true : checkBoolean('include_font', false);
         $verify_content = is_null(checkParam('verify_content')) ? false : checkBoolean('verify_content', false);
+        $verify_segmentation = checkBoolean('verify_segmentation');
 
         if ($this->v === 2 || $this->v === 3) {
             $id = substr($id, 0, 6);
@@ -445,9 +461,10 @@ class BiblesController extends APIController
                 $access_group_ids,
                 $include_font,
                 $verify_content,
-                $id
+                $id,
+                $verify_segmentation
             ))
-            : $this->reply(fractal($bible, new BibleTransformer(), $this->serializer));
+            : $this->reply(fractal($bible, new BibleTransformer($verify_segmentation), $this->serializer));
     }
 
     private function loadBibleForShow(string $id, $access_group_ids, bool $include_font)
@@ -479,17 +496,17 @@ class BiblesController extends APIController
         );
     }
 
-    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id) : array
+    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false) : array
     {
         return cacheRemember('bibles_show_verify_content_response',
-            [$id, $access_group_ids->toString(), $include_font, $verify_content],
+            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation],
             now()->addDay(),
-            function () use ($bible, $access_group_ids, $verify_content, $id) {
+            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation) {
                 $book_fileset_map = cacheRemember(
                     'bibles_show_book_filesets',
-                    [$id, $access_group_ids->toString(), $verify_content],
+                    [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
                     now()->addDay(),
-                    function () use ($bible) {
+                    function () use ($bible, $verify_segmentation) {
                         $batch_resolver = new FilesetBookIdBatchResolver();
                         $single_resolver = new FilesetBookIdResolver();
                         $fileset_book_ids = $batch_resolver->resolve($bible->filesets);
@@ -499,7 +516,11 @@ class BiblesController extends APIController
                                 ?? $single_resolver->resolve($fileset);
                             foreach ($book_ids as $book_id) {
                                 $map[$book_id] = $map[$book_id] ?? [];
-                                $map[$book_id][] = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
+                                $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
+                                if ($verify_segmentation) {
+                                    $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
+                                }
+                                $map[$book_id][] = $entry;
                             }
                         }
                         return $map;
@@ -512,7 +533,7 @@ class BiblesController extends APIController
                     $book->filesets = array_values($book_fileset_map[$book->book_id] ?? []);
                     return $book;
                 }));
-                return fractal($bible_response, new BibleTransformer(), $this->serializer)->toArray();
+                return fractal($bible_response, new BibleTransformer($verify_segmentation), $this->serializer)->toArray();
             }
         );
     }

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -523,7 +523,7 @@ class PlansController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\Parameter(name="days", in="query", required=true, @OA\Schema(type="integer"), description="Number of days to add to the plan"),
-     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="true"), description="If new days to add should be added to end of list of days")
+     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="boolean"), description="If new days to add should be added to end of list of days"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -107,6 +107,19 @@ class BibleFileset extends Model
      */
     protected $mode_id;
 
+    /**
+     *
+     * @OA\Property(
+     *     property="segmentation_type",
+     *     type="string",
+     *     enum={"section","chapter"},
+     *     nullable=true,
+     *     description="Segmentation strategy for this fileset (section, chapter, or null when unspecified)."
+     * )
+     *
+     */
+    protected $segmentation_type;
+
 
     protected $created_at;
 
@@ -117,7 +130,7 @@ class BibleFileset extends Model
      * @OA\Property(
      *   title="license_group_id",
      *   type="integer",
-     *   description="The liceense group id",
+     *   description="The license group id",
      * )
      */
     protected $license_group_id;

--- a/app/Transformers/BibleTransformer.php
+++ b/app/Transformers/BibleTransformer.php
@@ -12,6 +12,15 @@ class BibleTransformer extends BaseTransformer
 {
 
     use OrganizationFilterTrait;
+
+    private bool $verify_segmentation;
+
+    public function __construct(bool $verify_segmentation = false)
+    {
+        parent::__construct();
+        $this->verify_segmentation = $verify_segmentation;
+    }
+
     /**
      * A Fractal transformer.
      *
@@ -337,6 +346,10 @@ class BibleTransformer extends BaseTransformer
             'type' => $fileset->set_type_code,
             'size' => $fileset->set_size_code,
         ];
+
+        if ($this->verify_segmentation) {
+            $fileset_data['segmentation_type'] = $fileset->segmentation_type ?? null;
+        }
 
         $meta_records_indexed = $fileset->getMetaTagsIndexedByName();
 

--- a/app/Transformers/CopyrightTransformer.php
+++ b/app/Transformers/CopyrightTransformer.php
@@ -9,6 +9,14 @@ class CopyrightTransformer extends BaseTransformer
 {
     use OrganizationFilterTrait;
 
+    private bool $verify_segmentation;
+
+    public function __construct(bool $verify_segmentation = false)
+    {
+        parent::__construct();
+        $this->verify_segmentation = $verify_segmentation;
+    }
+
     /**
      * Transform copyright fileset data, filtering organizations as needed.
      *
@@ -22,6 +30,10 @@ class CopyrightTransformer extends BaseTransformer
             'type' => $fileset->type,
             'size' => $fileset->size,
         ];
+
+        if ($this->verify_segmentation) {
+            $transformed['segmentation_type'] = $fileset->segmentation_type ?? null;
+        }
 
         if (isset($fileset->asset_id)) {
             $transformed['asset_id'] = $fileset->asset_id;

--- a/database/factories/Bible/BibleFactory.php
+++ b/database/factories/Bible/BibleFactory.php
@@ -68,6 +68,9 @@ $factory->define(\App\Models\Bible\BibleFileset::class, function (Faker $faker) 
     ];
 });
 
+$factory->state(\App\Models\Bible\BibleFileset::class, 'segmentation_section', ['segmentation_type' => 'section']);
+$factory->state(\App\Models\Bible\BibleFileset::class, 'segmentation_chapter', ['segmentation_type' => 'chapter']);
+
 $factory->define(\App\Models\Bible\BibleFile::class, function (Faker $faker) {
     return [
         'id'      => '',

--- a/database/migrations/2026_04_28_180000_add_segmentation_type_to_bible_filesets.php
+++ b/database/migrations/2026_04_28_180000_add_segmentation_type_to_bible_filesets.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSegmentationTypeToBibleFilesets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+            $table->enum('segmentation_type', ['section', 'chapter'])
+                ->nullable()
+                ->default(null)
+                ->after('archived');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+            $table->dropColumn('segmentation_type');
+        });
+    }
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -322,6 +322,115 @@
                 }
             }
         },
+        "/download/package-create": {
+            "post": {
+                "tags": [
+                    "Bibles"
+                ],
+                "summary": "Create a download package from filesets",
+                "description": "Accepts a JSON payload containing fileset IDs and an encryption type, then proxies the request to BBHub package creation.",
+                "operationId": "v4_download_package_create",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/version_number"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "filesets",
+                                    "encryptionType"
+                                ],
+                                "properties": {
+                                    "filesets": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "minItems": 1,
+                                        "uniqueItems": true,
+                                        "example": [
+                                            "ENGESVN2DA",
+                                            "ENGESVO1DA"
+                                        ]
+                                    },
+                                    "encryptionType": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Response from the upstream BBHub service (status and body are proxied).",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Request body must be valid JSON.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Request body must be valid JSON."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed for the request body.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "The filesets field is required."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "BBHub is unavailable.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "BBHub is unavailable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/bibles/verses/{language_code}/{book_id}/{chapter_id}/{verse_number?}": {
             "get": {
                 "tags": [
@@ -517,6 +626,25 @@
                         "example": "true"
                     },
                     {
+                        "name": "show_country",
+                        "in": "query",
+                        "description": "Include country_id field in response. When true, adds country_id field containing the country ID from languages.country_id.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "example": "true"
+                    },
+                    {
+                        "name": "verify_segmentation",
+                        "in": "query",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/page"
                     },
                     {
@@ -630,6 +758,24 @@
                     {
                         "name": "include_font",
                         "in": "query"
+                    },
+                    {
+                        "name": "verify_content",
+                        "in": "query",
+                        "description": "When true, each entry in books includes a filesets array of { id, type } for all filesets that have content for that book; same id can appear with different types.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "verify_segmentation",
+                        "in": "query",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     },
                     {
                         "$ref": "#/components/parameters/version_number"
@@ -1566,14 +1712,177 @@
                     "size": {
                         "$ref": "#/components/schemas/BibleFileset/properties/set_size_code"
                     },
+                    "segmentation_type": {
+                        "$ref": "#/components/schemas/BibleFileset/properties/segmentation_type"
+                    },
+                    "asset_id": {
+                        "description": "The S3 bucket / asset identifier the fileset is stored under",
+                        "type": "string"
+                    },
                     "copyright": {
-                        "$ref": "#/components/schemas/BibleFilesetCopyright"
+                        "$ref": "#/components/schemas/v4_bible_filesets.copyright_details"
                     }
                 },
                 "type": "object",
                 "xml": {
                     "name": "v4_bible_filesets.copyright"
                 }
+            },
+            "v4_bible_filesets.copyright_details": {
+                "title": "v4_bible_filesets.copyright_details",
+                "description": "Structured copyright metadata returned by CopyrightTransformer",
+                "properties": {
+                    "copyright_date": {
+                        "description": "Copyright date as recorded in the license group",
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "copyright": {
+                        "description": "Copyright statement text",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "open_access": {
+                        "description": "Whether the fileset is open access",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "is_combined": {
+                        "description": "Whether the copyright is combined across multiple licensors",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "organizations": {
+                        "description": "Licensor organizations associated with this copyright (only present when at least one is attached)",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/v4_bible_filesets.copyright_organization"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "v4_bible_filesets.copyright_organization": {
+                "title": "v4_bible_filesets.copyright_organization",
+                "description": "Organization shape used in the copyright details payload",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "slug": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "abbreviation": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description_short": {
+                        "description": "Sourced from the organization's tagline",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "phone": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "email": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "email_director": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "logos": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "primaryColor": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "secondaryColor": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "inactive": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "url_site": {
+                        "description": "Sourced from the organization's url_website",
+                        "type": "string"
+                    },
+                    "url_donate": {
+                        "type": "string"
+                    },
+                    "url_twitter": {
+                        "type": "string"
+                    },
+                    "url_facebook": {
+                        "type": "string"
+                    },
+                    "address": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "address2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "city": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "state": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "country": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "zip": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "latitude": {
+                        "type": "number",
+                        "format": "float",
+                        "nullable": true
+                    },
+                    "longitude": {
+                        "type": "number",
+                        "format": "float",
+                        "nullable": true
+                    },
+                    "translations": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
             },
             "v4_bible_filesets_download.index": {
                 "title": "v4_bible_filesets_download.index",
@@ -2232,6 +2541,14 @@
                         "minimum": 0,
                         "example": 683,
                         "nullable": true
+                    },
+                    "is_complete_chapter": {
+                        "title": "is_complete_chapter",
+                        "description": "If the file is a complete chapter, this field will be true",
+                        "type": "boolean",
+                        "default": false,
+                        "example": true,
+                        "nullable": false
                     }
                 },
                 "type": "object",
@@ -2300,6 +2617,23 @@
                     },
                     "set_size_code": {
                         "$ref": "#/components/schemas/BibleFilesetSize/properties/set_size_code"
+                    },
+                    "mode_id": {
+                        "$ref": "#/components/schemas/BibleFilesetMode/properties/id"
+                    },
+                    "segmentation_type": {
+                        "description": "Segmentation strategy for this fileset (section, chapter, or null when unspecified).",
+                        "type": "string",
+                        "enum": [
+                            "section",
+                            "chapter"
+                        ],
+                        "nullable": true
+                    },
+                    "license_group_id": {
+                        "title": "license_group_id",
+                        "description": "The license group id",
+                        "type": "integer"
                     }
                 },
                 "type": "object",
@@ -2307,38 +2641,30 @@
                     "name": "BibleFileset"
                 }
             },
-            "BibleFilesetCopyright": {
-                "title": "Bible Fileset Copyright",
-                "description": "BibleFilesetCopyright",
+            "BibleFilesetMode": {
+                "title": "BibleFilesetMode",
+                "description": "The Bible fileset mode model communicates information about generalized fileset modes",
+                "required": [
+                    "filename"
+                ],
                 "properties": {
-                    "copyright_date": {
-                        "title": "copyright_date",
-                        "description": "The copyright date created copyright",
-                        "type": "string",
-                        "example": "2014"
-                    },
-                    "copyright": {
-                        "title": "copyright",
-                        "description": "The copyright",
-                        "type": "string",
-                        "example": "© Ethnos360"
-                    },
-                    "copyright_description": {
-                        "title": "copyright_description",
-                        "description": "The copyright description",
-                        "type": "string",
-                        "example": "© Ethnos360"
-                    },
-                    "open_access": {
-                        "title": "open_access",
-                        "description": "The open_access description",
+                    "id": {
+                        "title": "id",
+                        "description": "The id",
                         "type": "integer",
-                        "example": 1
+                        "minimum": 0,
+                        "example": 4
+                    },
+                    "name": {
+                        "title": "name",
+                        "description": "The name",
+                        "type": "string",
+                        "example": "video"
                     }
                 },
                 "type": "object",
                 "xml": {
-                    "name": "BibleFilesetCopyright"
+                    "name": "BibleFilesetMode"
                 }
             },
             "BibleFilesetSize": {
@@ -3639,6 +3965,50 @@
                     "name": "NumeralSystem"
                 }
             },
+            "LicenseGroup": {
+                "title": "License Group",
+                "description": "LicenseGroup",
+                "properties": {
+                    "id": {
+                        "title": "id",
+                        "description": "The license group id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "name",
+                        "description": "The license group name",
+                        "type": "string",
+                        "maxLength": 64
+                    },
+                    "permission_pattern_id": {
+                        "title": "permission_pattern_id",
+                        "description": "The permission pattern id",
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "description": {
+                        "title": "description",
+                        "description": "The license group description",
+                        "type": "string"
+                    },
+                    "copyright": {
+                        "title": "copyright",
+                        "description": "The copyright text",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_copyright_combined": {
+                        "title": "is_copyright_combined",
+                        "description": "Is this a combined copyright from multiple sources",
+                        "type": "boolean",
+                        "nullable": true
+                    }
+                },
+                "type": "object",
+                "xml": {
+                    "name": "LicenseGroup"
+                }
+            },
             "Asset": {
                 "title": "Asset",
                 "description": "Asset",
@@ -4870,6 +5240,11 @@
                                 },
                                 "date": {
                                     "$ref": "#/components/schemas/Bible/properties/date"
+                                },
+                                "country_id": {
+                                    "description": "Country ID from languages.country_id (only included when show_country=true)",
+                                    "type": "string",
+                                    "nullable": true
                                 },
                                 "filesets": {
                                     "properties": {

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -70,6 +70,60 @@ class BiblesRoutesTest extends ApiV4Test
 
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        // CopyrightTransformer uses ArraySerializer — response is the payload directly, no 'data' wrapper.
+        $payload = json_decode($response->getContent(), true) ?? [];
+        $this->assertArrayNotHasKey(
+            'segmentation_type',
+            $payload,
+            'Default copyright response must not contain segmentation_type'
+        );
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_bible_filesets.copyright
+     * @category Route Path: https://api.dbp.test/bibles/filesets/{fileset_id}/copyright?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BibleFileSetsController::copyright
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleFilesetsCopyrightWithVerifySegmentation()
+    {
+        $fileset = BibleFileset::whereNotNull('segmentation_type')
+            ->where('hidden', 0)
+            ->where('archived', 0)
+            ->inRandomOrder()
+            ->first();
+
+        if (!$fileset) {
+            $this->markTestSkipped('No fileset with non-null segmentation_type seeded in this environment.');
+        }
+
+        $params = array_merge(
+            ['fileset_id' => $fileset->id, 'verify_segmentation' => 'true'],
+            $this->params
+        );
+        $path = route('v4_internal_bible_filesets.copyright', $params);
+        echo "\nTesting: $path";
+
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        // CopyrightTransformer uses ArraySerializer — response is the payload directly, no 'data' wrapper.
+        $payload = json_decode($response->getContent(), true) ?? [];
+        $this->assertArrayHasKey(
+            'segmentation_type',
+            $payload,
+            'verify_segmentation=true must include segmentation_type key in copyright response'
+        );
+        $this->assertContains(
+            $payload['segmentation_type'],
+            ['section', 'chapter', null],
+            'segmentation_type must be section, chapter, or null'
+        );
     }
 
     /**
@@ -255,6 +309,82 @@ class BiblesRoutesTest extends ApiV4Test
         echo "\nTesting: $path";
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "Default v4_bible.one response must not contain segmentation_type for fileset {$fileset['id']}"
+                );
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_bible.one
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::show
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleOneWithVerifySegmentation()
+    {
+        // Discover an accessible bible whose filesets carry segmentation_type by hitting v4_bible.all first.
+        $index_path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        $index_response = $this->withHeaders($this->params)->get($index_path);
+        $index_response->assertSuccessful();
+        $index_decoded = json_decode($index_response->getContent(), true);
+        $index_payload = is_array($index_decoded) ? ($index_decoded['data'] ?? []) : [];
+
+        $bible_id = null;
+        foreach ($index_payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    if (!is_null($fileset['segmentation_type'] ?? null)) {
+                        $bible_id = $bible['abbr'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if (!$bible_id) {
+            $this->markTestSkipped('No accessible bible with a fileset carrying non-null segmentation_type in this environment.');
+        }
+
+        $path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        $checked_fileset_count = 0;
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "verify_segmentation=true must include segmentation_type for fileset {$fileset['id']}"
+                );
+                $this->assertContains(
+                    $fileset['segmentation_type'],
+                    ['section', 'chapter', null],
+                    "segmentation_type must be section, chapter, or null for fileset {$fileset['id']}"
+                );
+                $checked_fileset_count++;
+            }
+        }
+        $this->assertGreaterThan(0, $checked_fileset_count, 'Expected at least one fileset to verify');
     }
 
     /**
@@ -273,5 +403,59 @@ class BiblesRoutesTest extends ApiV4Test
         echo "\nTesting: $path";
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    $this->assertArrayNotHasKey(
+                        'segmentation_type',
+                        $fileset,
+                        "Default v4_bible.all response must not contain segmentation_type for fileset {$fileset['id']}"
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_bible.all
+     * @category Route Path: https://api.dbp.test/bibles?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::index
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleAllWithVerifySegmentation()
+    {
+        $path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        $checked_fileset_count = 0;
+        foreach ($payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    $this->assertArrayHasKey(
+                        'segmentation_type',
+                        $fileset,
+                        "verify_segmentation=true must include segmentation_type for fileset {$fileset['id']}"
+                    );
+                    $this->assertContains(
+                        $fileset['segmentation_type'],
+                        ['section', 'chapter', null],
+                        "segmentation_type must be section, chapter, or null for fileset {$fileset['id']}"
+                    );
+                    $checked_fileset_count++;
+                }
+            }
+        }
+        $this->assertGreaterThan(0, $checked_fileset_count, 'Expected at least one fileset to verify');
     }
 }


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 90116](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/90116): Public API: Display Segmentation type

# Description

This change exposes the new `bible_filesets.segmentation_type` column on the Public API behind an opt-in `verify_segmentation=true` query parameter, mirroring the existing `verify_content` pattern. When the flag is absent or false, every affected response is byte-identical to today, existing consumers (Amplify and others) see no change. When the flag is true, every fileset object grows one always-present key `segmentation_type` whose value is `"section"`, `"chapter"`, or JSON `null`.

## What Changed

### 1. New Database Column: `segmentation_type` on `bible_filesets`

A new `segmentation_type` enum column was added to the `bible_filesets` table on the `dbp` connection. Allowed values: `'section'`, `'chapter'`. Default `NULL`.

### 2. Endpoints Wired (audit result)

| Endpoint | Route name | Wire flag? |
|---|---|---|
| `GET /bibles/{id}` | `v4_bible.one` | **Yes (primary)** |
| `GET /bibles` | `v4_bible.all` | **Yes** |
| `GET /bibles/filesets/{id}/copyright` | `v4_internal_bible_filesets.copyright` | **Yes** |

### 3. Transformer Updates

Both `BibleTransformer` and `CopyrightTransformer` now take a constructor argument `bool $verify_segmentation = false`:

- `BibleTransformer::filesetWithMeta()` conditionally appends `segmentation_type` to the per-fileset array. Used by `v4_bible.one` and `v4_bible.all`.
- `CopyrightTransformer::transform()` conditionally appends `segmentation_type` to the response.
- `BiblesController::buildVerifyContentResponsePayload()` per-book fileset map (`bibles_show_book_filesets` cache) conditionally appends `segmentation_type` to each `book.filesets[]` entry alongside `id` and `type` so per-book references stay consistent with the top-level filesets array. Inner cache key is partitioned by the flag.

Constructor injection avoids transformers reading HTTP request state directly and keeps each fileset path independent of the others.

### 4. Cache Key Partitioning

| Cache key | Partitioned by `verify_segmentation`? | Reason |
|---|---|---|
| `bibles_show` (`loadBibleForShow`) | No | Cached value is the Eloquent Bible model — column is loaded the same way regardless. Adding the flag would double cache rows for no benefit. |
| `bibles_show_verify_content_response` | **Yes** | Caches `->toArray()` of the Fractal output, which contains the new key. |
| `bibles_show_book_filesets` | **Yes** | Caches the book→fileset map, whose entries vary by flag. |
| `bibles` (index) | **Yes** | Caches the populated Fractal paginator — output varies by flag. |
| `bible_fileset_license_group_copyright` | No | Column is always selected; the model carries it regardless, and only the transformer decides whether to expose it. |

### 5. OpenAPI / Swagger

- `@OA\Parameter` blocks added on each affected endpoint's docblock.
- New `@OA\Property` on `BibleFileset` model documenting `segmentation_type` (enum `{section, chapter}`, nullable).
- `v4_bible_filesets.copyright` schema updated to reference the new property.

### 6. Tests

Integration tests in `tests/Integration/BiblesRoutesTest.php`:

- Existing smoke tests `bibleOne`, `bibleAll`, `bibleFilesetsCopyright` extended with **absence** assertions (no `segmentation_type` key in default response).
- New `bibleOneWithVerifySegmentation`, `bibleAllWithVerifySegmentation`, `bibleFilesetsCopyrightWithVerifySegmentation` tests assert **presence** of the key for every fileset returned, with value validity (`'section'`, `'chapter'`, or `null`).

`database/factories/Bible/BibleFactory.php` gained two states (`segmentation_section`, `segmentation_chapter`) for any future unit test that wants explicit fixtures. The factory default was deliberately left unchanged so existing tests using `factory(BibleFileset::class)` are unaffected.

## Response Shape

### Default (flag absent or false)

```json
{
  "id": "BILTAOA",
  "type": "audio",
  "size": "NT"
}
```

### With `verify_segmentation=true`

```json
{
  "id": "BILTAOA",
  "type": "audio",
  "size": "NT",
  "segmentation_type": "section"
}
```

```json
{
  "id": "SOMEFSET",
  "type": "audio",
  "size": "NT",
  "segmentation_type": null
}
```

The key is **always present** when the flag is on, even when the underlying column is `NULL` (rendered as JSON `null`).

When combined with `verify_content=true`, the per-book references under `data.books[].filesets[]` carry the same key:

```json
{
  "id": "BILTAOA",
  "type": "audio",
  "segmentation_type": "section"
}
```

## How Do I QA This

You can verify this change using the following Postman folder:

[verify_segmentation Postman folder](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-ed621b51-4b74-41dc-bf14-d878b22285e6?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

Suggested manual QA steps:

1. **Default path (no flag)** — confirm the response is byte-identical to today (no `segmentation_type` key anywhere).
2. **`verify_segmentation=true`** on each in-scope endpoint:
   - `GET /bibles/{id}?verify_segmentation=true`
   - `GET /bibles?verify_segmentation=true`
   - `GET /bibles/filesets/{id}/copyright?verify_segmentation=true`
   Verify every fileset object carries the key with a valid value (`section`, `chapter`, or `null`).
3. **Combined with `verify_content=true`** — check that per-book fileset references under `books[].filesets[]` also carry the key.
4. **Cache contamination** — call each endpoint without the flag, then with `=true`, then without again. Each call should match its own flag state.
5. **404 / error paths** — invalid bible id with and without the flag should return identical 404 responses.