### PR TITLE
Task-93767 Public API: Bug - One-chapter books not returning individual section segments

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -44,6 +44,10 @@ class BibleFileSetsController extends APIController
      *     @OA\Parameter(name="type", in="query", description="The fileset type", required=true,
      *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/set_type_code")
      *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -69,14 +73,15 @@ class BibleFileSetsController extends APIController
         $book_id = checkParam('book_id');
         $chapter_id = checkParam('chapter_id|chapter');
         $type = checkParam('type', $set_type_code !== null, $set_type_code);
+        $expand_sections = checkBoolean('expand_sections', false);
 
-        $cache_params = [$this->v, $fileset_id, $book_id, $type, $chapter_id];
+        $cache_params = [$this->v, $fileset_id, $book_id, $type, $chapter_id, $expand_sections];
 
         $fileset_chapters = cacheRemember(
             $cache_key,
             $cache_params,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $type, $chapter_id) {
+            function () use ($fileset_id, $book_id, $type, $chapter_id, $expand_sections) {
                 $normalized_book_id = optional(Book::findBookByAnyIdentifier($book_id))->id;
                 $fileset = BibleFileset::with('bible')
                     ->uniqueFileset($fileset_id, $type)
@@ -96,7 +101,8 @@ class BibleFileSetsController extends APIController
                     $fileset,
                     $normalized_book_id,
                     $chapter_id,
-                    null
+                    null,
+                    $expand_sections
                 );
             }
         );
