### PR TITLE
Task-92918 Public API: Fix IP-whitelist resolution behind the AWS ALB

### DIFF
--- a/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
+++ b/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 
 class ThrottleRequestsWithWhitelist extends ThrottleRequests
@@ -23,9 +24,7 @@ class ThrottleRequestsWithWhitelist extends ThrottleRequests
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        // Use REMOTE_ADDR (actual peer IP) instead of $request->ip() to prevent
-        // X-Forwarded-For spoofing when TrustProxies is set to '*'.
-        $peerIp = $request->server('REMOTE_ADDR');
+        $peerIp = $this->resolvePeerIp($request);
 
         if ($this->isIpWhitelisted($peerIp)) {
             return $next($request);
@@ -35,7 +34,42 @@ class ThrottleRequestsWithWhitelist extends ThrottleRequests
     }
 
     /**
+     * Resolve the client IP used for whitelist matching.
+     *
+     * The API runs behind an AWS Application Load Balancer, so REMOTE_ADDR is the
+     * ALB's private IP, not the upstream (live.bible.is) proxy. The ALB appends the
+     * IP of the connection it received to the END of X-Forwarded-For, so the
+     * right-most entry is the address the ALB actually observed — a value a client
+     * cannot forge (anything a client puts in X-Forwarded-For is pushed left when the
+     * ALB appends the real source). We deliberately use this right-most entry instead
+     * of $request->ip(), which returns the spoofable left-most entry because
+     * TrustProxies is set to '*'. When X-Forwarded-For is absent (e.g. local/direct
+     * requests) we fall back to REMOTE_ADDR.
+     *
+     * @param \Illuminate\Http\Request $request The incoming HTTP request.
+     * @return string|null The resolved client IP address, or null if it cannot be determined.
+     */
+    private function resolvePeerIp(Request $request): ?string
+    {
+        $forwarded = $request->server('HTTP_X_FORWARDED_FOR');
+
+        if (!empty($forwarded)) {
+            $entries = explode(',', $forwarded);
+            $edge_ip = trim(end($entries)); // right-most entry = appended by the AWS ALB
+
+            if (filter_var($edge_ip, FILTER_VALIDATE_IP) !== false) {
+                return $edge_ip;
+            }
+        }
+
+        return $request->server('REMOTE_ADDR');
+    }
+
+    /**
      * Check if the given IP address is in the trusted no-rate-limit whitelist.
+     *
+     * @param string|null $ip The IP address to check.
+     * @return bool True if the IP is whitelisted, false otherwise.
      */
     private function isIpWhitelisted(?string $ip): bool
     {

--- a/tests/Feature/ThrottleWhitelistTest.php
+++ b/tests/Feature/ThrottleWhitelistTest.php
@@ -14,6 +14,11 @@ class ThrottleWhitelistTest extends TestCase
     private const TRUSTED_IP_2 = '192.0.2.2';
     private const TRUSTED_IP_3 = '192.0.2.3';
     private const UNTRUSTED_IP = '198.51.100.1';
+    private const ATTACKER_IP = '203.0.113.99';
+
+    // Private ALB-like peer IP (REMOTE_ADDR) used to simulate requests arriving
+    // through the AWS load balancer.
+    private const ALB_REMOTE_ADDR = '10.0.1.50';
 
     protected function setUp(): void
     {
@@ -110,6 +115,100 @@ class ThrottleWhitelistTest extends TestCase
         $this->assertTrue(
             $response->headers->has('X-RateLimit-Limit'),
             'IP not in whitelist should have rate limit headers'
+        );
+    }
+
+    /**
+     * Behind the AWS ALB the upstream client may appear on the left and the ALB
+     * appends the real proxy IP (live.bible.is) on the right. TrustProxies='*' does
+     * NOT rewrite the raw HTTP_X_FORWARDED_FOR server var, so the middleware reads
+     * exactly what is injected here.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_proxy_in_rightmost_xff_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::UNTRUSTED_IP . ', ' . self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted proxy as right-most X-Forwarded-For entry should bypass rate limiting'
+        );
+    }
+
+    /**
+     * Common case: the proxy did not forward an upstream client, so the ALB appends
+     * only the proxy IP as the single X-Forwarded-For entry.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_proxy_as_single_xff_entry_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted proxy as the only X-Forwarded-For entry should bypass rate limiting'
+        );
+    }
+
+    /**
+     * A client cannot bypass throttling by spoofing a whitelisted IP in
+     * X-Forwarded-For: the AWS ALB appends the real observed source on the right,
+     * so the left-most (client-controlled) value is never used for the match.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function spoofed_xff_does_not_bypass_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::TRUSTED_IP_1 . ', ' . self::ATTACKER_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Spoofed left-most X-Forwarded-For must NOT bypass rate limiting'
+        );
+    }
+
+    /**
+     * Without X-Forwarded-For (e.g. direct/local request) the whitelist matches
+     * against REMOTE_ADDR.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function falls_back_to_remote_addr_without_xff()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Without X-Forwarded-For the whitelist should match REMOTE_ADDR'
         );
     }
 }


### PR DESCRIPTION
# Issue Link
[Bug 92918](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/92918): Public API: Fix IP-whitelist resolution behind the AWS ALB

# Description

Follow-up fix to the live.bible.is rate-limit whitelist (Task-89367 / PR #1072). After deploying to dev.dbt.io the whitelist never matched: the DBP API runs on AWS Elastic Beanstalk behind an Application Load Balancer (ALB), so PHP's `REMOTE_ADDR` is the ALB's private IP, never the live.bible.is proxy IP the whitelist contains. This change matches the whitelist against the proxy IP the ALB actually observed, read from `X-Forwarded-For` in a spoofing-resistant way.

## Background

- The middleware matched against `$request->server('REMOTE_ADDR')`. Behind the ALB that is always the load balancer's private IP, so the configured live.bible.is public IPs could never match and the bypass never triggered.
- `App\Http\Middleware\TrustProxies` sets `$proxies = '*'`, so `$request->ip()` (and a naive left-most `X-Forwarded-For` read) returns a fully client-controlled value — a client could send `X-Forwarded-For: <whitelisted-ip>` and bypass throttling. So we must **not** use `$request->ip()`.

## The fix

The AWS ALB **appends** the IP of the connection it received (the live.bible.is proxy) to the **end** of `X-Forwarded-For`. Anything a client places in that header is pushed left when the ALB appends the real source, so the **right-most** entry is the address the ALB actually saw and cannot be forged.

`ThrottleRequestsWithWhitelist::handle()` now resolves the match IP via a new `resolvePeerIp()`:

1. Read `X-Forwarded-For` and take the **right-most** entry (ALB-appended).
2. Validate it with `filter_var(..., FILTER_VALIDATE_IP)`.
3. Fall back to `REMOTE_ADDR` when `X-Forwarded-For` is absent (direct/local requests).

The whitelist match (`isIpWhitelisted()`) and `parent::handle()` are unchanged. **No new configuration or environment variable** was added — `IP_TRUSTED_NO_RATE_LIMIT` keeps holding the live.bible.is proxy IPs.

## Security note

This relies on the standard Elastic Beanstalk posture where the EC2 instances accept traffic **only** from the ALB (instance security group restricted to the ALB's security group). That is what guarantees the right-most `X-Forwarded-For` entry is ALB-appended and unspoofable; direct-to-instance access would let a client forge the whole header.

## Test plan

- [x] `php vendor/bin/phpunit --filter=ThrottleWhitelistTest` — 8/8 pass (4 existing + 4 new):
  - Whitelisted proxy as right-most `X-Forwarded-For` entry → bypasses rate limit
  - Whitelisted proxy as the only `X-Forwarded-For` entry → bypasses rate limit
  - **Spoofed** `X-Forwarded-For: <whitelisted>, <attacker>` → still rate-limited (security regression)
  - No `X-Forwarded-For` → falls back to `REMOTE_ADDR`
- [ ] On dev.dbt.io (with DevOps): confirm `IP_TRUSTED_NO_RATE_LIMIT` holds the live.bible.is proxy IPs, then verify real proxy traffic bypasses (no `X-RateLimit-*` headers) while a forged `X-Forwarded-For: <whitelisted-ip>` is still throttled.