### PR TITLE
Task-90116/90749 Release: segmentation_type + verse_starts (cherry-pick #1079, #1080, #1083)

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -375,6 +375,12 @@ class BibleFileSetsController extends APIController
      *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/id"),
      *          description="The fileset ID to retrieve the copyright information for"
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, the response includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -391,7 +397,60 @@ class BibleFileSetsController extends APIController
      *     @OA\Property(property="id", ref="#/components/schemas/BibleFileset/properties/id"),
      *     @OA\Property(property="type", ref="#/components/schemas/BibleFileset/properties/set_type_code"),
      *     @OA\Property(property="size", ref="#/components/schemas/BibleFileset/properties/set_size_code"),
-     *     @OA\Property(property="copyright", ref="#/components/schemas/LicenseGroup/properties/copyright"),
+     *     @OA\Property(property="segmentation_type", ref="#/components/schemas/BibleFileset/properties/segmentation_type"),
+     *     @OA\Property(property="asset_id", type="string", description="The S3 bucket / asset identifier the fileset is stored under"),
+     *     @OA\Property(property="copyright", ref="#/components/schemas/v4_bible_filesets.copyright_details"),
+     * )
+     *
+     * @OA\Schema (
+     *     type="object",
+     *     schema="v4_bible_filesets.copyright_details",
+     *     description="Structured copyright metadata returned by CopyrightTransformer",
+     *     title="v4_bible_filesets.copyright_details",
+     *     @OA\Property(property="copyright_date", type="string", format="date", nullable=true, description="Copyright date as recorded in the license group"),
+     *     @OA\Property(property="copyright", type="string", nullable=true, description="Copyright statement text"),
+     *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+     *     @OA\Property(property="updated_at", type="string", format="date-time", nullable=true),
+     *     @OA\Property(property="open_access", type="boolean", default=false, description="Whether the fileset is open access"),
+     *     @OA\Property(property="is_combined", type="boolean", default=false, description="Whether the copyright is combined across multiple licensors"),
+     *     @OA\Property(
+     *         property="organizations",
+     *         type="array",
+     *         description="Licensor organizations associated with this copyright (only present when at least one is attached)",
+     *         @OA\Items(ref="#/components/schemas/v4_bible_filesets.copyright_organization")
+     *     ),
+     * )
+     *
+     * @OA\Schema (
+     *     type="object",
+     *     schema="v4_bible_filesets.copyright_organization",
+     *     description="Organization shape used in the copyright details payload",
+     *     title="v4_bible_filesets.copyright_organization",
+     *     @OA\Property(property="id", type="integer", nullable=true),
+     *     @OA\Property(property="slug", type="string", nullable=true),
+     *     @OA\Property(property="abbreviation", type="string", nullable=true),
+     *     @OA\Property(property="description", type="string", nullable=true),
+     *     @OA\Property(property="description_short", type="string", nullable=true, description="Sourced from the organization's tagline"),
+     *     @OA\Property(property="phone", type="string", nullable=true),
+     *     @OA\Property(property="email", type="string", nullable=true),
+     *     @OA\Property(property="email_director", type="string", nullable=true),
+     *     @OA\Property(property="logos", type="array", @OA\Items(type="object")),
+     *     @OA\Property(property="primaryColor", type="string", nullable=true),
+     *     @OA\Property(property="secondaryColor", type="string", nullable=true),
+     *     @OA\Property(property="inactive", type="boolean", default=false),
+     *     @OA\Property(property="url_site", type="string", description="Sourced from the organization's url_website"),
+     *     @OA\Property(property="url_donate", type="string"),
+     *     @OA\Property(property="url_twitter", type="string"),
+     *     @OA\Property(property="url_facebook", type="string"),
+     *     @OA\Property(property="address", type="string", nullable=true),
+     *     @OA\Property(property="address2", type="string", nullable=true),
+     *     @OA\Property(property="city", type="string", nullable=true),
+     *     @OA\Property(property="state", type="string", nullable=true),
+     *     @OA\Property(property="country", type="string", nullable=true),
+     *     @OA\Property(property="zip", type="string", nullable=true),
+     *     @OA\Property(property="latitude", type="number", format="float", nullable=true),
+     *     @OA\Property(property="longitude", type="number", format="float", nullable=true),
+     *     @OA\Property(property="translations", type="array", @OA\Items(type="object")),
      * )
      *
      * @param string $id
@@ -400,6 +459,7 @@ class BibleFileSetsController extends APIController
     public function copyright($id)
     {
         $iso = checkParam('iso') ?? 'eng';
+        $verify_segmentation = checkBoolean('verify_segmentation');
 
         $cache_params = [$id, $iso];
         $fileset = cacheRemember(
@@ -423,12 +483,13 @@ class BibleFileSetsController extends APIController
                         'bible_filesets.mode_id as mode_id',
                         'bible_filesets.set_type_code as type',
                         'bible_filesets.set_size_code as size',
+                        'bible_filesets.segmentation_type',
                         'bible_filesets.license_group_id'
                     ])->first();
             }
         );
 
-        return $this->reply(fractal($fileset, CopyrightTransformer::class, new ArraySerializer()));
+        return $this->reply(fractal($fileset, new CopyrightTransformer($verify_segmentation), new ArraySerializer()));
     }
 
     /**

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -30,6 +30,7 @@ use App\Models\Language\Language;
 use App\Services\Bibles\BibleFilesetService;
 use App\Services\Bibles\FilesetBookIdBatchResolver;
 use App\Services\Bibles\FilesetBookIdResolver;
+use App\Services\Bibles\FilesetVerseStartsResolver;
 use Exception;
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;
@@ -415,7 +416,7 @@ class BiblesController extends APIController
      *          name="verify_segmentation",
      *          in="query",
      *          @OA\Schema(type="boolean", default=false),
-     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries."
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -506,7 +507,10 @@ class BiblesController extends APIController
                     'bibles_show_book_filesets',
                     [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
                     now()->addDay(),
-                    function () use ($bible, $verify_segmentation) {
+                    function () use ($bible, $access_group_ids, $id, $verify_segmentation) {
+                        $verse_starts_map = $verify_segmentation
+                            ? $this->loadVerseStartsMap($bible, $id, $access_group_ids)
+                            : [];
                         $batch_resolver = new FilesetBookIdBatchResolver();
                         $single_resolver = new FilesetBookIdResolver();
                         $fileset_book_ids = $batch_resolver->resolve($bible->filesets);
@@ -519,6 +523,9 @@ class BiblesController extends APIController
                                 $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
                                 if ($verify_segmentation) {
                                     $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
+                                    if (isset($verse_starts_map[$fileset->hash_id][$book_id])) {
+                                        $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
+                                    }
                                 }
                                 $map[$book_id][] = $entry;
                             }
@@ -534,6 +541,34 @@ class BiblesController extends APIController
                     return $book;
                 }));
                 return fractal($bible_response, new BibleTransformer($verify_segmentation), $this->serializer)->toArray();
+            }
+        );
+    }
+
+    /**
+     * Load the verse_starts map for any qualifying section-segmented audio filesets on the bible.
+     * The map is keyed by hash_id then book_id, so attaching per-book entries is constant-time.
+     * Returns an empty array when no fileset qualifies (no DB query is issued in that case).
+     *
+     * The cache key includes the access group fingerprint because $bible->filesets
+     * is already filtered by isContentAvailable(); a narrower-access request must
+     * not poison the cache for a broader-access request that can see additional
+     * qualifying filesets.
+     */
+    private function loadVerseStartsMap(Bible $bible, string $bible_id, $access_group_ids) : array
+    {
+        $resolver = new FilesetVerseStartsResolver();
+        $qualifying_filesets = $resolver->qualifyingFilesets($bible->filesets);
+        if ($qualifying_filesets->isEmpty()) {
+            return [];
+        }
+
+        return cacheRemember(
+            'bibles_show_verse_starts',
+            [$bible_id, $access_group_ids->toString()],
+            now()->addDay(),
+            function () use ($resolver, $qualifying_filesets) {
+                return $resolver->resolveForFilesets($qualifying_filesets);
             }
         );
     }

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -416,7 +416,13 @@ class BiblesController extends APIController
      *          name="verify_segmentation",
      *          in="query",
      *          @OA\Schema(type="boolean", default=false),