@@ -126,6 +132,10 @@ class BibleFileSetsController extends APIController
      *     ),
      *     @OA\Parameter(name="verse_end", in="query", description="Will filter the results by the given ending verse",
      *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/verse_end")
+     *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -160,6 +170,7 @@ class BibleFileSetsController extends APIController
         $verse_start  = checkParam('verse_start') ?? 1;
         $verse_end    = checkParam('verse_end');
         $type         = checkParam('type') ?? '';
+        $expand_sections = checkBoolean('expand_sections', false);
         $chapter_id   = getAndCheckParam('chapter_id|chapter', true, $chapter_url_param);
 
         $validator = Validator::make([
@@ -188,7 +199,8 @@ class BibleFileSetsController extends APIController
             $chapter_id,
             $verse_start,
             $verse_end,
-            $type
+            $type,
+            $expand_sections
         ];
 
         $cache_safe_key = generateCacheSafeKey($cache_key, $cache_params);
@@ -196,7 +208,7 @@ class BibleFileSetsController extends APIController
         $fileset_chapters = cacheRememberByKey(
             $cache_safe_key,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $chapter_id, $verse_start, $verse_end, $type) {
+            function () use ($fileset_id, $book_id, $chapter_id, $verse_start, $verse_end, $type, $expand_sections) {
                 $normalized_book_id = optional(Book::findBookByAnyIdentifier($book_id))->id;
                 $fileset_from_id = BibleFileset::prioritizeTextPlainType($fileset_id)->first();
                 if (!$fileset_from_id) {
@@ -240,7 +252,8 @@ class BibleFileSetsController extends APIController
                         $fileset,
                         $normalized_book_id,
                         $chapter_id,
-                        null
+                        null,
+                        $expand_sections
                     );
                 }
             }
@@ -264,6 +277,10 @@ class BibleFileSetsController extends APIController
      *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
      *     ),
      *     @OA\Parameter(name="limit", in="query", description="limit for the pagination of the query"
+     *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -294,20 +311,21 @@ class BibleFileSetsController extends APIController
         $book_url_param = null,
         $cache_key = 'bible_filesets_show_bulk'
     ) {
-        $fileset_id   = checkParam('dam_id|fileset_id', true, $fileset_url_param);
-        $book_id      = checkParam('book_id', false, $book_url_param);
-        $type         = checkParam('type') ?? '';
-        $cache_params = [$this->v, $fileset_id, $book_id, $type];
-        $limit        = (int) (checkParam('limit') ?? 5000);
-        $limit        = max($limit, 5000);
-        $page         = checkParam('page') ?? 1;
-        $cache_key    = $cache_key . $page;
+        $fileset_id      = checkParam('dam_id|fileset_id', true, $fileset_url_param);
+        $book_id         = checkParam('book_id', false, $book_url_param);
+        $type            = checkParam('type') ?? '';
+        $expand_sections = checkBoolean('expand_sections', false);
+        $cache_params    = [$this->v, $fileset_id, $book_id, $type, $expand_sections];
+        $limit           = (int) (checkParam('limit') ?? 5000);
+        $limit           = max($limit, 5000);
+        $page            = checkParam('page') ?? 1;
+        $cache_key       = $cache_key . $page;
 
         $fileset_chapters = cacheRemember(
             $cache_key,
             $cache_params,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $limit, $type) {
+            function () use ($fileset_id, $book_id, $limit, $type, $expand_sections) {
                 $fileset_from_id = BibleFileset::prioritizeTextPlainType($fileset_id)->first();
                 if (!$fileset_from_id) {
                     return $this->setStatusCode(HttpResponse::HTTP_NOT_FOUND)->replyWithError(
@@ -349,7 +367,8 @@ class BibleFileSetsController extends APIController
                         $fileset,
                         $normalized_book_id,
                         null,
-                        $limit
+                        $limit,
+                        $expand_sections
                     );
                 }
             }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -60,6 +60,9 @@ class BibleFileset extends Model
         self::TYPE_AUDIO_DRAMA_STREAM,
     ];
 
+    public const SEGMENTATION_TYPE_SECTION = 'section';
+    public const SEGMENTATION_TYPE_CHAPTER = 'chapter';
+
     public const NEW_TEXT_PLAIN_FILESET_LENGTH = 10;
     public const OLD_TEXT_PLAIN_FILESET_LENGTH = 6;
     public const V1_AUDIO_16_KBPS_FILESET_LENGTH = 12;

--- a/app/Services/Bibles/FilesetVerseStartsResolver.php
+++ b/app/Services/Bibles/FilesetVerseStartsResolver.php
@@ -3,12 +3,11 @@
 namespace App\Services\Bibles;
 
 use App\Models\Bible\BibleFile;
+use App\Models\Bible\BibleFileset;
 use Illuminate\Support\Collection;
 
 class FilesetVerseStartsResolver
 {
-    private const SEGMENTATION_TYPE_SECTION = 'section';
-
     /**
      * Filter the in-memory fileset collection down to those that should
      * carry verse_starts: section-segmented audio filesets.
@@ -19,7 +18,7 @@ class FilesetVerseStartsResolver
     public function qualifyingFilesets(Collection $filesets) : Collection
     {
         return $filesets->filter(function ($fileset) {
-            return ($fileset->segmentation_type ?? null) === self::SEGMENTATION_TYPE_SECTION
+            return ($fileset->segmentation_type ?? null) === BibleFileset::SEGMENTATION_TYPE_SECTION
                 && $fileset->isAudio();
         })->values();
     }

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -5,6 +5,7 @@ namespace App\Traits;
 use Illuminate\Database\Eloquent\Collection;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Aws\CloudFront\CloudFrontClient;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileSecondary;
@@ -69,6 +70,7 @@ trait BibleFileSetsTrait
      */
     private function executeQuery($query, $limit)
     {
+        $fileset_chapters_paginated = null;
         if ($limit !== null) {
             $fileset_chapters_paginated = $query->paginate($limit);
             $filesets_pagination = new IlluminatePaginatorAdapter($fileset_chapters_paginated);
@@ -88,7 +90,8 @@ trait BibleFileSetsTrait
 
         return [
             'fileset_chapters' => $fileset_chapters,
-            'filesets_pagination' => $filesets_pagination
+            'filesets_pagination' => $filesets_pagination,
+            'paginator' => $fileset_chapters_paginated,
         ];
     }
 
@@ -123,7 +126,8 @@ trait BibleFileSetsTrait
         ?string $book_id = null,
         $chapter_id = null,
         bool $is_download = false,
-        ?int $limit = null
+        ?int $limit = null,
+        bool $expand_sections = false
     ) {
         $query = $this->buildAudioVideoFilesetQuery($fileset, $book_id, $chapter_id);
 
@@ -139,6 +143,7 @@ trait BibleFileSetsTrait
 
         $fileset_chapters = $queryResult['fileset_chapters'];
         $filesets_pagination = $queryResult['filesets_pagination'];
+        $paginator = $queryResult['paginator'];
         $client = $clientResult['client'];
 
         $bible = optional($fileset->bible)->first();
@@ -162,8 +167,27 @@ trait BibleFileSetsTrait
                 $fileset,
                 $fileset_chapters,
                 $bible->id,
-                $client
+                $client,
+                $expand_sections
             );
+        }
+
+        // Collapsing multiple files into a single .m3u8 playlist shrinks the item
+        // count. Realign the paginator so meta.pagination total/count match the
+        // returned data instead of the pre-collapse row count.
+        if ($paginator !== null) {
+            $processed_count = collect($fileset_chapters_processed)->count();
+            if ($processed_count < $paginator->count()) {
+                $filesets_pagination = new IlluminatePaginatorAdapter(
+                    new LengthAwarePaginator(
+                        $fileset_chapters_processed,
+                        $processed_count,
+                        $paginator->perPage(),
+                        $paginator->currentPage(),
+                        ['path' => $paginator->path()]
+                    )
+                );
+            }
         }
 
         $fileset_return = fractal(
@@ -194,9 +218,17 @@ trait BibleFileSetsTrait
         $fileset,
         ?string $book_id = null,
         $chapter_id = null,
-        $limit = null
+        $limit = null,
+        bool $expand_sections = false
     ) {
-        return $this->processAudioVideoFilesets($fileset, $book_id, $chapter_id, false, $limit);
+        return $this->processAudioVideoFilesets(
+            $fileset,
+            $book_id,
+            $chapter_id,
+            false,
+            $limit,
+            $expand_sections
+        );
     }
 
     private function showTextFilesetChapter(
@@ -365,7 +397,8 @@ trait BibleFileSetsTrait
         $fileset_chapters,
         $bible_id,
         $client,
-        bool $handle_multi_mp3 = false
+        bool $handle_multi_mp3 = false,
+        bool $expand_sections = false
     ) {
         if ($this->isStreamingFileset($fileset)) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
@@ -389,7 +422,11 @@ trait BibleFileSetsTrait
             if ($handle_multi_mp3) {
                 $hasMultiMp3Chapter = $fileset->isAudio() &&
                     sizeof($fileset_chapters) > 1 &&
-                    $this->hasMultipleMp3Chapters($fileset_chapters);
+                    $this->isSingleChapterSplitIntoMultipleFiles(
+                        $fileset,
+                        $fileset_chapters,
+                        $expand_sections
+                    );
 
                 if ($hasMultiMp3Chapter) {
                     if ($fileset_chapters[0]->chapter_start) {
@@ -459,9 +496,17 @@ trait BibleFileSetsTrait
         $fileset,
         $fileset_chapters,
         $bible_id,
-        $client
+        $client,
+        bool $expand_sections = false
     ) {
-        return $this->generateFilesetChaptersBase($fileset, $fileset_chapters, $bible_id, $client, true);
+        return $this->generateFilesetChaptersBase(
+            $fileset,
+            $fileset_chapters,
+            $bible_id,
+            $client,
+            true,
+            $expand_sections
+        );
     }
 
     private function generateFilesetChaptersToDownload(
@@ -556,10 +601,59 @@ trait BibleFileSetsTrait
         return $file_tags_indexed;
     }
 
-    private function hasMultipleMp3Chapters($fileset_chapters)
-    {
+    /**
+     * Determine whether a set of audio files represents a single chapter that was
+     * mechanically split across multiple mp3 files — the only case that should be
+     * collapsed into one .m3u8 playlist item by generateFilesetChaptersBase().
+     *
+     * Section-awareness is opt-in via $expand_sections. When a client opts in, the
+     * method must NOT collapse:
+     *  - Section-segmented filesets, where one-chapter books (e.g. PHM, JUD) have
+     *    several intentional per-section recordings that all share chapter_start = 1.
+     *    These are identified by segmentation_type = 'section'; for legacy filesets
+     *    that pre-date that column (segmentation_type = null) distinct verse_start
+     *    markers are used as a defensive fallback, since a mechanical split shares
+     *    the same verse_start across its files.
+     *
+     * When $expand_sections is false this reduces to the original behavior: collapse
+     * whenever every file shares the same chapter_start, so existing clients keep the
+     * single .m3u8 chapter playlist they rely on.
+     *
+     * @param BibleFileset $fileset
+     * @param iterable     $fileset_chapters
+     * @param bool         $expand_sections Opt-in: keep section-segmented audio as separate items
+     *
+     * @return bool
+     */
+    private function isSingleChapterSplitIntoMultipleFiles(
+        $fileset,
+        $fileset_chapters,
+        bool $expand_sections = false
+    ) {
+        $segmentation_type = $fileset->segmentation_type ?? null;
+
+        // Intentional per-section recordings are never a mechanical chapter split,
+        // but only honor this when the client has opted into section playback.
+        if ($expand_sections &&
+            $segmentation_type === BibleFileset::SEGMENTATION_TYPE_SECTION
+        ) {
+            return false;
+        }
+
+        $first = $fileset_chapters[0];
         foreach ($fileset_chapters as $chapter) {
-            if ($chapter['chapter_start'] !== $fileset_chapters[0]['chapter_start']) {
+            // More than one distinct chapter → not a single split chapter.
+            if ($chapter['chapter_start'] !== $first['chapter_start']) {
+                return false;
+            }
+            // Defensive fallback for filesets predating segmentation_type (null):
+            // distinct verse_start markers mean these are sections, not a
+            // mechanical split (whose files share the same verse_start). Gated
+            // behind the opt-in so non-opting clients keep the original behavior.
+            if ($expand_sections &&
+                $segmentation_type === null &&
+                $chapter['verse_start'] !== $first['verse_start']
+            ) {
                 return false;
             }
         }

--- a/tests/Feature/BibleFileSetsTraitTest.php
+++ b/tests/Feature/BibleFileSetsTraitTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bible\BibleFileset;
+use App\Traits\BibleFileSetsTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit coverage for BibleFileSetsTrait::isSingleChapterSplitIntoMultipleFiles(),
+ * the guard that decides whether a set of audio files is a single chapter
+ * mechanically split across multiple mp3 files (collapse into one .m3u8) or a
+ * set of items that must each stay playable on their own.
+ *
+ * Section-awareness is opt-in via $expand_sections:
+ *  - flag false => original behavior (collapse whenever every file shares
+ *    chapter_start), so existing clients keep the single .m3u8 chapter playlist.
+ *  - flag true  => section-segmented audio (segmentation_type='section', or the
+ *    null-segmentation verse_start fallback) is kept as separate items.
+ *
+ * Regression for the bug where section-segmented one-chapter books (e.g. PHM,
+ * JUD) were collapsed into a single playlist item because every section shares
+ * chapter_start = 1.
+ *
+ * @group bible_filesets
+ */
+class BibleFileSetsTraitTest extends TestCase
+{
+    /**
+     * Invoke the private guard via reflection on an anonymous host that uses the trait.
+     */
+    private function isSingleChapterSplit(
+        $segmentation_type,
+        array $fileset_chapters,
+        bool $expand_sections = false
+    ): bool {
+        $host = new class {
+            use BibleFileSetsTrait;
+        };
+
+        $fileset = new BibleFileset();
+        if ($segmentation_type !== null) {
+            $fileset->forceFill(['segmentation_type' => $segmentation_type]);
+        }
+
+        $method = new ReflectionMethod(
+            $host,
+            'isSingleChapterSplitIntoMultipleFiles'
+        );
+        $method->setAccessible(true);
+
+        return $method->invoke(
+            $host,
+            $fileset,
+            $fileset_chapters,
+            $expand_sections
+        );
+    }
+
+    private function chapters(array ...$rows): array
+    {
+        return array_map(function ($row) {
+            return ['chapter_start' => $row[0], 'verse_start' => $row[1]];
+        }, $rows);
+    }
+
+    /**
+     * Without the opt-in flag the guard must behave exactly like the original:
+     * a one-chapter section book collapses into a single .m3u8 playlist, so
+     * existing clients (e.g. bibleis mobile) are unaffected.
+     *
+     * @test
+     */
+    public function legacy_collapses_section_book_when_flag_off()
+    {
+        $chapters = $this->chapters(
+            [1, '001'],
+            [1, '007'],
+            [1, '017'],
+            [1, '023']
+        );
+
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                false
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function legacy_collapses_null_segmentation_distinct_verses_when_flag_off()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '007'], [1, '017']);
+
+        $this->assertTrue($this->isSingleChapterSplit(null, $chapters, false));
+    }
+
+    /**
+     * @test
+     */
+    public function section_book_is_not_collapsed_when_flag_on()
+    {
+        // PHM-style: one chapter, several intentional sections with distinct verse_starts.
+        $chapters = $this->chapters(
+            [1, '001'],
+            [1, '007'],
+            [1, '017'],
+            [1, '023']
+        );
+
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function section_type_wins_over_matching_verses_when_flag_on()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '001'], [1, '001']);
+
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function null_segmentation_distinct_verses_is_not_collapsed_when_flag_on()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '007'], [1, '017']);
+
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, true));
+    }
+
+    /**
+     * @test
+     */
+    public function null_segmentation_mechanical_split_is_collapsed_when_flag_on()
+    {
+        // Same chapter, same verse_start across files → genuine mechanical split.
+        $chapters = $this->chapters([1, '001'], [1, '001'], [1, '001']);
+
+        $this->assertTrue($this->isSingleChapterSplit(null, $chapters, true));
+    }
+
+    /**
+     * @test
+     */
+    public function chapter_type_with_matching_verses_is_collapsed()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '001']);
+
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_CHAPTER,
+                $chapters,
+                true
+            )
+        );
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_CHAPTER,
+                $chapters,
+                false
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function multi_chapter_book_is_never_collapsed()
+    {
+        // Files span multiple chapters → each chapter stays its own item, both flag values.
+        $chapters = $this->chapters([1, '001'], [2, '001'], [3, '001']);
+
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, true));
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, false));
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+}


