### PR TITLE
Task-90749 Public API: Add per-book verse_starts payload to /bibles/{id}

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -30,6 +30,7 @@ use App\Models\Language\Language;
 use App\Services\Bibles\BibleFilesetService;
 use App\Services\Bibles\FilesetBookIdBatchResolver;
 use App\Services\Bibles\FilesetBookIdResolver;
+use App\Services\Bibles\FilesetVerseStartsResolver;
 use Exception;
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;
@@ -415,7 +416,7 @@ class BiblesController extends APIController
      *          name="verify_segmentation",
      *          in="query",
      *          @OA\Schema(type="boolean", default=false),
-     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries."
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -506,7 +507,10 @@ class BiblesController extends APIController
                     'bibles_show_book_filesets',
                     [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
                     now()->addDay(),
-                    function () use ($bible, $verify_segmentation) {
+                    function () use ($bible, $access_group_ids, $id, $verify_segmentation) {
+                        $verse_starts_map = $verify_segmentation
+                            ? $this->loadVerseStartsMap($bible, $id, $access_group_ids)
+                            : [];
                         $batch_resolver = new FilesetBookIdBatchResolver();
                         $single_resolver = new FilesetBookIdResolver();
                         $fileset_book_ids = $batch_resolver->resolve($bible->filesets);
@@ -519,6 +523,9 @@ class BiblesController extends APIController
                                 $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
                                 if ($verify_segmentation) {
                                     $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
+                                    if (isset($verse_starts_map[$fileset->hash_id][$book_id])) {
+                                        $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
+                                    }
                                 }
                                 $map[$book_id][] = $entry;
                             }
@@ -534,6 +541,34 @@ class BiblesController extends APIController
                     return $book;
                 }));
                 return fractal($bible_response, new BibleTransformer($verify_segmentation), $this->serializer)->toArray();
+            }
+        );
+    }
+
+    /**
+     * Load the verse_starts map for any qualifying section-segmented audio filesets on the bible.
+     * The map is keyed by hash_id then book_id, so attaching per-book entries is constant-time.
+     * Returns an empty array when no fileset qualifies (no DB query is issued in that case).
+     *
+     * The cache key includes the access group fingerprint because $bible->filesets
+     * is already filtered by isContentAvailable(); a narrower-access request must
+     * not poison the cache for a broader-access request that can see additional
+     * qualifying filesets.
+     */
+    private function loadVerseStartsMap(Bible $bible, string $bible_id, $access_group_ids) : array
+    {
+        $resolver = new FilesetVerseStartsResolver();
+        $qualifying_filesets = $resolver->qualifyingFilesets($bible->filesets);
+        if ($qualifying_filesets->isEmpty()) {
+            return [];
+        }
+
+        return cacheRemember(
+            'bibles_show_verse_starts',
+            [$bible_id, $access_group_ids->toString()],
+            now()->addDay(),
+            function () use ($resolver, $qualifying_filesets) {
+                return $resolver->resolveForFilesets($qualifying_filesets);
             }
         );
     }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -53,6 +53,13 @@ class BibleFileset extends Model
     public const TYPE_TEXT_PLAIN = 'text_plain';
     public const TYPE_TEXT_USX = 'text_usx';
 
+    public const AUDIO_TYPES = [
+        self::TYPE_AUDIO,
+        self::TYPE_AUDIO_DRAMA,
+        self::TYPE_AUDIO_STREAM,
+        self::TYPE_AUDIO_DRAMA_STREAM,
+    ];
+
     public const NEW_TEXT_PLAIN_FILESET_LENGTH = 10;
     public const OLD_TEXT_PLAIN_FILESET_LENGTH = 6;
     public const V1_AUDIO_16_KBPS_FILESET_LENGTH = 12;
@@ -120,6 +127,22 @@ class BibleFileset extends Model
      */
     protected $segmentation_type;
 
+    /**
+     *
+     * @OA\Property(
+     *     property="verse_starts",
+     *     type="array",
+     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+     *     @OA\Items(
+     *         type="object",
+     *         @OA\Property(property="chapter_start",   type="integer", example=1, description="The starting chapter of the section."),
+     *         @OA\Property(property="verse_start",     ref="#/components/schemas/BibleFile/properties/verse_sequence"),
+     *         @OA\Property(property="verse_start_alt", ref="#/components/schemas/BibleFile/properties/verse_start")
+     *     )
+     * )
+     *
+     */
+    protected $verse_starts;
 
     protected $created_at;
 