-     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries."
+     *          description="When true, the top-level filesets map exposes a segmentation_type key on each fileset entry (section, chapter, or null). This metadata is intentionally not duplicated under books[].filesets[]; clients should consult the top-level map for fileset-level metadata."
+     *     ),
+     *     @OA\Parameter(
+     *          name="verse_starts",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries. Setting this parameter implicitly enables verify_segmentation=true and verify_content=true; sending verify_segmentation=true and verify_content=true alone does NOT return verse_starts."
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -436,6 +442,11 @@ class BiblesController extends APIController
         $include_font = is_null(checkParam('include_font')) ? true : checkBoolean('include_font', false);
         $verify_content = is_null(checkParam('verify_content')) ? false : checkBoolean('verify_content', false);
         $verify_segmentation = checkBoolean('verify_segmentation');
+        $include_verse_starts = checkBoolean('verse_starts');
+        if ($include_verse_starts) {
+            $verify_segmentation = true;
+            $verify_content = true;
+        }
 
         if ($this->v === 2 || $this->v === 3) {
             $id = substr($id, 0, 6);
@@ -463,7 +474,8 @@ class BiblesController extends APIController
                 $include_font,
                 $verify_content,
                 $id,
-                $verify_segmentation
+                $verify_segmentation,
+                $include_verse_starts
             ))
             : $this->reply(fractal($bible, new BibleTransformer($verify_segmentation), $this->serializer));
     }
@@ -497,18 +509,18 @@ class BiblesController extends APIController
         );
     }
 
-    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false) : array
+    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false, bool $include_verse_starts = false) : array
     {
         return cacheRemember('bibles_show_verify_content_response',
-            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation],
+            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation, $include_verse_starts],
             now()->addDay(),
