### PR TITLE
Task-90749 Public API: Add per-book verse_starts payload to /bibles/{id}

### DIFF
--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -416,7 +416,13 @@ class BiblesController extends APIController
      *          name="verify_segmentation",
      *          in="query",
      *          @OA\Schema(type="boolean", default=false),
-     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries."
+     *          description="When true, the top-level filesets map exposes a segmentation_type key on each fileset entry (section, chapter, or null). This metadata is intentionally not duplicated under books[].filesets[]; clients should consult the top-level map for fileset-level metadata."
+     *     ),
+     *     @OA\Parameter(
+     *          name="verse_starts",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries. Setting this parameter implicitly enables verify_segmentation=true and verify_content=true; sending verify_segmentation=true and verify_content=true alone does NOT return verse_starts."
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -436,6 +442,11 @@ class BiblesController extends APIController
         $include_font = is_null(checkParam('include_font')) ? true : checkBoolean('include_font', false);
         $verify_content = is_null(checkParam('verify_content')) ? false : checkBoolean('verify_content', false);
         $verify_segmentation = checkBoolean('verify_segmentation');
+        $include_verse_starts = checkBoolean('verse_starts');
+        if ($include_verse_starts) {
+            $verify_segmentation = true;
+            $verify_content = true;
+        }
 
         if ($this->v === 2 || $this->v === 3) {
             $id = substr($id, 0, 6);
@@ -463,7 +474,8 @@ class BiblesController extends APIController
                 $include_font,
                 $verify_content,
                 $id,
-                $verify_segmentation
+                $verify_segmentation,
+                $include_verse_starts
             ))
             : $this->reply(fractal($bible, new BibleTransformer($verify_segmentation), $this->serializer));
     }
@@ -497,18 +509,18 @@ class BiblesController extends APIController
         );
     }
 
-    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false) : array
+    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false, bool $include_verse_starts = false) : array
     {
         return cacheRemember('bibles_show_verify_content_response',
-            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation],
+            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation, $include_verse_starts],
             now()->addDay(),