### PR DESCRIPTION
# Issue Link
[Bug 93767](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/93767): Public API: Bug - One-chapter books not returning individual section segments

# PR: 'Keep section-segmented audio as separate items (opt-in `expand_sections`)'

## Description

Fix: stop collapsing section-segmented audio into one `.m3u8` (opt-in `expand_sections`). The audio fileset endpoints collapse multiple same-chapter files into a single `.m3u8` playlist. That's correct for a chapter mechanically split across mp3s, but wrong for `segmentation_type='section'` filesets, where a one-chapter book (PHM, JUD, …) is split into intentional sections that all share `chapter_start = 1`. Those sections were being merged into one item.

This PR keeps section-segmented audio as **separate playable items**, gated behind a new opt-in query param `expand_sections` (default `false`).

### Why opt-in

With the flag absent/`false`, responses are **byte-for-byte identical to today**, so existing clients are unaffected. No shipped client sends the flag (verified: neither bibleis mobile nor `dbp-web`), so this is safe to ship with no client coordination. Per-section adoption happens later, per client, after each makes the code changes it needs.

### Changes

- `BibleFileSetsTrait`: replace `hasMultipleMp3Chapters()` with `isSingleChapterSplitIntoMultipleFiles()` — section-aware, opt-in. Thread `expand_sections` through the audio pipeline. Realign the paginator so `meta.pagination.total/count` match the post-collapse item count.
- `BibleFileSetsController`: read `expand_sections` on `show`, `showChapter`, `showBulk`; add it to each `cache_params`; document the OpenAPI param.
- `BibleFileset`: add `SEGMENTATION_TYPE_SECTION` / `SEGMENTATION_TYPE_CHAPTER`.
- `FilesetVerseStartsResolver`: use the shared constant.
- Tests: `tests/Feature/BibleFileSetsTraitTest.php` covers the new guard.