-            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation) {
+            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation, $include_verse_starts) {
                 $book_fileset_map = cacheRemember(
                     'bibles_show_book_filesets',
-                    [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
+                    [$id, $access_group_ids->toString(), $verify_content, $include_verse_starts],
                     now()->addDay(),
-                    function () use ($bible, $access_group_ids, $id, $verify_segmentation) {
-                        $verse_starts_map = $verify_segmentation
+                    function () use ($bible, $access_group_ids, $id, $include_verse_starts) {
+                        $verse_starts_map = $include_verse_starts
                             ? $this->loadVerseStartsMap($bible, $id, $access_group_ids)
                             : [];
                         $batch_resolver = new FilesetBookIdBatchResolver();
@@ -521,11 +533,8 @@ class BiblesController extends APIController
                             foreach ($book_ids as $book_id) {
                                 $map[$book_id] = $map[$book_id] ?? [];
                                 $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
-                                if ($verify_segmentation) {
-                                    $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
-                                    if (isset($verse_starts_map[$fileset->hash_id][$book_id])) {
-                                        $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
-                                    }
+                                if ($include_verse_starts && isset($verse_starts_map[$fileset->hash_id][$book_id])) {
+                                    $entry['verse_starts'] = $verse_starts_map[$fileset->hash_id][$book_id];
                                 }
                                 $map[$book_id][] = $entry;
                             }

--- a/app/Http/Controllers/Bible/BiblesController.php
+++ b/app/Http/Controllers/Bible/BiblesController.php
@@ -93,6 +93,12 @@ class BiblesController extends APIController
      *          description="Include country_id field in response. When true, adds country_id field containing the country ID from languages.country_id.",
      *          example="true"
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Parameter(ref="#/components/parameters/page"),
      *     @OA\Parameter(ref="#/components/parameters/limit"),
      *     @OA\Response(
@@ -116,6 +122,7 @@ class BiblesController extends APIController
         $media_exclude      = checkParam('media_exclude');
         $audio_timing       = checkParam('audio_timing') ?? false;
         $show_country       = checkBoolean('show_country', false);
+        $verify_segmentation = checkBoolean('verify_segmentation');
         $size               = checkParam('size'); #removed from API for initial release
         $size_exclude       = checkParam('size_exclude'); #removed from API for initial release
         $limit              = (int) (checkParam('limit') ?? 50);
@@ -165,7 +172,8 @@ class BiblesController extends APIController
             $order_cache_key,
             $access_group_ids->toString(),
             $audio_timing,
-            $show_country
+            $show_country,
+            $verify_segmentation
         ]);
 
         $bibles = cacheRemember(
@@ -185,7 +193,8 @@ class BiblesController extends APIController
                 $limit,
                 $order_by,
                 $audio_timing,
-                $show_country
+                $show_country,
+                $verify_segmentation
             ) {
                 $bibles = Bible::filterByLanguage($language_code)
                 ->withRequiredFilesets([
@@ -255,7 +264,7 @@ class BiblesController extends APIController
                 $bibles = $bibles->paginate($limit);
                 $bibles_return = fractal(
                     $bibles->getCollection(),
-                    BibleTransformer::class,
+                    new BibleTransformer($verify_segmentation),
                     new DataArraySerializer()
                 );
                 return $bibles_return->paginateWith(new IlluminatePaginatorAdapter($bibles));
@@ -402,6 +411,12 @@ class BiblesController extends APIController
      *          @OA\Schema(type="boolean", default=false),
      *          description="When true, each entry in books includes a filesets array of { id, type } for all filesets that have content for that book; same id can appear with different types."
      *     ),
+     *     @OA\Parameter(
+     *          name="verify_segmentation",
+     *          in="query",
+     *          @OA\Schema(type="boolean", default=false),
+     *          description="When true, each fileset object includes a segmentation_type key (section, chapter, or null)."
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -419,6 +434,7 @@ class BiblesController extends APIController
 
         $include_font = is_null(checkParam('include_font')) ? true : checkBoolean('include_font', false);
         $verify_content = is_null(checkParam('verify_content')) ? false : checkBoolean('verify_content', false);
+        $verify_segmentation = checkBoolean('verify_segmentation');
 
         if ($this->v === 2 || $this->v === 3) {
             $id = substr($id, 0, 6);
@@ -445,9 +461,10 @@ class BiblesController extends APIController
                 $access_group_ids,
                 $include_font,
                 $verify_content,
-                $id
+                $id,
+                $verify_segmentation
             ))
-            : $this->reply(fractal($bible, new BibleTransformer(), $this->serializer));
+            : $this->reply(fractal($bible, new BibleTransformer($verify_segmentation), $this->serializer));
     }
 
     private function loadBibleForShow(string $id, $access_group_ids, bool $include_font)
@@ -479,17 +496,17 @@ class BiblesController extends APIController
         );
     }
 
-    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id) : array
+    private function buildVerifyContentResponsePayload($bible, $access_group_ids, $include_font, $verify_content, $id, bool $verify_segmentation = false) : array
     {
         return cacheRemember('bibles_show_verify_content_response',
-            [$id, $access_group_ids->toString(), $include_font, $verify_content],
+            [$id, $access_group_ids->toString(), $include_font, $verify_content, $verify_segmentation],
             now()->addDay(),
-            function () use ($bible, $access_group_ids, $verify_content, $id) {
+            function () use ($bible, $access_group_ids, $verify_content, $id, $verify_segmentation) {
                 $book_fileset_map = cacheRemember(
                     'bibles_show_book_filesets',
-                    [$id, $access_group_ids->toString(), $verify_content],
+                    [$id, $access_group_ids->toString(), $verify_content, $verify_segmentation],
                     now()->addDay(),
-                    function () use ($bible) {
+                    function () use ($bible, $verify_segmentation) {
                         $batch_resolver = new FilesetBookIdBatchResolver();
                         $single_resolver = new FilesetBookIdResolver();
                         $fileset_book_ids = $batch_resolver->resolve($bible->filesets);
@@ -499,7 +516,11 @@ class BiblesController extends APIController
                                 ?? $single_resolver->resolve($fileset);
                             foreach ($book_ids as $book_id) {
                                 $map[$book_id] = $map[$book_id] ?? [];
-                                $map[$book_id][] = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
+                                $entry = ['id' => $fileset->id, 'type' => $fileset->set_type_code];
+                                if ($verify_segmentation) {
+                                    $entry['segmentation_type'] = $fileset->segmentation_type ?? null;
+                                }
+                                $map[$book_id][] = $entry;
                             }
                         }
                         return $map;
@@ -512,7 +533,7 @@ class BiblesController extends APIController
                     $book->filesets = array_values($book_fileset_map[$book->book_id] ?? []);
                     return $book;
                 }));
-                return fractal($bible_response, new BibleTransformer(), $this->serializer)->toArray();
+                return fractal($bible_response, new BibleTransformer($verify_segmentation), $this->serializer)->toArray();
             }
         );
     }

--- a/app/Http/Controllers/Plan/PlansController.php
+++ b/app/Http/Controllers/Plan/PlansController.php
@@ -523,7 +523,7 @@ class PlansController extends APIController
      *     security={{"api_token":{}}},
      *     @OA\Parameter(name="plan_id", in="path", required=true, @OA\Schema(ref="#/components/schemas/Plan/properties/id")),
      *     @OA\Parameter(name="days", in="query", required=true, @OA\Schema(type="integer"), description="Number of days to add to the plan"),
-     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="true"), description="If new days to add should be added to end of list of days")
+     *     @OA\Parameter(name="add_to_end", in="query", required=false, @OA\Schema(type="boolean"), description="If new days to add should be added to end of list of days"),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -107,6 +107,19 @@ class BibleFileset extends Model
      */
     protected $mode_id;
 
+    /**
+     *
+     * @OA\Property(
+     *     property="segmentation_type",
+     *     type="string",
+     *     enum={"section","chapter"},
+     *     nullable=true,
+     *     description="Segmentation strategy for this fileset (section, chapter, or null when unspecified)."
+     * )
+     *
+     */
+    protected $segmentation_type;
+
 
     protected $created_at;
 
@@ -117,7 +130,7 @@ class BibleFileset extends Model
      * @OA\Property(
      *   title="license_group_id",
      *   type="integer",
-     *   description="The liceense group id",
+     *   description="The license group id",
      * )
      */
     protected $license_group_id;

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -53,6 +53,13 @@ class BibleFileset extends Model
     public const TYPE_TEXT_PLAIN = 'text_plain';
     public const TYPE_TEXT_USX = 'text_usx';
 
+    public const AUDIO_TYPES = [
+        self::TYPE_AUDIO,
+        self::TYPE_AUDIO_DRAMA,
+        self::TYPE_AUDIO_STREAM,
+        self::TYPE_AUDIO_DRAMA_STREAM,
+    ];
+
     public const NEW_TEXT_PLAIN_FILESET_LENGTH = 10;
     public const OLD_TEXT_PLAIN_FILESET_LENGTH = 6;
     public const V1_AUDIO_16_KBPS_FILESET_LENGTH = 12;
@@ -120,6 +127,22 @@ class BibleFileset extends Model
      */
     protected $segmentation_type;
 
+    /**
+     *
+     * @OA\Property(
+     *     property="verse_starts",
+     *     type="array",
+     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+     *     @OA\Items(
+     *         type="object",
+     *         @OA\Property(property="chapter_start",   type="integer", example=1, description="The starting chapter of the section."),
+     *         @OA\Property(property="verse_start",     ref="#/components/schemas/BibleFile/properties/verse_sequence"),
+     *         @OA\Property(property="verse_start_alt", ref="#/components/schemas/BibleFile/properties/verse_start")
+     *     )
+     * )
+     *
+     */
+    protected $verse_starts;
 
     protected $created_at;
 
@@ -460,15 +483,7 @@ class BibleFileset extends Model
      */
     public function isAudio() : bool
     {
-        return in_array(
-            $this['set_type_code'],
-            [
-                BibleFileset::TYPE_AUDIO_DRAMA,
-                BibleFileset::TYPE_AUDIO,
-                BibleFileset::TYPE_AUDIO_DRAMA,
-                BibleFileset::TYPE_AUDIO_DRAMA_STREAM
-            ]
-        );
+        return in_array($this['set_type_code'], self::AUDIO_TYPES, true);
     }
 
     /**

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -132,7 +132,7 @@ class BibleFileset extends Model
      * @OA\Property(
      *     property="verse_starts",
      *     type="array",
-     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+     *     description="Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when verse_starts=true is sent (which implicitly enables verify_segmentation=true and verify_content=true), and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
      *     @OA\Items(
      *         type="object",
      *         @OA\Property(property="chapter_start",   type="integer", example=1, description="The starting chapter of the section."),

--- a/app/Services/Bibles/FilesetVerseStartsResolver.php
+++ b/app/Services/Bibles/FilesetVerseStartsResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\Bibles;
+
+use App\Models\Bible\BibleFile;
+use Illuminate\Support\Collection;
+
+class FilesetVerseStartsResolver
+{
+    private const SEGMENTATION_TYPE_SECTION = 'section';
+
+    /**
+     * Filter the in-memory fileset collection down to those that should
+     * carry verse_starts: section-segmented audio filesets.
+     *
+     * Pure in-memory: relies on segmentation_type and set_type_code which
+     * are already loaded on every BibleFileset returned by the show query.
+     */
+    public function qualifyingFilesets(Collection $filesets) : Collection
+    {
+        return $filesets->filter(function ($fileset) {
+            return ($fileset->segmentation_type ?? null) === self::SEGMENTATION_TYPE_SECTION
+                && $fileset->isAudio();
+        })->values();
+    }
+
+    /**
+     * Fetch verse_starts data for the qualifying filesets in a single
+     * batched query and return a map keyed first by hash_id, then by
+     * book_id, so per-book attach lookups are constant-time.
+     *
+     * @return array<string, array<string, array<int, array{chapter_start: int|null, verse_start: int|null, verse_start_alt: string|null}>>>
+     */
+    public function resolveForFilesets(Collection $qualifying_filesets) : array
+    {
+        $hash_ids = $qualifying_filesets->pluck('hash_id')->unique()->values();
+        if ($hash_ids->isEmpty()) {
+            return [];
+        }
+
+        $rows = BibleFile::select(['hash_id', 'book_id', 'chapter_start', 'verse_start', 'verse_sequence'])
+            ->whereIn('hash_id', $hash_ids)
+            ->orderBy('hash_id')
+            ->orderBy('book_id')
+            ->orderBy('chapter_start')
+            ->orderBy('verse_sequence')
+            ->get();
+
+        $map = [];
+        foreach ($rows as $row) {
+            $map[$row->hash_id][$row->book_id][] = [
+                'chapter_start' => $row->chapter_start,
+                'verse_start' => $row->verse_sequence,
+                'verse_start_alt' => $row->verse_start,
+            ];
+        }
+        return $map;
+    }
+}

