### PR TITLE
Task-89367 Release: IP whitelist for live.bible.is in Public API (cherry-pick #1072, #1087)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ GET_STARTED_URL=
 NODE_PATH=/usr/local
 LOG_CHANNEL=stack
 
+# Rate Limiting
+# -----------------------------------
+IP_TRUSTED_NO_RATE_LIMIT=
+
 # Database connections
 # -----------------------------------
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -73,7 +73,7 @@ class Kernel extends HttpKernel
         'can'                     => \Illuminate\Auth\Middleware\Authorize::class,
         'guest'                   => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'signed'                  => \Illuminate\Routing\Middleware\ValidateSignature::class,
-        'throttle'                => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttle'                => \App\Http\Middleware\ThrottleRequestsWithWhitelist::class,
         'verified'                => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'APIToken'                => \App\Http\Middleware\APIToken::class,
         'AccessControl'           => \App\Http\Middleware\AccessControl::class,

--- a/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
+++ b/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+
+class ThrottleRequestsWithWhitelist extends ThrottleRequests
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Bypasses rate limiting for IPs listed in IP_TRUSTED_NO_RATE_LIMIT.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int|string  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @param  string  $prefix
+     * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @throws \Illuminate\Http\Exceptions\ThrottleRequestsException
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
+    {
+        // Use REMOTE_ADDR (actual peer IP) instead of $request->ip() to prevent
+        // X-Forwarded-For spoofing when TrustProxies is set to '*'.
+        $peerIp = $request->server('REMOTE_ADDR');
+
+        if ($this->isIpWhitelisted($peerIp)) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next, $maxAttempts, $decayMinutes, $prefix);
+    }
+
+    /**
+     * Check if the given IP address is in the trusted no-rate-limit whitelist.
+     */
+    private function isIpWhitelisted(?string $ip): bool
+    {
+        if (empty($ip)) {
+            return false;
+        }
+
+        $trusted_ips = config('app.ip_trusted_no_rate_limit');
+
+        if ($trusted_ips === null || trim((string) $trusted_ips) === '') {
+            return false;
+        }
+
+        $allowed_ips = array_map('trim', explode(',', $trusted_ips));
+
+        return in_array($ip, $allowed_ips, true);
+    }
+}

--- a/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
+++ b/app/Http/Middleware/ThrottleRequestsWithWhitelist.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 
 class ThrottleRequestsWithWhitelist extends ThrottleRequests