-            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation) {
+            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation, $include_verse_starts) {
                 $book_fileset_map = cacheRemember(
                     'bibles_show_book_filesets',
-                    [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
+                    [$id, $access_group_ids->toString(), $verify_content, $include_verse_starts],
                     now()->addDay(),
-                    function () use ($bible, $access_group_ids, $id, $verify_segmentation) {
-                        $verse_starts_map = $verify_segmentation
+                    function () use ($bible, $access_group_ids, $id, $include_verse_starts) {
+                        $verse_starts_map = $include_verse_starts
                             ? $this->loadVerseStartsMap($bible, $id, $access_group_ids)
                             : [];
                         $batch_resolver = new FilesetBookIdBatchResolver();
@@ -521,11 +533,8 @@ class BiblesController extends APIController
                             foreach ($book_ids as $book_id) {
                                 $map[$book_id] = $map[$book_id] ?? [];
                                 $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
-                                if ($verify_segmentation) {
-                                    $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
-                                    if (isset($verse_starts_map[$fileset->hash_id][$book_id])) {
-                                        $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
-                                    }
+                                if ($include_verse_starts && isset($verse_starts_map[$fileset->hash_id][$book_id])) {
+                                    $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
                                 }
                                 $map[$book_id][] = $entry;
                             }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -132,7 +132,7 @@ class BibleFileset extends Model
      * @OA\Property(
      *     property="verse_starts",
      *     type="array",
-     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when verse_starts=true is sent (which implicitly enables verify_segmentation=true and verify_content=true), and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
      *     @OA\Items(
      *         type="object",
      *         @OA\Property(property="chapter_start",   type="integer", example=1, description="The starting chapter of the section."),

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -771,7 +771,16 @@
                     {
                         "name": "verify_segmentation",
                         "in": "query",
-                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries.",
+                        "description": "When true, the top-level filesets map exposes a segmentation_type key on each fileset entry (section, chapter, or null). This metadata is intentionally not duplicated under books[].filesets[]; clients should consult the top-level map for fileset-level metadata.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "verse_starts",
+                        "in": "query",
+                        "description": "When true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries. Setting this parameter implicitly enables verify_segmentation=true and verify_content=true; sending verify_segmentation=true and verify_content=true alone does NOT return verse_starts.",
                         "schema": {
                             "type": "boolean",
                             "default": false
@@ -2631,7 +2640,7 @@
                         "nullable": true
                     },
                     "verse_starts": {
-                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when verse_starts=true is sent (which implicitly enables verify_segmentation=true and verify_content=true), and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
                         "type": "array",
                         "items": {
                             "properties": {

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -390,7 +390,7 @@ class BiblesRoutesTest extends ApiV4Test
     /**
      * @category V4_API
      * @category Route Name: v4_bible.one
-     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true&verify_content=true
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verse_starts=true
      * @see      \App\Http\Controllers\Bible\BiblesController::show
      * @group    BibleRoutes
      * @group    V4
@@ -427,70 +427,62 @@ class BiblesRoutesTest extends ApiV4Test
             $this->markTestSkipped('No accessible bible with a section-segmented audio fileset in this environment.');
         }
 
-        // Both flags: per-book verse_starts must appear on qualifying filesets only.
-        $path = route('v4_bible.one', array_merge(
+        // Scenario 1: all three flags explicit — per-book verse_starts must appear on qualifying filesets.
+        $all_flags_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true', 'verse_starts' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $all_flags_path";
+        $qualifying = $this->assertVerseStartsPresentOnQualifyingFilesets(
+            $this->withHeaders($this->params)->get($all_flags_path),
+            $audio_types,
+            'verify_segmentation=true & verify_content=true & verse_starts=true'
+        );
+        $this->assertGreaterThan(0, $qualifying, 'Expected at least one qualifying per-book fileset entry');
+
+        // Scenario 2 (behavior change): verify_segmentation=true & verify_content=true WITHOUT verse_starts
+        // must produce no verse_starts anywhere; the per-book filesets array is still emitted
+        // (verify_content is on), but per-book entries must NOT carry segmentation_type — that key
+        // is exposed only on the top-level filesets map. Top-level entries DO carry segmentation_type
+        // because verify_segmentation is explicitly on.
+        // Cache is flushed between scenarios so each request gets a fresh Bible model
+        // (mimics production Memcached, where each request deserializes a fresh copy).
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $combined_no_verse_starts_path = route('v4_bible.one', array_merge(
             ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true'],
             $this->params
         ));
-        echo "\nTesting: $path";
-        $response = $this->withHeaders($this->params)->get($path);
-        $response->assertSuccessful();
+        $combined_response = $this->withHeaders($this->params)->get($combined_no_verse_starts_path);
+        $this->assertNoVerseStartsAnywhere(
+            $combined_response,
+            'verify_segmentation=true & verify_content=true without verse_starts'
+        );
+        $this->assertTopLevelSegmentationTypePresentAndNoPerBookDuplicate(
+            $combined_response,
+            'verify_segmentation=true & verify_content=true without verse_starts'
+        );
 
-        $decoded = json_decode($response->getContent(), true);
-        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
-
-        // Top-level filesets map must NOT include verse_starts.
-        foreach ($payload['filesets'] ?? [] as $asset_group) {
-            foreach ($asset_group as $fileset) {
-                $this->assertArrayNotHasKey(
-                    'verse_starts',
-                    $fileset,
-                    "Top-level fileset {$fileset['id']} must not include verse_starts"
-                );
-            }
-        }
-
-        $qualifying_book_filesets = 0;
-        foreach ($payload['books'] ?? [] as $book) {
-            foreach ($book['filesets'] ?? [] as $book_fileset) {
-                $is_qualifying = ($book_fileset['segmentation_type'] ?? null) === 'section'
-                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
-                if ($is_qualifying) {
-                    $this->assertArrayHasKey(
-                        'verse_starts',
-                        $book_fileset,
-                        "Qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
-                    );
-                    $this->assertIsArray($book_fileset['verse_starts']);
-                    $this->assertNotEmpty(
-                        $book_fileset['verse_starts'],
-                        "verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
-                    );
-                    foreach ($book_fileset['verse_starts'] as $entry) {
-                        $this->assertArrayHasKey('chapter_start', $entry);
-                        $this->assertArrayHasKey('verse_start', $entry);
-                        $this->assertArrayHasKey('verse_start_alt', $entry);
-                        $this->assertArrayNotHasKey(
-                            'book_id',
-                            $entry,
-                            "verse_starts entry must not carry book_id (implied by the parent book)"
-                        );
-                    }
-                    $qualifying_book_filesets++;
-                } else {
-                    $this->assertArrayNotHasKey(
-                        'verse_starts',
-                        $book_fileset,
-                        "Non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
-                    );
-                }
-            }
-        }
-        $this->assertGreaterThan(0, $qualifying_book_filesets, 'Expected at least one qualifying per-book fileset entry');
+        // Scenario 3: verse_starts=true alone — implicit-enable contract. The response shape must match
+        // Scenario 1: per-book filesets present (verify_content implicitly on), top-level filesets carry
+        // segmentation_type (verify_segmentation implicitly on), and verse_starts is attached to qualifying
+        // audio filesets under books[].filesets[]. Per-book entries themselves carry only {id, type, verse_starts?}.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $verse_starts_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verse_starts' => 'true'],
+            $this->params
+        ));
+        $qualifying_implicit = $this->assertVerseStartsPresentOnQualifyingFilesets(
+            $this->withHeaders($this->params)->get($verse_starts_only_path),
+            $audio_types,
+            'verse_starts=true alone (implicit-enable)'
+        );
+        $this->assertGreaterThan(
+            0,
+            $qualifying_implicit,
+            'verse_starts=true alone must implicitly enable verify_content and produce qualifying per-book filesets'
+        );
 
         // verify_segmentation alone: verse_starts must be absent everywhere.
-        // Cache is flushed between scenarios so each request gets a fresh Bible model
-        // (mimics production Memcached, where each request deserializes a fresh copy).
         \Illuminate\Support\Facades\Cache::store('array')->flush();
         $seg_only_path = route('v4_bible.one', array_merge(
             ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
@@ -519,6 +511,110 @@ class BiblesRoutesTest extends ApiV4Test
             $this->withHeaders($this->params)->get($default_path),
             'default request'
         );
+    }
+
+    private function assertVerseStartsPresentOnQualifyingFilesets($response, array $audio_types, string $context) : int
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        // The top-level filesets map is the single authoritative source for fileset-level metadata.
+        // Build a fileset_id => segmentation_type lookup from it; also assert each top-level entry
+        // exposes segmentation_type (verify_segmentation is on, explicit or implicit) and never
+        // carries verse_starts.
+        $segmentation_by_id = [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must include segmentation_type (verify_segmentation is on, explicit or implicit)"
+                );
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+                $segmentation_by_id[$fileset['id']] = $fileset['segmentation_type'];
+            }
+        }
+
+        $qualifying_book_filesets = 0;
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                // Per-book entries must NOT duplicate fileset-level metadata.
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include segmentation_type — it is exposed only on the top-level filesets map"
+                );
+
+                $segmentation_type = $segmentation_by_id[$book_fileset['id']] ?? null;
+                $is_qualifying = $segmentation_type === 'section'
+                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
+                if ($is_qualifying) {
+                    $this->assertArrayHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "[$context] qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
+                    );
+                    $this->assertIsArray($book_fileset['verse_starts']);
+                    $this->assertNotEmpty(
+                        $book_fileset['verse_starts'],
+                        "[$context] verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
+                    );
+                    foreach ($book_fileset['verse_starts'] as $entry) {
+                        $this->assertArrayHasKey('chapter_start', $entry);
+                        $this->assertArrayHasKey('verse_start', $entry);
+                        $this->assertArrayHasKey('verse_start_alt', $entry);
+                        $this->assertArrayNotHasKey(
+                            'book_id',
+                            $entry,
+                            "[$context] verse_starts entry must not carry book_id (implied by the parent book)"
+                        );
+                    }
+                    $qualifying_book_filesets++;
+                } else {
+                    $this->assertArrayNotHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "[$context] non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                    );
+                }
+            }
+        }
+        return $qualifying_book_filesets;
+    }
+
+    private function assertTopLevelSegmentationTypePresentAndNoPerBookDuplicate($response, string $context) : void
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        $top_level_checked = 0;
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must include segmentation_type"
+                );
+                $top_level_checked++;
+            }
+        }
+        $this->assertGreaterThan(0, $top_level_checked, "[$context] expected at least one top-level fileset to inspect");
+
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include segmentation_type — it is exposed only on the top-level filesets map"
+                );
+            }
+        }
     }
 
     private function assertNoVerseStartsAnywhere($response, string $context) : void


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 90749](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/90749): Public API: Add per-book verse_starts payload to /bibles/{id}

# Description

This change is a follow-up to PR #1080 (Task-90749) and rolls two related adjustments to the `GET /bibles/{id}` payload into a single PR:

1. **Gating** — the per-book `verse_starts` payload is now gated behind a new query parameter, `verse_starts=true`. Sending `verify_segmentation=true` and `verify_content=true` alone no longer returns `verse_starts` arrays; each of those parameters now only triggers what it individually controls. For convenience, `verse_starts=true` implicitly enables `verify_segmentation=true` and `verify_content=true` on the server, so clients that only care about the verse_starts payload can use a single parameter and still get the full response shape required to render it.

2. **Payload trim** — `segmentation_type` is no longer duplicated under `books[].filesets[]`. It is now exposed only on the top-level `filesets` map, which is the single authoritative source for fileset-level metadata. Per-book entries become a pure "what's in this book?" listing — `{id, type}`, plus a `verse_starts` array on qualifying audio filesets when `verse_starts=true`.


# Behavioral matrix

| `verse_starts` | `verify_segmentation` | `verify_content` | top-level `segmentation_type` | per-book `filesets[]` returned | per-book `segmentation_type` | per-book `verse_starts[]` |
|---|---|---|---|---|---|---|
| (absent / false) | false | false | no  | no  | n/a | **no** |
| (absent / false) | true  | false | yes | no  | n/a | **no** |
| (absent / false) | false | true  | no  | yes | **no** (trim) | **no** |
| (absent / false) | true  | true  | yes | yes | **no** (trim) | **no** ← gating change vs. PR #1080 |
| **true** | (anything) | (anything) | yes (implicit) | yes (implicit) | **no** (trim) | **yes** |

# Response Shape

## Example A — explicit three-flag request

```
GET /bibles/ENGESV?verify_segmentation=true&verify_content=true&verse_starts=true&v=4&key=...
```

Top-level `filesets` carries `segmentation_type`. Per-book entries are `{id, type}` plus `verse_starts` on qualifying audio filesets:

```json
{
  "data": {
    "abbr": "ENGESV",
    "books": [{
      "book_id": "GEN",
      "filesets": [
        {
          "id": "ENGESVN2DA",
          "type": "audio_drama",
          "verse_starts": [
            { "chapter_start": 1, "verse_start": 1,  "verse_start_alt": "1"  },
            { "chapter_start": 1, "verse_start": 11, "verse_start_alt": "11" },
            { "chapter_start": 2, "verse_start": 4,  "verse_start_alt": "4"  }
          ]
        },
        { "id": "ENGESVN_ET", "type": "text_plain" }
      ]
    }],
    "filesets": {
      "dbp-prod": [
        { "id": "ENGESVN2DA", "type": "audio_drama", "segmentation_type": "section" },
        { "id": "ENGESVN_ET", "type": "text_plain",  "segmentation_type": null     }
      ]
    }
  }
}
```

## Example B — `verse_starts=true` only (implicit enable)

```
GET /bibles/ENGESV?verse_starts=true&v=4&key=...
```

Response shape is identical to Example A. The server implicitly turns on `verify_segmentation` and `verify_content`, so the client gets `segmentation_type` on the top-level `filesets` map, per-book `filesets[]`, and `verse_starts` on qualifying audio filesets in a single request.

## Example C — combined flags WITHOUT the new parameter

```
GET /bibles/ENGESV?verify_segmentation=true&verify_content=true&v=4&key=...
```

Top-level `filesets` carries `segmentation_type`. Per-book entries are `{id, type}` only — no `segmentation_type`, no `verse_starts`:

```json
{
  "data": {
    "abbr": "ENGESV",
    "books": [{
      "book_id": "GEN",
      "filesets": [
        { "id": "ENGESVN2DA", "type": "audio_drama" },
        { "id": "ENGESVN_ET", "type": "text_plain"  }
      ]
    }],
    "filesets": {
      "dbp-prod": [
        { "id": "ENGESVN2DA", "type": "audio_drama", "segmentation_type": "section" },
        { "id": "ENGESVN_ET", "type": "text_plain",  "segmentation_type": null     }
      ]
    }
  }
}
```

This is what the developers asked for: per-book content + segmentation metadata (via the top-level map) without paying for the `verse_starts` payload.

## Other scenarios

- `?verify_segmentation=true` alone → top-level `filesets` carries `segmentation_type`; no per-book `filesets[]`, no `verse_starts`. (Unchanged from PR #1079 behavior.)
- `?verify_content=true` alone → per-book `filesets[]` with `{id, type}` only; top-level `filesets` has no `segmentation_type`, no `verse_starts` anywhere. (Unchanged.)
- No flags → minimal payload as before.

# How Do I QA This

Suggested manual QA steps against a Bible known to have a section-segmented audio fileset (e.g., one returned by `?verify_segmentation=true` with `segmentation_type='section'` on an audio fileset):

1. **Explicit three flags** — `?verify_segmentation=true&verify_content=true&verse_starts=true`:
   - Top-level `filesets` map carries `segmentation_type` and NOT `verse_starts`.
   - Per-book filesets carry `{id, type}` and a non-empty `verse_starts` array on qualifying audio filesets (`{chapter_start, verse_start, verse_start_alt}`).
   - **Per-book filesets do NOT carry `segmentation_type`.**
2. **`verse_starts=true` alone** — `?verse_starts=true`: response shape must be identical to step 1 (implicit-enable contract). Top-level `segmentation_type` present, per-book `{id, type, verse_starts?}`, no per-book `segmentation_type`.
3. **Combined flags without the new param** — `?verify_segmentation=true&verify_content=true`:
   - Top-level `filesets` map carries `segmentation_type`.
   - Per-book filesets carry `{id, type}` only — **no `segmentation_type`, no `verse_starts`**. This is the gating + trim outcome.
4. **Single-flag and default requests** — `?verify_segmentation=true` alone, `?verify_content=true` alone, and the default (no flags): confirm no `verse_starts` anywhere. The single-flag cases match PR #1079's response shape; the trim does not visibly affect them (the per-book filesets array is either not emitted or already lacks `segmentation_type`).
5. **No regression on qualifying-fileset shape** — confirm each `verse_starts` entry has exactly `chapter_start`, `verse_start`, `verse_start_alt` (no `book_id`); entries are sorted ascending by `chapter_start` then numeric `verse_start`.

I have updated the postman tests from the following [postman folder](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-ed621b51-4b74-41dc-bf14-d878b22285e6?action=share&creator=17122915&active-environment=17122915-810fd94b-9392-43e2-9f13-943e8d323135) to suppor the new request: