### PR TITLE
Release #1089 — Task-93767: section-segmented audio (opt-in expand_sections)

### DIFF
--- a/app/Http/Controllers/Bible/BibleFileSetsController.php
+++ b/app/Http/Controllers/Bible/BibleFileSetsController.php
@@ -44,6 +44,10 @@ class BibleFileSetsController extends APIController
      *     @OA\Parameter(name="type", in="query", description="The fileset type", required=true,
      *          @OA\Schema(ref="#/components/schemas/BibleFileset/properties/set_type_code")
      *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="successful operation",
@@ -69,14 +73,15 @@ class BibleFileSetsController extends APIController
         $book_id = checkParam('book_id');
         $chapter_id = checkParam('chapter_id|chapter');
         $type = checkParam('type', $set_type_code !== null, $set_type_code);
+        $expand_sections = checkBoolean('expand_sections', false);
 
-        $cache_params = [$this->v, $fileset_id, $book_id, $type, $chapter_id];
+        $cache_params = [$this->v, $fileset_id, $book_id, $type, $chapter_id, $expand_sections];
 
         $fileset_chapters = cacheRemember(
             $cache_key,
             $cache_params,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $type, $chapter_id) {
+            function () use ($fileset_id, $book_id, $type, $chapter_id, $expand_sections) {
                 $normalized_book_id = optional(Book::findBookByAnyIdentifier($book_id))->id;
                 $fileset = BibleFileset::with('bible')
                     ->uniqueFileset($fileset_id, $type)
@@ -96,7 +101,8 @@ class BibleFileSetsController extends APIController
                     $fileset,
                     $normalized_book_id,
                     $chapter_id,
-                    null
+                    null,
+                    $expand_sections
                 );
             }
         );