@@ -460,15 +483,7 @@ class BibleFileset extends Model
      */
     public function isAudio() : bool
     {
-        return in_array(
-            $this['set_type_code'],
-            [
-                BibleFileset::TYPE_AUDIO_DRAMA,
-                BibleFileset::TYPE_AUDIO,
-                BibleFileset::TYPE_AUDIO_DRAMA,
-                BibleFileset::TYPE_AUDIO_DRAMA_STREAM
-            ]
-        );
+        return in_array($this['set_type_code'], self::AUDIO_TYPES, true);
     }
 
     /**

--- a/app/Services/Bibles/FilesetVerseStartsResolver.php
+++ b/app/Services/Bibles/FilesetVerseStartsResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\Bibles;
+
+use App\Models\Bible\BibleFile;
+use Illuminate\Support\Collection;
+
+class FilesetVerseStartsResolver
+{
+    private const SEGMENTATION_TYPE_SECTION = 'section';
+
+    /**
+     * Filter the in-memory fileset collection down to those that should
+     * carry verse_starts: section-segmented audio filesets.
+     *
+     * Pure in-memory: relies on segmentation_type and set_type_code which
+     * are already loaded on every BibleFileset returned by the show query.
+     */
+    public function qualifyingFilesets(Collection $filesets) : Collection
+    {
+        return $filesets->filter(function ($fileset) {
+            return ($fileset->segmentation_type ?? null) === self::SEGMENTATION_TYPE_SECTION
+                && $fileset->isAudio();
+        })->values();
+    }
+
+    /**
+     * Fetch verse_starts data for the qualifying filesets in a single
+     * batched query and return a map keyed first by hash_id, then by
+     * book_id, so per-book attach lookups are constant-time.
+     *
+     * @return array<string, array<string, array<int, array{chapter_start: int|null, verse_start: int|null, verse_start_alt: string|null}>>>
+     */
+    public function resolveForFilesets(Collection $qualifying_filesets) : array
+    {
+        $hash_ids = $qualifying_filesets->pluck('hash_id')->unique()->values();
+        if ($hash_ids->isEmpty()) {
+            return [];
+        }
+
+        $rows = BibleFile::select(['hash_id', 'book_id', 'chapter_start', 'verse_start', 'verse_sequence'])
+            ->whereIn('hash_id', $hash_ids)
+            ->orderBy('hash_id')
+            ->orderBy('book_id')
+            ->orderBy('chapter_start')
+            ->orderBy('verse_sequence')
+            ->get();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row->hash_id][$row->book_id][] = [
+                'chapter_start' => $row->chapter_start,
+                'verse_start' => $row->verse_sequence,
+                'verse_start_alt' => $row->verse_start,
+            ];
+        }
+        return $map;
+    }
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -771,7 +771,7 @@
                     {
                         "name": "verify_segmentation",
                         "in": "query",
-                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries.",
                         "schema": {
                             "type": "boolean",
                             "default": false
@@ -2629,6 +2629,26 @@
                             "chapter"
                         ],
                         "nullable": true
+                    },
+                    "verse_starts": {
+                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "chapter_start": {
+                                    "description": "The starting chapter of the section.",
+                                    "type": "integer",
+                                    "example": 1
+                                },
+                                "verse_start": {
+                                    "$ref": "#/components/schemas/BibleFile/properties/verse_sequence"
+                                },
+                                "verse_start_alt": {
+                                    "$ref": "#/components/schemas/BibleFile/properties/verse_start"
+                                }
+                            },
+                            "type": "object"
+                        }
                     },
                     "license_group_id": {
                         "title": "license_group_id",

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -389,6 +389,165 @@ class BiblesRoutesTest extends ApiV4Test
 
     /**
      * @category V4_API
+     * @category Route Name: v4_bible.one
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true&verify_content=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::show
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleOneWithVerseStarts()
+    {
+        $audio_types = BibleFileset::AUDIO_TYPES;
+
+        // Discover an accessible bible whose filesets carry a section-segmented audio fileset.
+        $index_path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        $index_response = $this->withHeaders($this->params)->get($index_path);
+        $index_response->assertSuccessful();
+        $index_decoded = json_decode($index_response->getContent(), true);
+        $index_payload = is_array($index_decoded) ? ($index_decoded['data'] ?? []) : [];
+
+        $bible_id = null;
+        foreach ($index_payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    if (
+                        ($fileset['segmentation_type'] ?? null) === 'section'
+                        && in_array($fileset['type'] ?? null, $audio_types, true)
+                    ) {
+                        $bible_id = $bible['abbr'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if (!$bible_id) {
+            $this->markTestSkipped('No accessible bible with a section-segmented audio fileset in this environment.');
+        }
+
+        // Both flags: per-book verse_starts must appear on qualifying filesets only.
+        $path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        // Top-level filesets map must NOT include verse_starts.
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "Top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+            }
+        }
+
+        $qualifying_book_filesets = 0;
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $is_qualifying = ($book_fileset['segmentation_type'] ?? null) === 'section'
+                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
+                if ($is_qualifying) {
+                    $this->assertArrayHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "Qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
+                    );
+                    $this->assertIsArray($book_fileset['verse_starts']);
+                    $this->assertNotEmpty(
+                        $book_fileset['verse_starts'],
+                        "verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
+                    );
+                    foreach ($book_fileset['verse_starts'] as $entry) {
+                        $this->assertArrayHasKey('chapter_start', $entry);
+                        $this->assertArrayHasKey('verse_start', $entry);
+                        $this->assertArrayHasKey('verse_start_alt', $entry);
+                        $this->assertArrayNotHasKey(
+                            'book_id',
+                            $entry,
+                            "verse_starts entry must not carry book_id (implied by the parent book)"
+                        );
+                    }
+                    $qualifying_book_filesets++;
+                } else {
+                    $this->assertArrayNotHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "Non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                    );
+                }
+            }
+        }
+        $this->assertGreaterThan(0, $qualifying_book_filesets, 'Expected at least one qualifying per-book fileset entry');
+
+        // verify_segmentation alone: verse_starts must be absent everywhere.
+        // Cache is flushed between scenarios so each request gets a fresh Bible model
+        // (mimics production Memcached, where each request deserializes a fresh copy).
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $seg_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
+            $this->params
+        ));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($seg_only_path),
+            'verify_segmentation=true alone'
+        );
+
+        // verify_content alone: verse_starts must be absent everywhere.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $content_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_content' => 'true'],
+            $this->params
+        ));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($content_only_path),
+            'verify_content=true alone'
+        );
+
+        // Default request: verse_starts must be absent everywhere.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $default_path = route('v4_bible.one', array_merge(['bible_id' => $bible_id], $this->params));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($default_path),
+            'default request'
+        );
+    }
+
+    private function assertNoVerseStartsAnywhere($response, string $context) : void
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+            }
+        }
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                );
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
      * @category Route Name: v4_bible.all
      * @category Route Path: https://api.dbp.test/bibles?v=4&key={key}
      * @see      \App\Http\Controllers\Bible\BiblesController::index


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 90749](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/90749): Public API: Add per-book verse_starts payload to /bibles/{id} when verify_segmentation=true and verify_content=true

# Description

This change extends the `verify_segmentation=true` payload on `GET /bibles/{id}` so that section-segmented audio filesets can publish their section boundaries inline. When a request combines `verify_segmentation=true` AND `verify_content=true`, every qualifying fileset entry under `data.books[].filesets[]` grows a new `verse_starts` array of `{chapter_start, verse_start, verse_start_alt}` items, scoped to that parent book.

# Context

- Original concern + flat-array proposal from the Amplify team.
- Approved middle-road structure (per-book nesting, both flags required, no `book_id` on entries).

# Performance characteristics

The original concern from the Amplify team was that any extra DB work on the non-qualifying path would compound across the catalogue, since the client cannot know which Bibles have section-segmented filesets and will send `verify_segmentation=true` on every call. The implementation preserves that constraint and goes one step further:

| Request shape | Extra work |
|---|---|
| `verify_segmentation` unset / false (any `verify_content`) | None |
| `verify_segmentation=true`, `verify_content=false` | **None** — `loadVerseStartsMap` is never called on this branch |
| Both true, no qualifying fileset | `Collection::filter` on the already-loaded fileset models. Microseconds. No DB query, no cache lookup |
| Both true, ≥1 qualifying fileset | One `cacheRemember` lookup; on cache miss, one batched `WHERE hash_id IN (...)` against `bible_files` (covered by the existing unique index). Cached for 24h |


# Response Shape

## Default (no flag, or `verify_segmentation=true` alone, or `verify_content=true` alone)

Byte-identical to today. Per-book entries (when `verify_content=true`) keep the existing `{id, type, segmentation_type}` shape (`segmentation_type` only when `verify_segmentation` is also on, per Task-90116). No `verse_starts` anywhere.

## With `verify_segmentation=true&verify_content=true`

```json
{
  "data": {
    "abbr": "ENGESV",
    "name": "English Standard Version",
    "books": [
      {
        "book_id": "COL",
        "name": "Colossians",
        "chapters": [1, 2, 3, 4],
        "book_seq": "B12",
        "testament": "NT",
        "filesets": [
          {
            "id": "ENGESVN2DA",
            "type": "audio_drama",
            "segmentation_type": "section",
            "verse_starts": [
              { "chapter_start": 1, "verse_start": 1,  "verse_start_alt": "1"  },
              { "chapter_start": 1, "verse_start": 17, "verse_start_alt": "17" },
              { "chapter_start": 2, "verse_start": 1,  "verse_start_alt": "1"  },
              { "chapter_start": 3, "verse_start": 1,  "verse_start_alt": "1"  },
              { "chapter_start": 3, "verse_start": 6,  "verse_start_alt": "6"  },
              { "chapter_start": 3, "verse_start": 13, "verse_start_alt": "13" },
              { "chapter_start": 4, "verse_start": 1,  "verse_start_alt": "1"  },
              { "chapter_start": 4, "verse_start": 12, "verse_start_alt": "12" }
            ]
          },
          { "id": "ENGESVN1DA-opus16", "type": "audio",     "segmentation_type": "chapter" },
          { "id": "ENGESVN_ET-json",   "type": "text_json", "segmentation_type": null     }
        ]
      }
    ],
    "filesets": {
      "dbp-prod": [
        { "id": "ENGESVN2DA",      "type": "audio_drama", "size": "NT", "segmentation_type": "section" },
        { "id": "ENGESVN_ET-json", "type": "text_json",   "size": "NT", "segmentation_type": null     }
      ]
    }
  }
}
```

Notes:
- `verse_starts` is present only on per-book filesets that are audio AND have `segmentation_type='section'`. Non-qualifying filesets in the same per-book list keep their `{id, type, segmentation_type}` shape.
- `book_id` is intentionally absent from each entry — it is implied by the parent book.
- `verse_start` is the numeric value (`bible_files.verse_sequence`). `verse_start_alt` preserves the original `bible_files.verse_start` char form, including alphanumeric markers like `001`, `2b`, `10a`.
- Within each book, entries are returned in canonical order: ascending `chapter_start`, then ascending `verse_sequence`.

# How Do I QA This

Suggested manual QA steps:

1. **Default path (no flag)** — confirm the response is byte-identical to today (no `verse_starts` anywhere; no `segmentation_type` anywhere).
2. **`verify_segmentation=true` alone** on a Bible known to have a section-segmented audio fileset — confirm `segmentation_type` appears on every fileset (Task-90116 behaviour preserved) but `verse_starts` is absent everywhere.
3. **`verify_content=true` alone** — confirm per-book filesets list appears as today (`{id, type}`, no `segmentation_type`, no `verse_starts`).
4. **Both flags** on the same Bible:
   - `verse_starts` must be present on per-book entries that are audio AND have `segmentation_type='section'`.
   - Each `verse_starts` entry has exactly `chapter_start`, `verse_start`, `verse_start_alt` (no `book_id`).
   - `verse_starts` is absent on non-qualifying per-book entries (text, video, or chapter-segmented audio).
   - The top-level `filesets` map carries `segmentation_type` but NOT `verse_starts`.
   - Entries are sorted ascending by `chapter_start` then `verse_start` (numeric — verse 2 comes before verse 10).
5. **Both flags on a Bible with no qualifying fileset** — confirm response is identical to the `verify_segmentation=true` + `verify_content=true` shape but with no `verse_starts` keys; tail the query log to confirm no `bible_files` query fires.
6. I have create a postman test to validate this change:
[bible by ID + segmentation_type = section + verses start](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/request/12519377-d8a68755-8f17-45cf-9568-e63c7e47cf7e?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135)

# Incidental fix

`BibleFileset::isAudio()` previously had a typo bug: the in-array list duplicated `TYPE_AUDIO_DRAMA` and omitted `TYPE_AUDIO_STREAM`, so any caller asking "is this an audio fileset?" would silently miss `audio_stream` filesets. This PR fixes the helper to use the new `BibleFileset::AUDIO_TYPES` class constant — `[TYPE_AUDIO, TYPE_AUDIO_DRAMA, TYPE_AUDIO_STREAM, TYPE_AUDIO_DRAMA_STREAM]` — and the resolver, the download controller, and the multi-mp3-chapter trait all share that one source of truth.

Affected pre-existing call sites (now correctly include `audio_stream`):
- `BibleFilesetsDownloadController::download` — triggers `UserDownload` creation when an authenticated user downloads an audio fileset.
- `BibleFileSetsTrait::hasMultiMp3Chapter` — drives the multi-MP3-chapter routing for media playback.

Both are semantically audio-handling paths; including `audio_stream` is the correct behaviour and brings them in line with what `BibleFileset::getsetTypeCodeFromMedia(BibleFileset::AUDIO)` already returns elsewhere in the codebase.