### Behavior

| `expand_sections` | `segmentation_type` | files | Result |
| --- | --- | --- | --- |
| absent / `false` | anything | same chapter_start | Collapse (unchanged) |
| `true` | `section` | one-chapter sections | Keep separate (the fix) |
| `true` | `null` | same chapter, distinct `verse_start` | Keep separate (fallback) |
| `true` | `null` | same chapter, same `verse_start` | Collapse (real split) |
| `true` | `chapter` | same chapter_start | Collapse (real split) |
| any | any | multiple chapters | Keep separate (unchanged) |

### How to test it

```bash
vendor/bin/phpunit --filter BibleFileSetsTraitTest
```

Manual: with `PICCIEP1DA` + `PHM`, default request collapses to one `.m3u8`; `expand_sections=true` returns one item per section.

### Postman tests

Collection variables: `base_url` (e.g. `https://dev.dbt.io`), `key` (API key). Fileset `PICCIEP1DA` (`segmentation_type='section'`), one-chapter book `PHM`.

| # | Request | Expectation |
| --- | --- | --- |
| 1 | `GET {{base_url}}/bibles/filesets/PICCIEP1DA?v=4&key={{key}}&type=audio&book_id=PHM` | **Baseline (no flag):** PHM collapses to a **single** `.m3u8` item. |
| 2 | `GET {{base_url}}/bibles/filesets/PICCIEP1DA?v=4&key={{key}}&type=audio&book_id=PHM&expand_sections=true` | **Opt-in:** **N** items (one per section), each with its own `verse_start`. |
| 3 | `GET {{base_url}}/bibles/filesets/bulk/PICCIEP1DA/PHM?v=4&key={{key}}&type=audio&expand_sections=true` | Bulk endpoint returns per-section items; `meta.pagination.total`/`count` equal the **returned** item count, not the pre-collapse row count. |
| 4 | `GET {{base_url}}/bibles/filesets/PICCIEP1DA/PHM/1?v=4&key={{key}}&type=audio&expand_sections=true` | `showChapter` returns per-section items for chapter 1. |
| 5 | Repeat #1 then #2 back-to-back | Responses **differ** → `expand_sections` is part of the cache key (no cache bleed). |
| 6 | Any multi-chapter book, with and without `expand_sections=true` | Identical: one item per chapter (flag has no effect). |

### Postman folder with the examples related to this change

[DBP4 workspace - section-segmented audio tests](https://digitalbibleplatform.postman.co/workspace/DBP4-workspace~0a283f7f-06d9-467d-97f0-fef92d18bd3d/folder/12519377-ed621b51-4b74-41dc-bf14-d878b22285e6?action=share&creator=17122915&ctx=documentation&active-environment=12519377-2465063f-c35d-430f-839c-7cbb993d3a47)