@@ -126,6 +132,10 @@ class BibleFileSetsController extends APIController
      *     ),
      *     @OA\Parameter(name="verse_end", in="query", description="Will filter the results by the given ending verse",
      *          @OA\Schema(ref="#/components/schemas/BibleFile/properties/verse_end")
+     *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -160,6 +170,7 @@ class BibleFileSetsController extends APIController
         $verse_start  = checkParam('verse_start') ?? 1;
         $verse_end    = checkParam('verse_end');
         $type         = checkParam('type') ?? '';
+        $expand_sections = checkBoolean('expand_sections', false);
         $chapter_id   = getAndCheckParam('chapter_id|chapter', true, $chapter_url_param);
 
         $validator = Validator::make([
@@ -188,7 +199,8 @@ class BibleFileSetsController extends APIController
             $chapter_id,
             $verse_start,
             $verse_end,
-            $type
+            $type,
+            $expand_sections
         ];
 
         $cache_safe_key = generateCacheSafeKey($cache_key, $cache_params);
@@ -196,7 +208,7 @@ class BibleFileSetsController extends APIController
         $fileset_chapters = cacheRememberByKey(
             $cache_safe_key,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $chapter_id, $verse_start, $verse_end, $type) {
+            function () use ($fileset_id, $book_id, $chapter_id, $verse_start, $verse_end, $type, $expand_sections) {
                 $normalized_book_id = optional(Book::findBookByAnyIdentifier($book_id))->id;
                 $fileset_from_id = BibleFileset::prioritizeTextPlainType($fileset_id)->first();
                 if (!$fileset_from_id) {
@@ -240,7 +252,8 @@ class BibleFileSetsController extends APIController
                         $fileset,
                         $normalized_book_id,
                         $chapter_id,
-                        null
+                        null,
+                        $expand_sections
                     );
                 }
             }
@@ -264,6 +277,10 @@ class BibleFileSetsController extends APIController
      *          @OA\Schema(ref="#/components/schemas/Book/properties/id")
      *     ),
      *     @OA\Parameter(name="limit", in="query", description="limit for the pagination of the query"
+     *     ),
+     *     @OA\Parameter(name="expand_sections", in="query",
+     *          description="Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+     *          @OA\Schema(type="boolean", default=false)
      *     ),
      *     @OA\Response(
      *         response=200,
@@ -294,20 +311,21 @@ class BibleFileSetsController extends APIController
         $book_url_param = null,
         $cache_key = 'bible_filesets_show_bulk'
     ) {
-        $fileset_id   = checkParam('dam_id|fileset_id', true, $fileset_url_param);
-        $book_id      = checkParam('book_id', false, $book_url_param);
-        $type         = checkParam('type') ?? '';
-        $cache_params = [$this->v, $fileset_id, $book_id, $type];
-        $limit        = (int) (checkParam('limit') ?? 5000);
-        $limit        = max($limit, 5000);
-        $page         = checkParam('page') ?? 1;
-        $cache_key    = $cache_key . $page;
+        $fileset_id      = checkParam('dam_id|fileset_id', true, $fileset_url_param);
+        $book_id         = checkParam('book_id', false, $book_url_param);
+        $type            = checkParam('type') ?? '';
+        $expand_sections = checkBoolean('expand_sections', false);
+        $cache_params    = [$this->v, $fileset_id, $book_id, $type, $expand_sections];
+        $limit           = (int) (checkParam('limit') ?? 5000);
+        $limit           = max($limit, 5000);
+        $page            = checkParam('page') ?? 1;
+        $cache_key       = $cache_key . $page;
 
         $fileset_chapters = cacheRemember(
             $cache_key,
             $cache_params,
             now()->addHours(12),
-            function () use ($fileset_id, $book_id, $limit, $type) {
+            function () use ($fileset_id, $book_id, $limit, $type, $expand_sections) {
                 $fileset_from_id = BibleFileset::prioritizeTextPlainType($fileset_id)->first();
                 if (!$fileset_from_id) {
                     return $this->setStatusCode(HttpResponse::HTTP_NOT_FOUND)->replyWithError(
@@ -349,7 +367,8 @@ class BibleFileSetsController extends APIController
                         $fileset,
                         $normalized_book_id,
                         null,
-                        $limit
+                        $limit,
+                        $expand_sections
                     );
                 }
             }

--- a/app/Models/Bible/BibleFileset.php
+++ b/app/Models/Bible/BibleFileset.php
@@ -60,6 +60,9 @@ class BibleFileset extends Model
         self::TYPE_AUDIO_DRAMA_STREAM,
     ];
 
+    public const SEGMENTATION_TYPE_SECTION = 'section';
+    public const SEGMENTATION_TYPE_CHAPTER = 'chapter';
+
     public const NEW_TEXT_PLAIN_FILESET_LENGTH = 10;
     public const OLD_TEXT_PLAIN_FILESET_LENGTH = 6;
     public const V1_AUDIO_16_KBPS_FILESET_LENGTH = 12;

--- a/app/Services/Bibles/FilesetVerseStartsResolver.php
+++ b/app/Services/Bibles/FilesetVerseStartsResolver.php
@@ -3,12 +3,11 @@
 namespace App\Services\Bibles;
 
 use App\Models\Bible\BibleFile;
+use App\Models\Bible\BibleFileset;
 use Illuminate\Support\Collection;
 
 class FilesetVerseStartsResolver
 {
-    private const SEGMENTATION_TYPE_SECTION = 'section';
-
     /**
      * Filter the in-memory fileset collection down to those that should
      * carry verse_starts: section-segmented audio filesets.
@@ -19,7 +18,7 @@ class FilesetVerseStartsResolver
     public function qualifyingFilesets(Collection $filesets) : Collection
     {
         return $filesets->filter(function ($fileset) {
-            return ($fileset->segmentation_type ?? null) === self::SEGMENTATION_TYPE_SECTION
+            return ($fileset->segmentation_type ?? null) === BibleFileset::SEGMENTATION_TYPE_SECTION
                 && $fileset->isAudio();
         })->values();
     }

--- a/app/Traits/BibleFileSetsTrait.php
+++ b/app/Traits/BibleFileSetsTrait.php
@@ -5,6 +5,7 @@ namespace App\Traits;
 use Illuminate\Database\Eloquent\Collection;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 use League\Fractal\Pagination\IlluminatePaginatorAdapter;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Aws\CloudFront\CloudFrontClient;
 use App\Models\Bible\BibleFile;
 use App\Models\Bible\BibleFileSecondary;
@@ -69,6 +70,7 @@ trait BibleFileSetsTrait
      */
     private function executeQuery($query, $limit)
     {
+        $fileset_chapters_paginated = null;
         if ($limit !== null) {
             $fileset_chapters_paginated = $query->paginate($limit);
             $filesets_pagination = new IlluminatePaginatorAdapter($fileset_chapters_paginated);
@@ -88,7 +90,8 @@ trait BibleFileSetsTrait
 
         return [
             'fileset_chapters' => $fileset_chapters,
-            'filesets_pagination' => $filesets_pagination
+            'filesets_pagination' => $filesets_pagination,
+            'paginator' => $fileset_chapters_paginated,
         ];
     }
 
@@ -123,7 +126,8 @@ trait BibleFileSetsTrait
         ?string $book_id = null,
         $chapter_id = null,
         bool $is_download = false,
-        ?int $limit = null
+        ?int $limit = null,
+        bool $expand_sections = false
     ) {
         $query = $this->buildAudioVideoFilesetQuery($fileset, $book_id, $chapter_id);
 
@@ -139,6 +143,7 @@ trait BibleFileSetsTrait
 
         $fileset_chapters = $queryResult['fileset_chapters'];
         $filesets_pagination = $queryResult['filesets_pagination'];
+        $paginator = $queryResult['paginator'];
         $client = $clientResult['client'];
 
         $bible = optional($fileset->bible)->first();
@@ -162,8 +167,27 @@ trait BibleFileSetsTrait
                 $fileset,
                 $fileset_chapters,
                 $bible->id,
-                $client
+                $client,
+                $expand_sections
             );
+        }
+
+        // Collapsing multiple files into a single .m3u8 playlist shrinks the item
+        // count. Realign the paginator so meta.pagination total/count match the
+        // returned data instead of the pre-collapse row count.
+        if ($paginator !== null) {
+            $processed_count = collect($fileset_chapters_processed)->count();
+            if ($processed_count < $paginator->count()) {
+                $filesets_pagination = new IlluminatePaginatorAdapter(
+                    new LengthAwarePaginator(
+                        $fileset_chapters_processed,
+                        $processed_count,
+                        $paginator->perPage(),
+                        $paginator->currentPage(),
+                        ['path' => $paginator->path()]
+                    )
+                );
+            }
         }
 
         $fileset_return = fractal(
@@ -194,9 +218,17 @@ trait BibleFileSetsTrait
         $fileset,
         ?string $book_id = null,
         $chapter_id = null,
-        $limit = null
+        $limit = null,
+        bool $expand_sections = false
     ) {
-        return $this->processAudioVideoFilesets($fileset, $book_id, $chapter_id, false, $limit);
+        return $this->processAudioVideoFilesets(
+            $fileset,
+            $book_id,
+            $chapter_id,
+            false,
+            $limit,
+            $expand_sections
+        );
     }
 
     private function showTextFilesetChapter(
@@ -365,7 +397,8 @@ trait BibleFileSetsTrait
         $fileset_chapters,
         $bible_id,
         $client,
-        bool $handle_multi_mp3 = false
+        bool $handle_multi_mp3 = false,
+        bool $expand_sections = false
     ) {
         if ($this->isStreamingFileset($fileset)) {
             foreach ($fileset_chapters as $key => $fileset_chapter) {
@@ -389,7 +422,11 @@ trait BibleFileSetsTrait
             if ($handle_multi_mp3) {
                 $hasMultiMp3Chapter = $fileset->isAudio() &&
                     sizeof($fileset_chapters) > 1 &&
-                    $this->hasMultipleMp3Chapters($fileset_chapters);
+                    $this->isSingleChapterSplitIntoMultipleFiles(
+                        $fileset,
+                        $fileset_chapters,
+                        $expand_sections
+                    );
 
                 if ($hasMultiMp3Chapter) {
                     if ($fileset_chapters[0]->chapter_start) {
@@ -459,9 +496,17 @@ trait BibleFileSetsTrait
         $fileset,
         $fileset_chapters,
         $bible_id,
-        $client
+        $client,
+        bool $expand_sections = false
     ) {
-        return $this->generateFilesetChaptersBase($fileset, $fileset_chapters, $bible_id, $client, true);
+        return $this->generateFilesetChaptersBase(
+            $fileset,
+            $fileset_chapters,
+            $bible_id,
+            $client,
+            true,
+            $expand_sections
+        );
     }
 
     private function generateFilesetChaptersToDownload(
@@ -556,10 +601,59 @@ trait BibleFileSetsTrait
         return $file_tags_indexed;
     }
 
-    private function hasMultipleMp3Chapters($fileset_chapters)
-    {
+    /**
+     * Determine whether a set of audio files represents a single chapter that was
+     * mechanically split across multiple mp3 files — the only case that should be
+     * collapsed into one .m3u8 playlist item by generateFilesetChaptersBase().
+     *
+     * Section-awareness is opt-in via $expand_sections. When a client opts in, the
+     * method must NOT collapse:
+     *  - Section-segmented filesets, where one-chapter books (e.g. PHM, JUD) have
+     *    several intentional per-section recordings that all share chapter_start = 1.
+     *    These are identified by segmentation_type = 'section'; for legacy filesets
+     *    that pre-date that column (segmentation_type = null) distinct verse_start
+     *    markers are used as a defensive fallback, since a mechanical split shares
+     *    the same verse_start across its files.
+     *
+     * When $expand_sections is false this reduces to the original behavior: collapse
+     * whenever every file shares the same chapter_start, so existing clients keep the
+     * single .m3u8 chapter playlist they rely on.
+     *
+     * @param BibleFileset $fileset
+     * @param iterable     $fileset_chapters
+     * @param bool         $expand_sections Opt-in: keep section-segmented audio as separate items
+     *
+     * @return bool
+     */
+    private function isSingleChapterSplitIntoMultipleFiles(
+        $fileset,
+        $fileset_chapters,
+        bool $expand_sections = false
+    ) {
+        $segmentation_type = $fileset->segmentation_type ?? null;
+
+        // Intentional per-section recordings are never a mechanical chapter split,
+        // but only honor this when the client has opted into section playback.
+        if ($expand_sections &&
+            $segmentation_type === BibleFileset::SEGMENTATION_TYPE_SECTION
+        ) {
+            return false;
+        }
+
+        $first = $fileset_chapters[0];
         foreach ($fileset_chapters as $chapter) {
-            if ($chapter['chapter_start'] !== $fileset_chapters[0]['chapter_start']) {
+            // More than one distinct chapter → not a single split chapter.
+            if ($chapter['chapter_start'] !== $first['chapter_start']) {
+                return false;
+            }
+            // Defensive fallback for filesets predating segmentation_type (null):
+            // distinct verse_start markers mean these are sections, not a
+            // mechanical split (whose files share the same verse_start). Gated
+            // behind the opt-in so non-opting clients keep the original behavior.
+            if ($expand_sections &&
+                $segmentation_type === null &&
+                $chapter['verse_start'] !== $first['verse_start']
+            ) {
                 return false;
             }
         }

--- a/tests/Feature/BibleFileSetsTraitTest.php
+++ b/tests/Feature/BibleFileSetsTraitTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Bible\BibleFileset;
+use App\Traits\BibleFileSetsTrait;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit coverage for BibleFileSetsTrait::isSingleChapterSplitIntoMultipleFiles(),
+ * the guard that decides whether a set of audio files is a single chapter
+ * mechanically split across multiple mp3 files (collapse into one .m3u8) or a
+ * set of items that must each stay playable on their own.
+ *
+ * Section-awareness is opt-in via $expand_sections:
+ *  - flag false => original behavior (collapse whenever every file shares
+ *    chapter_start), so existing clients keep the single .m3u8 chapter playlist.
+ *  - flag true  => section-segmented audio (segmentation_type='section', or the
+ *    null-segmentation verse_start fallback) is kept as separate items.
+ *
+ * Regression for the bug where section-segmented one-chapter books (e.g. PHM,
+ * JUD) were collapsed into a single playlist item because every section shares
+ * chapter_start = 1.
+ *
+ * @group bible_filesets
+ */
+class BibleFileSetsTraitTest extends TestCase
+{
+    /**
+     * Invoke the private guard via reflection on an anonymous host that uses the trait.
+     */
+    private function isSingleChapterSplit(
+        $segmentation_type,
+        array $fileset_chapters,
+        bool $expand_sections = false
+    ): bool {
+        $host = new class {
+            use BibleFileSetsTrait;
+        };
+
+        $fileset = new BibleFileset();
+        if ($segmentation_type !== null) {
+            $fileset->forceFill(['segmentation_type' => $segmentation_type]);
+        }
+
+        $method = new ReflectionMethod(
+            $host,
+            'isSingleChapterSplitIntoMultipleFiles'
+        );
+        $method->setAccessible(true);
+
+        return $method->invoke(
+            $host,
+            $fileset,
+            $fileset_chapters,
+            $expand_sections
+        );
+    }
+
+    private function chapters(array ...$rows): array
+    {
+        return array_map(function ($row) {
+            return ['chapter_start' => $row[0], 'verse_start' => $row[1]];
+        }, $rows);
+    }
+
+    /**
+     * Without the opt-in flag the guard must behave exactly like the original:
+     * a one-chapter section book collapses into a single .m3u8 playlist, so
+     * existing clients (e.g. bibleis mobile) are unaffected.
+     *
+     * @test
+     */
+    public function legacy_collapses_section_book_when_flag_off()
+    {
+        $chapters = $this->chapters(
+            [1, '001'],
+            [1, '007'],
+            [1, '017'],
+            [1, '023']
+        );
+
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                false
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function legacy_collapses_null_segmentation_distinct_verses_when_flag_off()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '007'], [1, '017']);
+
+        $this->assertTrue($this->isSingleChapterSplit(null, $chapters, false));
+    }
+
+    /**
+     * @test
+     */
+    public function section_book_is_not_collapsed_when_flag_on()
+    {
+        // PHM-style: one chapter, several intentional sections with distinct verse_starts.
+        $chapters = $this->chapters(
+            [1, '001'],
+            [1, '007'],
+            [1, '017'],
+            [1, '023']
+        );
+
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function section_type_wins_over_matching_verses_when_flag_on()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '001'], [1, '001']);
+
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function null_segmentation_distinct_verses_is_not_collapsed_when_flag_on()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '007'], [1, '017']);
+
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, true));
+    }
+
+    /**
+     * @test
+     */
+    public function null_segmentation_mechanical_split_is_collapsed_when_flag_on()
+    {
+        // Same chapter, same verse_start across files → genuine mechanical split.
+        $chapters = $this->chapters([1, '001'], [1, '001'], [1, '001']);
+
+        $this->assertTrue($this->isSingleChapterSplit(null, $chapters, true));
+    }
+
+    /**
+     * @test
+     */
+    public function chapter_type_with_matching_verses_is_collapsed()
+    {
+        $chapters = $this->chapters([1, '001'], [1, '001']);
+
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_CHAPTER,
+                $chapters,
+                true
+            )
+        );
+        $this->assertTrue(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_CHAPTER,
+                $chapters,
+                false
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function multi_chapter_book_is_never_collapsed()
+    {
+        // Files span multiple chapters → each chapter stays its own item, both flag values.
+        $chapters = $this->chapters([1, '001'], [2, '001'], [3, '001']);
+
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, true));
+        $this->assertFalse($this->isSingleChapterSplit(null, $chapters, false));
+        $this->assertFalse(
+            $this->isSingleChapterSplit(
+                BibleFileset::SEGMENTATION_TYPE_SECTION,
+                $chapters,
+                true
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Release of #1089 to `master`

Cherry-picks the single commit from #1089 (`470b8ff0`) onto `master` for production release. No other develop changes are included.

### What it does
Task-93767 — One-chapter books were collapsing their section-segmented audio into a single item. This keeps each section as a separate item, exposed via a new **opt-in `expand_sections`** query parameter.

- Backward compatible: default response is unchanged; new behavior only applies when `expand_sections` is passed.

Ref: #1089