@@ -23,9 +24,7 @@ class ThrottleRequestsWithWhitelist extends ThrottleRequests
      */
     public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1, $prefix = '')
     {
-        // Use REMOTE_ADDR (actual peer IP) instead of $request->ip() to prevent
-        // X-Forwarded-For spoofing when TrustProxies is set to '*'.
-        $peerIp = $request->server('REMOTE_ADDR');
+        $peerIp = $this->resolvePeerIp($request);
 
         if ($this->isIpWhitelisted($peerIp)) {
             return $next($request);
@@ -35,7 +34,42 @@ class ThrottleRequestsWithWhitelist extends ThrottleRequests
     }
 
     /**
+     * Resolve the client IP used for whitelist matching.
+     *
+     * The API runs behind an AWS Application Load Balancer, so REMOTE_ADDR is the
+     * ALB's private IP, not the upstream (live.bible.is) proxy. The ALB appends the
+     * IP of the connection it received to the END of X-Forwarded-For, so the
+     * right-most entry is the address the ALB actually observed — a value a client
+     * cannot forge (anything a client puts in X-Forwarded-For is pushed left when the
+     * ALB appends the real source). We deliberately use this right-most entry instead
+     * of $request->ip(), which returns the spoofable left-most entry because
+     * TrustProxies is set to '*'. When X-Forwarded-For is absent (e.g. local/direct
+     * requests) we fall back to REMOTE_ADDR.
+     *
+     * @param \Illuminate\Http\Request $request The incoming HTTP request.
+     * @return string|null The resolved client IP address, or null if it cannot be determined.
+     */
+    private function resolvePeerIp(Request $request): ?string
+    {
+        $forwarded = $request->server('HTTP_X_FORWARDED_FOR');
+
+        if (!empty($forwarded)) {
+            $entries = explode(',', $forwarded);
+            $edge_ip = trim(end($entries)); // right-most entry = appended by the AWS ALB
+
+            if (filter_var($edge_ip, FILTER_VALIDATE_IP) !== false) {
+                return $edge_ip;
+            }
+        }
+
+        return $request->server('REMOTE_ADDR');
+    }
+
+    /**
      * Check if the given IP address is in the trusted no-rate-limit whitelist.
+     *
+     * @param string|null $ip The IP address to check.
+     * @return bool True if the IP is whitelisted, false otherwise.
      */
     private function isIpWhitelisted(?string $ip): bool
     {

--- a/config/app.php
+++ b/config/app.php
@@ -114,6 +114,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Rate Limiting IP Whitelist
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated list of trusted IP addresses that bypass API rate
+    | limiting. Used for proxy servers (e.g. live.bible.is) that already
+    | have rate limiting enforced at the infrastructure level.
+    |
+    */
+
+    'ip_trusted_no_rate_limit' => env('IP_TRUSTED_NO_RATE_LIMIT', ''),
+
+    /*
+    |--------------------------------------------------------------------------
     | Autoloaded Service Providers
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/ThrottleWhitelistTest.php
+++ b/tests/Feature/ThrottleWhitelistTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ThrottleWhitelistTest extends TestCase
+{
+    private const TEST_ROUTE = '/test-throttle';
+
+    // Test-only IP addresses (RFC 5737 documentation range — not routable)
+    private const TRUSTED_IP_1 = '192.0.2.1';
+    private const TRUSTED_IP_2 = '192.0.2.2';
+    private const TRUSTED_IP_3 = '192.0.2.3';
+    private const UNTRUSTED_IP = '198.51.100.1';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(['throttle:60,1'])->get(self::TEST_ROUTE, function () {
+            return response()->json(['status' => 'ok']);
+        });
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_ip_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted IP should not have rate limit headers'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function non_whitelisted_ip_is_rate_limited()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::UNTRUSTED_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Non-whitelisted IP should have rate limit headers'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function empty_whitelist_applies_rate_limiting_to_all()
+    {
+        config(['app.ip_trusted_no_rate_limit' => '']);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Empty whitelist should rate limit all IPs'
+        );
+    }
+
+    /**
+     * @group throttle_whitelist
+     * @test
+     */
+    public function multiple_ips_in_whitelist()
+    {
+        $whitelist = implode(', ', [self::TRUSTED_IP_1, self::TRUSTED_IP_2, self::TRUSTED_IP_3]);
+        config(['app.ip_trusted_no_rate_limit' => $whitelist]);
+
+        foreach ([self::TRUSTED_IP_1, self::TRUSTED_IP_2, self::TRUSTED_IP_3] as $ip) {
+            $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+                'REMOTE_ADDR' => $ip,
+            ]);
+
+            $response->assertStatus(200);
+            $this->assertFalse(
+                $response->headers->has('X-RateLimit-Limit'),
+                "Whitelisted IP {$ip} should not have rate limit headers"
+            );
+        }
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::UNTRUSTED_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'IP not in whitelist should have rate limit headers'
+        );
+    }
+}

--- a/tests/Feature/ThrottleWhitelistTest.php
+++ b/tests/Feature/ThrottleWhitelistTest.php
@@ -14,6 +14,11 @@ class ThrottleWhitelistTest extends TestCase
     private const TRUSTED_IP_2 = '192.0.2.2';
     private const TRUSTED_IP_3 = '192.0.2.3';
     private const UNTRUSTED_IP = '198.51.100.1';