--- a/app/Transformers/BibleTransformer.php
+++ b/app/Transformers/BibleTransformer.php
@@ -12,6 +12,15 @@ class BibleTransformer extends BaseTransformer
 {
 
     use OrganizationFilterTrait;
+
+    private bool $verify_segmentation;
+
+    public function __construct(bool $verify_segmentation = false)
+    {
+        parent::__construct();
+        $this->verify_segmentation = $verify_segmentation;
+    }
+
     /**
      * A Fractal transformer.
      *
@@ -337,6 +346,10 @@ class BibleTransformer extends BaseTransformer
             'type' => $fileset->set_type_code,
             'size' => $fileset->set_size_code,
         ];
+
+        if ($this->verify_segmentation) {
+            $fileset_data['segmentation_type'] = $fileset->segmentation_type ?? null;
+        }
 
         $meta_records_indexed = $fileset->getMetaTagsIndexedByName();
 

--- a/app/Transformers/CopyrightTransformer.php
+++ b/app/Transformers/CopyrightTransformer.php
@@ -9,6 +9,14 @@ class CopyrightTransformer extends BaseTransformer
 {
     use OrganizationFilterTrait;
 
+    private bool $verify_segmentation;
+
+    public function __construct(bool $verify_segmentation = false)
+    {
+        parent::__construct();
+        $this->verify_segmentation = $verify_segmentation;
+    }
+
     /**
      * Transform copyright fileset data, filtering organizations as needed.
      *
@@ -22,6 +30,10 @@ class CopyrightTransformer extends BaseTransformer
             'type' => $fileset->type,
             'size' => $fileset->size,
         ];
+
+        if ($this->verify_segmentation) {
+            $transformed['segmentation_type'] = $fileset->segmentation_type ?? null;
+        }
 
         if (isset($fileset->asset_id)) {
             $transformed['asset_id'] = $fileset->asset_id;

--- a/database/factories/Bible/BibleFactory.php
+++ b/database/factories/Bible/BibleFactory.php
@@ -68,6 +68,9 @@ $factory->define(\App\Models\Bible\BibleFileset::class, function (Faker $faker) 
     ];
 });
 
+$factory->state(\App\Models\Bible\BibleFileset::class, 'segmentation_section', ['segmentation_type' => 'section']);
+$factory->state(\App\Models\Bible\BibleFileset::class, 'segmentation_chapter', ['segmentation_type' => 'chapter']);
+
 $factory->define(\App\Models\Bible\BibleFile::class, function (Faker $faker) {
     return [
         'id'      => '',

--- a/database/migrations/2026_04_28_180000_add_segmentation_type_to_bible_filesets.php
+++ b/database/migrations/2026_04_28_180000_add_segmentation_type_to_bible_filesets.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSegmentationTypeToBibleFilesets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+            $table->enum('segmentation_type', ['section', 'chapter'])
+                ->nullable()
+                ->default(null)
+                ->after('archived');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('dbp')->table('bible_filesets', function (Blueprint $table) {
+            $table->dropColumn('segmentation_type');
+        });
+    }
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -322,6 +322,115 @@
                 }
             }
         },
+        "/download/package-create": {
+            "post": {
+                "tags": [
+                    "Bibles"
+                ],
+                "summary": "Create a download package from filesets",
+                "description": "Accepts a JSON payload containing fileset IDs and an encryption type, then proxies the request to BBHub package creation.",
+                "operationId": "v4_download_package_create",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/version_number"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "filesets",
+                                    "encryptionType"
+                                ],
+                                "properties": {
+                                    "filesets": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "minItems": 1,
+                                        "uniqueItems": true,
+                                        "example": [
+                                            "ENGESVN2DA",
+                                            "ENGESVO1DA"
+                                        ]
+                                    },
+                                    "encryptionType": {
+                                        "type": "integer",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Response from the upstream BBHub service (status and body are proxied).",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Request body must be valid JSON.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "Request body must be valid JSON."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed for the request body.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "The filesets field is required."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "BBHub is unavailable.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "BBHub is unavailable."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/bibles/verses/{language_code}/{book_id}/{chapter_id}/{verse_number?}": {
             "get": {
                 "tags": [
@@ -517,6 +626,25 @@
                         "example": "true"
                     },
                     {
+                        "name": "show_country",
+                        "in": "query",
+                        "description": "Include country_id field in response. When true, adds country_id field containing the country ID from languages.country_id.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "example": "true"
+                    },
+                    {
+                        "name": "verify_segmentation",
+                        "in": "query",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/page"
                     },
                     {
@@ -630,6 +758,24 @@
                     {
                         "name": "include_font",
                         "in": "query"
+                    },
+                    {
+                        "name": "verify_content",
+                        "in": "query",
+                        "description": "When true, each entry in books includes a filesets array of { id, type } for all filesets that have content for that book; same id can appear with different types.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "verify_segmentation",
+                        "in": "query",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
                     },
                     {
                         "$ref": "#/components/parameters/version_number"
@@ -1566,14 +1712,177 @@
                     "size": {
                         "$ref": "#/components/schemas/BibleFileset/properties/set_size_code"
                     },
+                    "segmentation_type": {
+                        "$ref": "#/components/schemas/BibleFileset/properties/segmentation_type"
+                    },
+                    "asset_id": {
+                        "description": "The S3 bucket / asset identifier the fileset is stored under",
+                        "type": "string"
+                    },
                     "copyright": {
-                        "$ref": "#/components/schemas/BibleFilesetCopyright"
+                        "$ref": "#/components/schemas/v4_bible_filesets.copyright_details"
                     }
                 },
                 "type": "object",
                 "xml": {
                     "name": "v4_bible_filesets.copyright"
                 }
+            },
+            "v4_bible_filesets.copyright_details": {
+                "title": "v4_bible_filesets.copyright_details",
+                "description": "Structured copyright metadata returned by CopyrightTransformer",
+                "properties": {
+                    "copyright_date": {
+                        "description": "Copyright date as recorded in the license group",
+                        "type": "string",
+                        "format": "date",
+                        "nullable": true
+                    },
+                    "copyright": {
+                        "description": "Copyright statement text",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "open_access": {
+                        "description": "Whether the fileset is open access",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "is_combined": {
+                        "description": "Whether the copyright is combined across multiple licensors",
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "organizations": {
+                        "description": "Licensor organizations associated with this copyright (only present when at least one is attached)",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/v4_bible_filesets.copyright_organization"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "v4_bible_filesets.copyright_organization": {
+                "title": "v4_bible_filesets.copyright_organization",
+                "description": "Organization shape used in the copyright details payload",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "slug": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "abbreviation": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "description_short": {
+                        "description": "Sourced from the organization's tagline",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "phone": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "email": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "email_director": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "logos": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    },
+                    "primaryColor": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "secondaryColor": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "inactive": {
+                        "type": "boolean",
+                        "default": false
+                    },
+                    "url_site": {
+                        "description": "Sourced from the organization's url_website",
+                        "type": "string"
+                    },
+                    "url_donate": {
+                        "type": "string"
+                    },
+                    "url_twitter": {
+                        "type": "string"
+                    },
+                    "url_facebook": {
+                        "type": "string"
+                    },
+                    "address": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "address2": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "city": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "state": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "country": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "zip": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "latitude": {
+                        "type": "number",
+                        "format": "float",
+                        "nullable": true
+                    },
+                    "longitude": {
+                        "type": "number",
+                        "format": "float",
+                        "nullable": true
+                    },
+                    "translations": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
             },
             "v4_bible_filesets_download.index": {
                 "title": "v4_bible_filesets_download.index",
@@ -2232,6 +2541,14 @@
                         "minimum": 0,
                         "example": 683,
                         "nullable": true
+                    },
+                    "is_complete_chapter": {
+                        "title": "is_complete_chapter",
+                        "description": "If the file is a complete chapter, this field will be true",
+                        "type": "boolean",
+                        "default": false,
+                        "example": true,
+                        "nullable": false
                     }
                 },
                 "type": "object",
@@ -2300,6 +2617,23 @@
                     },
                     "set_size_code": {
                         "$ref": "#/components/schemas/BibleFilesetSize/properties/set_size_code"
+                    },
+                    "mode_id": {
+                        "$ref": "#/components/schemas/BibleFilesetMode/properties/id"
+                    },
+                    "segmentation_type": {
+                        "description": "Segmentation strategy for this fileset (section, chapter, or null when unspecified).",
+                        "type": "string",
+                        "enum": [
+                            "section",
+                            "chapter"
+                        ],
+                        "nullable": true
+                    },
+                    "license_group_id": {
+                        "title": "license_group_id",
+                        "description": "The license group id",
+                        "type": "integer"
                     }
                 },
                 "type": "object",
@@ -2307,38 +2641,30 @@
                     "name": "BibleFileset"
                 }
             },
-            "BibleFilesetCopyright": {
-                "title": "Bible Fileset Copyright",
-                "description": "BibleFilesetCopyright",
+            "BibleFilesetMode": {
+                "title": "BibleFilesetMode",
+                "description": "The Bible fileset mode model communicates information about generalized fileset modes",
+                "required": [
+                    "filename"
+                ],
                 "properties": {
-                    "copyright_date": {
-                        "title": "copyright_date",
-                        "description": "The copyright date created copyright",
-                        "type": "string",
-                        "example": "2014"
-                    },
-                    "copyright": {
-                        "title": "copyright",
-                        "description": "The copyright",
-                        "type": "string",
-                        "example": "© Ethnos360"
-                    },
-                    "copyright_description": {
-                        "title": "copyright_description",
-                        "description": "The copyright description",
-                        "type": "string",
-                        "example": "© Ethnos360"
-                    },
-                    "open_access": {
-                        "title": "open_access",
-                        "description": "The open_access description",
+                    "id": {
+                        "title": "id",
+                        "description": "The id",
                         "type": "integer",
-                        "example": 1
+                        "minimum": 0,
+                        "example": 4
+                    },
+                    "name": {
+                        "title": "name",
+                        "description": "The name",
+                        "type": "string",
+                        "example": "video"
                     }
                 },
                 "type": "object",
                 "xml": {
-                    "name": "BibleFilesetCopyright"
+                    "name": "BibleFilesetMode"
                 }
             },
             "BibleFilesetSize": {
@@ -3639,6 +3965,50 @@
                     "name": "NumeralSystem"
                 }
             },
+            "LicenseGroup": {
+                "title": "License Group",
+                "description": "LicenseGroup",
+                "properties": {
+                    "id": {
+                        "title": "id",
+                        "description": "The license group id",
+                        "type": "integer"
+                    },
+                    "name": {
+                        "title": "name",
+                        "description": "The license group name",
+                        "type": "string",
+                        "maxLength": 64
+                    },
+                    "permission_pattern_id": {
+                        "title": "permission_pattern_id",
+                        "description": "The permission pattern id",
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "description": {
+                        "title": "description",
+                        "description": "The license group description",
+                        "type": "string"
+                    },
+                    "copyright": {
+                        "title": "copyright",
+                        "description": "The copyright text",
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "is_copyright_combined": {
+                        "title": "is_copyright_combined",
+                        "description": "Is this a combined copyright from multiple sources",
+                        "type": "boolean",
+                        "nullable": true
+                    }
+                },
+                "type": "object",
+                "xml": {
+                    "name": "LicenseGroup"
+                }
+            },
             "Asset": {
                 "title": "Asset",
                 "description": "Asset",
@@ -4870,6 +5240,11 @@
                                 },
                                 "date": {
                                     "$ref": "#/components/schemas/Bible/properties/date"
+                                },
+                                "country_id": {
+                                    "description": "Country ID from languages.country_id (only included when show_country=true)",
+                                    "type": "string",
+                                    "nullable": true
                                 },
                                 "filesets": {
                                     "properties": {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -771,7 +771,7 @@
                     {
                         "name": "verify_segmentation",
                         "in": "query",
-                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null).",
+                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries.",
                         "schema": {
                             "type": "boolean",
                             "default": false
@@ -2629,6 +2629,26 @@
                             "chapter"
                         ],
                         "nullable": true
+                    },
+                    "verse_starts": {
+                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "chapter_start": {
+                                    "description": "The starting chapter of the section.",
+                                    "type": "integer",
+                                    "example": 1
+                                },
+                                "verse_start": {
+                                    "$ref": "#/components/schemas/BibleFile/properties/verse_sequence"
+                                },
+                                "verse_start_alt": {
+                                    "$ref": "#/components/schemas/BibleFile/properties/verse_start"
+                                }
+                            },
+                            "type": "object"
+                        }
                     },
                     "license_group_id": {
                         "title": "license_group_id",

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -771,7 +771,16 @@
                     {
                         "name": "verify_segmentation",
                         "in": "query",
-                        "description": "When true, each fileset object includes a segmentation_type key (section, chapter, or null). When combined with verify_content=true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry will additionally include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries.",
+                        "description": "When true, the top-level filesets map exposes a segmentation_type key on each fileset entry (section, chapter, or null). This metadata is intentionally not duplicated under books[].filesets[]; clients should consult the top-level map for fileset-level metadata.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "verse_starts",
+                        "in": "query",
+                        "description": "When true, qualifying audio filesets (segmentation_type='section') under each books[].filesets[] entry include a verse_starts array of {chapter_start, verse_start, verse_start_alt} items describing that book's section boundaries. Setting this parameter implicitly enables verify_segmentation=true and verify_content=true; sending verify_segmentation=true and verify_content=true alone does NOT return verse_starts.",
                         "schema": {
                             "type": "boolean",
                             "default": false
@@ -2631,7 +2640,7 @@
                         "nullable": true
                     },
                     "verse_starts": {
-                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when both verify_segmentation=true and verify_content=true are present, and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
+                        "description": "Section boundaries for the fileset, scoped to the parent book. Returned only on per-book fileset entries (under books[].filesets[]) when verse_starts=true is sent (which implicitly enables verify_segmentation=true and verify_content=true), and only for audio filesets with segmentation_type='section'. verse_start is the numeric verse_sequence for client-side arithmetic; verse_start_alt preserves the original verse marker, which may be alphanumeric (e.g. '001', '2b').",
                         "type": "array",
                         "items": {
                             "properties": {

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -70,6 +70,60 @@ class BiblesRoutesTest extends ApiV4Test
 
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        // CopyrightTransformer uses ArraySerializer — response is the payload directly, no 'data' wrapper.
+        $payload = json_decode($response->getContent(), true) ?? [];
+        $this->assertArrayNotHasKey(
+            'segmentation_type',
+            $payload,
+            'Default copyright response must not contain segmentation_type'
+        );
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_bible_filesets.copyright
+     * @category Route Path: https://api.dbp.test/bibles/filesets/{fileset_id}/copyright?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BibleFileSetsController::copyright
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleFilesetsCopyrightWithVerifySegmentation()
+    {
+        $fileset = BibleFileset::whereNotNull('segmentation_type')
+            ->where('hidden', 0)
+            ->where('archived', 0)
+            ->inRandomOrder()
+            ->first();
+
+        if (!$fileset) {
+            $this->markTestSkipped('No fileset with non-null segmentation_type seeded in this environment.');
+        }
+
+        $params = array_merge(
+            ['fileset_id' => $fileset->id, 'verify_segmentation' => 'true'],
+            $this->params
+        );
+        $path = route('v4_internal_bible_filesets.copyright', $params);
+        echo "\nTesting: $path";
+
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        // CopyrightTransformer uses ArraySerializer — response is the payload directly, no 'data' wrapper.
+        $payload = json_decode($response->getContent(), true) ?? [];
+        $this->assertArrayHasKey(
+            'segmentation_type',
+            $payload,
+            'verify_segmentation=true must include segmentation_type key in copyright response'
+        );
+        $this->assertContains(
+            $payload['segmentation_type'],
+            ['section', 'chapter', null],
+            'segmentation_type must be section, chapter, or null'
+        );
     }
 
     /**
@@ -255,6 +309,82 @@ class BiblesRoutesTest extends ApiV4Test
         echo "\nTesting: $path";
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "Default v4_bible.one response must not contain segmentation_type for fileset {$fileset['id']}"
+                );
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_bible.one
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::show
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleOneWithVerifySegmentation()
+    {
+        // Discover an accessible bible whose filesets carry segmentation_type by hitting v4_bible.all first.
+        $index_path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        $index_response = $this->withHeaders($this->params)->get($index_path);
+        $index_response->assertSuccessful();
+        $index_decoded = json_decode($index_response->getContent(), true);
+        $index_payload = is_array($index_decoded) ? ($index_decoded['data'] ?? []) : [];
+
+        $bible_id = null;
+        foreach ($index_payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    if (!is_null($fileset['segmentation_type'] ?? null)) {
+                        $bible_id = $bible['abbr'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if (!$bible_id) {
+            $this->markTestSkipped('No accessible bible with a fileset carrying non-null segmentation_type in this environment.');
+        }
+
+        $path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        $checked_fileset_count = 0;
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "verify_segmentation=true must include segmentation_type for fileset {$fileset['id']}"
+                );
+                $this->assertContains(
+                    $fileset['segmentation_type'],
+                    ['section', 'chapter', null],
+                    "segmentation_type must be section, chapter, or null for fileset {$fileset['id']}"
+                );
+                $checked_fileset_count++;
+            }
+        }
+        $this->assertGreaterThan(0, $checked_fileset_count, 'Expected at least one fileset to verify');
     }
 
     /**
@@ -273,5 +403,59 @@ class BiblesRoutesTest extends ApiV4Test
         echo "\nTesting: $path";
         $response = $this->withHeaders($this->params)->get($path);
         $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    $this->assertArrayNotHasKey(
+                        'segmentation_type',
+                        $fileset,
+                        "Default v4_bible.all response must not contain segmentation_type for fileset {$fileset['id']}"
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_bible.all
+     * @category Route Path: https://api.dbp.test/bibles?v=4&key={key}&verify_segmentation=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::index
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleAllWithVerifySegmentation()
+    {
+        $path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        $checked_fileset_count = 0;
+        foreach ($payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    $this->assertArrayHasKey(
+                        'segmentation_type',
+                        $fileset,
+                        "verify_segmentation=true must include segmentation_type for fileset {$fileset['id']}"
+                    );
+                    $this->assertContains(
+                        $fileset['segmentation_type'],
+                        ['section', 'chapter', null],
+                        "segmentation_type must be section, chapter, or null for fileset {$fileset['id']}"
+                    );
+                    $checked_fileset_count++;
+                }
+            }
+        }
+        $this->assertGreaterThan(0, $checked_fileset_count, 'Expected at least one fileset to verify');
     }
 }

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -390,7 +390,7 @@ class BiblesRoutesTest extends ApiV4Test
     /**
      * @category V4_API
      * @category Route Name: v4_bible.one
-     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true&verify_content=true
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verse_starts=true
      * @see      \App\Http\Controllers\Bible\BiblesController::show
      * @group    BibleRoutes
      * @group    V4
@@ -427,70 +427,62 @@ class BiblesRoutesTest extends ApiV4Test
             $this->markTestSkipped('No accessible bible with a section-segmented audio fileset in this environment.');
         }
 
-        // Both flags: per-book verse_starts must appear on qualifying filesets only.
-        $path = route('v4_bible.one', array_merge(
+        // Scenario 1: all three flags explicit — per-book verse_starts must appear on qualifying filesets.
+        $all_flags_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true', 'verse_starts' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $all_flags_path";
+        $qualifying = $this->assertVerseStartsPresentOnQualifyingFilesets(
+            $this->withHeaders($this->params)->get($all_flags_path),
+            $audio_types,
+            'verify_segmentation=true & verify_content=true & verse_starts=true'
+        );
+        $this->assertGreaterThan(0, $qualifying, 'Expected at least one qualifying per-book fileset entry');
+
+        // Scenario 2 (behavior change): verify_segmentation=true & verify_content=true WITHOUT verse_starts
+        // must produce no verse_starts anywhere; the per-book filesets array is still emitted
+        // (verify_content is on), but per-book entries must NOT carry segmentation_type — that key
+        // is exposed only on the top-level filesets map. Top-level entries DO carry segmentation_type
+        // because verify_segmentation is explicitly on.
+        // Cache is flushed between scenarios so each request gets a fresh Bible model
+        // (mimics production Memcached, where each request deserializes a fresh copy).
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $combined_no_verse_starts_path = route('v4_bible.one', array_merge(
             ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true'],
             $this->params
         ));
-        echo "\nTesting: $path";
-        $response = $this->withHeaders($this->params)->get($path);
-        $response->assertSuccessful();
+        $combined_response = $this->withHeaders($this->params)->get($combined_no_verse_starts_path);
+        $this->assertNoVerseStartsAnywhere(
+            $combined_response,
+            'verify_segmentation=true & verify_content=true without verse_starts'
+        );
+        $this->assertTopLevelSegmentationTypePresentAndNoPerBookDuplicate(
+            $combined_response,
+            'verify_segmentation=true & verify_content=true without verse_starts'
+        );
 
-        $decoded = json_decode($response->getContent(), true);
-        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
-
-        // Top-level filesets map must NOT include verse_starts.
-        foreach ($payload['filesets'] ?? [] as $asset_group) {
-            foreach ($asset_group as $fileset) {
-                $this->assertArrayNotHasKey(
-                    'verse_starts',
-                    $fileset,
-                    "Top-level fileset {$fileset['id']} must not include verse_starts"
-                );
-            }
-        }
-
-        $qualifying_book_filesets = 0;
-        foreach ($payload['books'] ?? [] as $book) {
-            foreach ($book['filesets'] ?? [] as $book_fileset) {
-                $is_qualifying = ($book_fileset['segmentation_type'] ?? null) === 'section'
-                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
-                if ($is_qualifying) {
-                    $this->assertArrayHasKey(
-                        'verse_starts',
-                        $book_fileset,
-                        "Qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
-                    );
-                    $this->assertIsArray($book_fileset['verse_starts']);
-                    $this->assertNotEmpty(
-                        $book_fileset['verse_starts'],
-                        "verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
-                    );
-                    foreach ($book_fileset['verse_starts'] as $entry) {
-                        $this->assertArrayHasKey('chapter_start', $entry);
-                        $this->assertArrayHasKey('verse_start', $entry);
-                        $this->assertArrayHasKey('verse_start_alt', $entry);
-                        $this->assertArrayNotHasKey(
-                            'book_id',
-                            $entry,
-                            "verse_starts entry must not carry book_id (implied by the parent book)"
-                        );
-                    }
-                    $qualifying_book_filesets++;
-                } else {
-                    $this->assertArrayNotHasKey(
-                        'verse_starts',
-                        $book_fileset,
-                        "Non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
-                    );
-                }
-            }
-        }
-        $this->assertGreaterThan(0, $qualifying_book_filesets, 'Expected at least one qualifying per-book fileset entry');
+        // Scenario 3: verse_starts=true alone — implicit-enable contract. The response shape must match
+        // Scenario 1: per-book filesets present (verify_content implicitly on), top-level filesets carry
+        // segmentation_type (verify_segmentation implicitly on), and verse_starts is attached to qualifying
+        // audio filesets under books[].filesets[]. Per-book entries themselves carry only {id, type, verse_starts?}.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $verse_starts_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verse_starts' => 'true'],
+            $this->params
+        ));
+        $qualifying_implicit = $this->assertVerseStartsPresentOnQualifyingFilesets(
+            $this->withHeaders($this->params)->get($verse_starts_only_path),
+            $audio_types,
+            'verse_starts=true alone (implicit-enable)'
+        );
+        $this->assertGreaterThan(
+            0,
+            $qualifying_implicit,
+            'verse_starts=true alone must implicitly enable verify_content and produce qualifying per-book filesets'
+        );
 
         // verify_segmentation alone: verse_starts must be absent everywhere.
-        // Cache is flushed between scenarios so each request gets a fresh Bible model
-        // (mimics production Memcached, where each request deserializes a fresh copy).
         \Illuminate\Support\Facades\Cache::store('array')->flush();
         $seg_only_path = route('v4_bible.one', array_merge(
             ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
@@ -519,6 +511,110 @@ class BiblesRoutesTest extends ApiV4Test
             $this->withHeaders($this->params)->get($default_path),
             'default request'
         );
+    }
+
+    private function assertVerseStartsPresentOnQualifyingFilesets($response, array $audio_types, string $context) : int
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        // The top-level filesets map is the single authoritative source for fileset-level metadata.
+        // Build a fileset_id => segmentation_type lookup from it; also assert each top-level entry
+        // exposes segmentation_type (verify_segmentation is on, explicit or implicit) and never
+        // carries verse_starts.
+        $segmentation_by_id = [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must include segmentation_type (verify_segmentation is on, explicit or implicit)"
+                );
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+                $segmentation_by_id[$fileset['id']] = $fileset['segmentation_type'];
+            }
+        }
+
+        $qualifying_book_filesets = 0;
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                // Per-book entries must NOT duplicate fileset-level metadata.
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include segmentation_type — it is exposed only on the top-level filesets map"
+                );
+
+                $segmentation_type = $segmentation_by_id[$book_fileset['id']] ?? null;
+                $is_qualifying = $segmentation_type === 'section'
+                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
+                if ($is_qualifying) {
+                    $this->assertArrayHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "[$context] qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
+                    );
+                    $this->assertIsArray($book_fileset['verse_starts']);
+                    $this->assertNotEmpty(
+                        $book_fileset['verse_starts'],
+                        "[$context] verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
+                    );
+                    foreach ($book_fileset['verse_starts'] as $entry) {
+                        $this->assertArrayHasKey('chapter_start', $entry);
+                        $this->assertArrayHasKey('verse_start', $entry);
+                        $this->assertArrayHasKey('verse_start_alt', $entry);
+                        $this->assertArrayNotHasKey(
+                            'book_id',
+                            $entry,
+                            "[$context] verse_starts entry must not carry book_id (implied by the parent book)"
+                        );
+                    }
+                    $qualifying_book_filesets++;
+                } else {
+                    $this->assertArrayNotHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "[$context] non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                    );
+                }
+            }
+        }
+        return $qualifying_book_filesets;
+    }
+
+    private function assertTopLevelSegmentationTypePresentAndNoPerBookDuplicate($response, string $context) : void
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        $top_level_checked = 0;
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayHasKey(
+                    'segmentation_type',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must include segmentation_type"
+                );
+                $top_level_checked++;
+            }
+        }
+        $this->assertGreaterThan(0, $top_level_checked, "[$context] expected at least one top-level fileset to inspect");
+
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $this->assertArrayNotHasKey(
+                    'segmentation_type',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include segmentation_type — it is exposed only on the top-level filesets map"
+                );
+            }
+        }
     }
 
     private function assertNoVerseStartsAnywhere($response, string $context) : void

--- a/tests/Integration/BiblesRoutesTest.php
+++ b/tests/Integration/BiblesRoutesTest.php
@@ -389,6 +389,165 @@ class BiblesRoutesTest extends ApiV4Test
 
     /**
      * @category V4_API
+     * @category Route Name: v4_bible.one
+     * @category Route Path: https://api.dbp.test/bibles/{bible_id}?v=4&key={key}&verify_segmentation=true&verify_content=true
+     * @see      \App\Http\Controllers\Bible\BiblesController::show
+     * @group    BibleRoutes
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function bibleOneWithVerseStarts()
+    {
+        $audio_types = BibleFileset::AUDIO_TYPES;
+
+        // Discover an accessible bible whose filesets carry a section-segmented audio fileset.
+        $index_path = route('v4_bible.all', array_merge(['verify_segmentation' => 'true'], $this->params));
+        $index_response = $this->withHeaders($this->params)->get($index_path);
+        $index_response->assertSuccessful();
+        $index_decoded = json_decode($index_response->getContent(), true);
+        $index_payload = is_array($index_decoded) ? ($index_decoded['data'] ?? []) : [];
+
+        $bible_id = null;
+        foreach ($index_payload as $bible) {
+            foreach ($bible['filesets'] ?? [] as $asset_group) {
+                foreach ($asset_group as $fileset) {
+                    if (
+                        ($fileset['segmentation_type'] ?? null) === 'section'
+                        && in_array($fileset['type'] ?? null, $audio_types, true)
+                    ) {
+                        $bible_id = $bible['abbr'];
+                        break 3;
+                    }
+                }
+            }
+        }
+
+        if (!$bible_id) {
+            $this->markTestSkipped('No accessible bible with a section-segmented audio fileset in this environment.');
+        }
+
+        // Both flags: per-book verse_starts must appear on qualifying filesets only.
+        $path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true', 'verify_content' => 'true'],
+            $this->params
+        ));
+        echo "\nTesting: $path";
+        $response = $this->withHeaders($this->params)->get($path);
+        $response->assertSuccessful();
+
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+
+        // Top-level filesets map must NOT include verse_starts.
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "Top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+            }
+        }
+
+        $qualifying_book_filesets = 0;
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $is_qualifying = ($book_fileset['segmentation_type'] ?? null) === 'section'
+                    && in_array($book_fileset['type'] ?? null, $audio_types, true);
+                if ($is_qualifying) {
+                    $this->assertArrayHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "Qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must include verse_starts"
+                    );
+                    $this->assertIsArray($book_fileset['verse_starts']);
+                    $this->assertNotEmpty(
+                        $book_fileset['verse_starts'],
+                        "verse_starts must contain at least one entry for fileset {$book_fileset['id']} (book {$book['book_id']})"
+                    );
+                    foreach ($book_fileset['verse_starts'] as $entry) {
+                        $this->assertArrayHasKey('chapter_start', $entry);
+                        $this->assertArrayHasKey('verse_start', $entry);
+                        $this->assertArrayHasKey('verse_start_alt', $entry);
+                        $this->assertArrayNotHasKey(
+                            'book_id',
+                            $entry,
+                            "verse_starts entry must not carry book_id (implied by the parent book)"
+                        );
+                    }
+                    $qualifying_book_filesets++;
+                } else {
+                    $this->assertArrayNotHasKey(
+                        'verse_starts',
+                        $book_fileset,
+                        "Non-qualifying per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                    );
+                }
+            }
+        }
+        $this->assertGreaterThan(0, $qualifying_book_filesets, 'Expected at least one qualifying per-book fileset entry');
+
+        // verify_segmentation alone: verse_starts must be absent everywhere.
+        // Cache is flushed between scenarios so each request gets a fresh Bible model
+        // (mimics production Memcached, where each request deserializes a fresh copy).
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $seg_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_segmentation' => 'true'],
+            $this->params
+        ));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($seg_only_path),
+            'verify_segmentation=true alone'
+        );
+
+        // verify_content alone: verse_starts must be absent everywhere.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $content_only_path = route('v4_bible.one', array_merge(
+            ['bible_id' => $bible_id, 'verify_content' => 'true'],
+            $this->params
+        ));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($content_only_path),
+            'verify_content=true alone'
+        );
+
+        // Default request: verse_starts must be absent everywhere.
+        \Illuminate\Support\Facades\Cache::store('array')->flush();
+        $default_path = route('v4_bible.one', array_merge(['bible_id' => $bible_id], $this->params));
+        $this->assertNoVerseStartsAnywhere(
+            $this->withHeaders($this->params)->get($default_path),
+            'default request'
+        );
+    }
+
+    private function assertNoVerseStartsAnywhere($response, string $context) : void
+    {
+        $response->assertSuccessful();
+        $decoded = json_decode($response->getContent(), true);
+        $payload = is_array($decoded) ? ($decoded['data'] ?? []) : [];
+        foreach ($payload['filesets'] ?? [] as $asset_group) {
+            foreach ($asset_group as $fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $fileset,
+                    "[$context] top-level fileset {$fileset['id']} must not include verse_starts"
+                );
+            }
+        }
+        foreach ($payload['books'] ?? [] as $book) {
+            foreach ($book['filesets'] ?? [] as $book_fileset) {
+                $this->assertArrayNotHasKey(
+                    'verse_starts',
+                    $book_fileset,
+                    "[$context] per-book fileset {$book_fileset['id']} (book {$book['book_id']}) must not include verse_starts"
+                );
+            }
+        }
+    }
+
+    /**
+     * @category V4_API
      * @category Route Name: v4_bible.all
      * @category Route Path: https://api.dbp.test/bibles?v=4&key={key}
      * @see      \App\Http\Controllers\Bible\BiblesController::index


### PR DESCRIPTION
# Description
Cherry-pick release to **master** of three develop PRs delivering the Public API `segmentation_type` and per-book `verse_starts` payload on `/bibles/{id}`, gated behind opt-in query parameters. Cherry-picked in order (provenance recorded with `-x`):
1. #1079 — Task-90116 Display `segmentation_type` (adds `bible_filesets.segmentation_type` column + migration; `verify_segmentation=true`)
2. #1080 — Task-90749 Add per-book `verse_starts` payload
3. #1083 — Task-90749 Gate `verse_starts` behind `verse_starts=true`; stop duplicating `segmentation_type` under `books[].filesets[]`

No other develop changes are included. Verified locally on **PHP 8.2** (master's runtime): app boots (Laravel 11.47), migration applied, and the cherry-picked code loads/runs.

⚠️ **Migration required on deploy:** add the nullable `segmentation_type` enum column on `bible_filesets` (`dbp` connection).