+    private const ATTACKER_IP = '203.0.113.99';
+
+    // Private ALB-like peer IP (REMOTE_ADDR) used to simulate requests arriving
+    // through the AWS load balancer.
+    private const ALB_REMOTE_ADDR = '10.0.1.50';
 
     protected function setUp(): void
     {
@@ -110,6 +115,100 @@ class ThrottleWhitelistTest extends TestCase
         $this->assertTrue(
             $response->headers->has('X-RateLimit-Limit'),
             'IP not in whitelist should have rate limit headers'
+        );
+    }
+
+    /**
+     * Behind the AWS ALB the upstream client may appear on the left and the ALB
+     * appends the real proxy IP (live.bible.is) on the right. TrustProxies='*' does
+     * NOT rewrite the raw HTTP_X_FORWARDED_FOR server var, so the middleware reads
+     * exactly what is injected here.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_proxy_in_rightmost_xff_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::UNTRUSTED_IP . ', ' . self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted proxy as right-most X-Forwarded-For entry should bypass rate limiting'
+        );
+    }
+
+    /**
+     * Common case: the proxy did not forward an upstream client, so the ALB appends
+     * only the proxy IP as the single X-Forwarded-For entry.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function whitelisted_proxy_as_single_xff_entry_bypasses_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Whitelisted proxy as the only X-Forwarded-For entry should bypass rate limiting'
+        );
+    }
+
+    /**
+     * A client cannot bypass throttling by spoofing a whitelisted IP in
+     * X-Forwarded-For: the AWS ALB appends the real observed source on the right,
+     * so the left-most (client-controlled) value is never used for the match.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function spoofed_xff_does_not_bypass_rate_limit()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR'          => self::ALB_REMOTE_ADDR,
+            'HTTP_X_FORWARDED_FOR' => self::TRUSTED_IP_1 . ', ' . self::ATTACKER_IP,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertTrue(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Spoofed left-most X-Forwarded-For must NOT bypass rate limiting'
+        );
+    }
+
+    /**
+     * Without X-Forwarded-For (e.g. direct/local request) the whitelist matches
+     * against REMOTE_ADDR.
+     *
+     * @group throttle_whitelist
+     * @test
+     */
+    public function falls_back_to_remote_addr_without_xff()
+    {
+        config(['app.ip_trusted_no_rate_limit' => self::TRUSTED_IP_1]);
+
+        $response = $this->call('GET', self::TEST_ROUTE, [], [], [], [
+            'REMOTE_ADDR' => self::TRUSTED_IP_1,
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertFalse(
+            $response->headers->has('X-RateLimit-Limit'),
+            'Without X-Forwarded-For the whitelist should match REMOTE_ADDR'
         );
     }
 }


### PR DESCRIPTION
## Release to prod (master)

Releases **Task-89367 — Add whitelist logic for live.bible.is IPs in Public API** to `master`/prod, together with its follow-up fix **Task-92918** (IP-whitelist resolution behind the AWS ALB).

This release branch was built off `master` and contains **only** these two changes — no other `develop` work is included.

### Cherry-picked commits (in order)
| PR | Commit | Description |
|----|--------|-------------|
| #1072 | `3ff41f9` | Task-89367 IP Whitelist to Bypass API Rate Limiting (adds `ThrottleRequestsWithWhitelist` middleware, config, env, tests) |
| #1087 | `959bd59` | Task-92918 Fix the rate-limit whitelist so live.bible.is proxies bypass throttling behind the AWS ALB |

### Files changed
- `app/Http/Middleware/ThrottleRequestsWithWhitelist.php` (new)
- `app/Http/Kernel.php` (`throttle` alias → whitelist middleware)
- `config/app.php` (`ip_trusted_no_rate_limit`)
- `.env.example` (`IP_TRUSTED_NO_RATE_LIMIT`)
- `tests/Feature/ThrottleWhitelistTest.php` (new)

### ⚠️ Deploy note
This adds a new env var **`IP_TRUSTED_NO_RATE_LIMIT`**. The prod environment must set it to the trusted proxy IP(s) (e.g. live.bible.is) for the whitelist to take effect; if unset it defaults to empty (rate limiting applies to everyone, i.e. current behavior).
