### PR TITLE
Task-96056 Public API request - Social provider login attempts without email - please do a fallback account lookup without project_id

### DIFF
--- a/app/Http/Controllers/User/UsersController.php
+++ b/app/Http/Controllers/User/UsersController.php
@@ -182,7 +182,10 @@ class UsersController extends APIController
      *     )),
      *     @OA\Response(
      *         response=200,
-     *         description="User successfully logged in",
+     *         description="User successfully logged in. When a social login was resolved through an
+     *                      account belonging to another project (first login into this project), the
+     *                      response additionally contains `linked_from_project` with the source
+     *                      project id, so clients can tell the user their existing account was linked",
      *         @OA\MediaType(mediaType="application/json", @OA\Schema(ref="#/components/schemas/v4_internal_user_index"))
      *     ),
      *     @OA\Response(
@@ -190,7 +193,26 @@ class UsersController extends APIController
      *         description="Authentication failed. For social providers with autocreate=false,
      *                      this indicates the account doesn't exist and signup is required",
      *         @OA\JsonContent(
-     *             @OA\Property(property="error", type="string", example="No account found for this Facebook account. Please sign up first.")
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="message", type="string", example="No account found for this Facebook account. Please sign up first."),
+     *                 @OA\Property(property="status_code", type="integer", example=401),
+     *                 @OA\Property(property="action", type="string", example="")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="The given project_id does not exist",
+     *         @OA\JsonContent(
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="message", type="string", example="Project Not found"),
+     *                 @OA\Property(property="status_code", type="integer", example=404),
+     *                 @OA\Property(property="action", type="string", example="")
+     *             )
      *         )
      *     )
      * )
@@ -208,6 +230,14 @@ class UsersController extends APIController
         $email = checkParam('email');
         $social_provider_id = checkParam('social_provider_id');
         $project_id = checkParam('project_id');
+
+        // Fail fast on an unknown project_id: without this, login proceeds and the
+        // user_accounts/project_members inserts below die on the projects FK with a 500.
+        if ($project_id && !Project::where('id', $project_id)->exists()) {
+            return $this->setStatusCode(404)->replyWithError(
+                trans('api.projects_404')
+            );
+        }
 
         if ($social_provider_id) {
             $social_provider_user_id = checkParam('social_provider_user_id');
@@ -359,10 +389,40 @@ class UsersController extends APIController
             'autocreate',
         ]);
 
+        // Cross-project fallback: this social account may already be linked to a user under
+        // another project (e.g. an existing Bible.is user logging into another client app for
+        // the first time with a provider that returns no email, like Apple or Facebook).
+        // Oldest account wins. NOTE: although the create migration declares an id column,
+        // the deployed user_accounts table has none — its primary key is the composite
+        // (user_id, provider_id, project_id), matching Account::setKeysForSaveQuery() —
+        // so order by created_at with user_id as tiebreak (ORDER BY id would error).
+        // whereHas('user') skips accounts whose user was soft deleted.
+        $user = null;
+        $linked_from_project = null;
+        $cross_project_account = Account::where('provider_id', $provider_id)
+            ->where('provider_user_id', $provider_user_id)
+            ->whereHas('user')
+            ->orderBy('created_at')
+            ->orderBy('user_id')
+            ->first();
+        if ($cross_project_account) {
+            $user = User::with('accounts', 'profile')
+                ->whereId($cross_project_account->user_id)
+                ->first();
+            if ($user) {
+                $linked_from_project = (int) $cross_project_account->project_id;
+                $cross_project_log = 'social provider login matched an account from another project.' .
+                                     ' request:' . json_encode($safe_log_fields) .
+                                     ', matched_project_id: ' . $cross_project_account->project_id .
+                                     ', user_id: ' . $user->id;
+                Log::info($cross_project_log);
+            }
+        }
+
         // Before erroring when autocreate=false, check if a user with this email exists
-        $user = $request->email
-            ? User::with('accounts', 'profile')->where('email', $request->email)->first()
-            : null;
+        if (!$user && $request->email) {
+            $user = User::with('accounts', 'profile')->where('email', $request->email)->first();
+        }
 
         // Return null (401) only when autocreate is false AND no user exists for this email
         if ($autocreate === false && !$user) {
@@ -422,7 +482,15 @@ class UsersController extends APIController
             Log::error($provider_error_message);
         }
 
-        return User::with('accounts', 'profile')->whereId($user->id)->first();
+        $logged_in_user = User::with('accounts', 'profile')->whereId($user->id)->first();
+        // Surface the cross-project link to the client (one-time event: the account row
+        // created above means the next login resolves through the project-scoped lookup),
+        // so apps can show a "we connected your existing account" notice.
+        if ($linked_from_project !== null) {
+            $logged_in_user->linked_from_project = $linked_from_project;
+        }
+
+        return $logged_in_user;
     }
 
     /**

--- a/database/migrations/2026_07_15_000000_add_provider_index_to_user_accounts.php
+++ b/database/migrations/2026_07_15_000000_add_provider_index_to_user_accounts.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProviderIndexToUserAccounts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * The social login lookups (UsersController::loginWithSocialProvider and
+     * AccountValidator) filter user_accounts by provider_user_id + provider_id,
+     * but the table only has indexes leading with user_id or project_id, so
+     * every lookup was a full table scan.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Deploys apply this index with plain SQL; skip when it already exists so
+        // running migrations stays safe in environments prepared either way.
+        $schema = Schema::connection('dbp_users');
+        if (
+            $schema->hasIndex(
+                'user_accounts',
+                'user_accounts_provider_user_id_provider_id_index'
+            )
+        ) {
+            return;
+        }
+        $schema->table('user_accounts', function (Blueprint $table) {
+            $table->index(
+                ['provider_user_id', 'provider_id'],
+                'user_accounts_provider_user_id_provider_id_index'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $schema = Schema::connection('dbp_users');
+        if (
+            !$schema->hasIndex(
+                'user_accounts',
+                'user_accounts_provider_user_id_provider_id_index'
+            )
+        ) {
+            return;
+        }
+        $schema->table('user_accounts', function (Blueprint $table) {
+            $table->dropIndex(
+                'user_accounts_provider_user_id_provider_id_index'
+            );
+        });
+    }
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -163,6 +163,15 @@
                         }
                     },
                     {
+                        "name": "expand_sections",
+                        "in": "query",
+                        "description": "Opt-in (default false). When true, section-segmented audio filesets (segmentation_type='section') return one playable item per section instead of a collapsed .m3u8 chapter playlist.",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "$ref": "#/components/parameters/version_number"
                     }
                 ],

--- a/tests/Integration/SocialLoginTest.php
+++ b/tests/Integration/SocialLoginTest.php
@@ -1,0 +1,331 @@
+<?php
+
+namespace Tests\Integration;
+
+use App\Models\User\Account;
+use App\Models\User\APIToken;
+use App\Models\User\Profile;
+use App\Models\User\Project;
+use App\Models\User\ProjectMember;
+use App\Models\User\Role;
+use App\Models\User\User;
+use Illuminate\Support\Str;
+
+/**
+ * Coverage for the cross-project social login fallback in
+ * UsersController::loginWithSocialProvider().
+ *
+ * The dbp_users database is shared by multiple client apps, each with its own
+ * project_id. When a social provider sends no email (Facebook accounts without
+ * email, Apple ID on any sign-in after the first), an existing user from another
+ * project must still be found by their (provider_id, provider_user_id) pair and
+ * linked to the new project, instead of being duplicated (autocreate=true) or
+ * rejected with a 401 (autocreate=false).
+ */
+class SocialLoginTest extends ApiV4Test
+{
+    private $user;
+    private $origin_project_id;
+    private $new_project_id;
+    private $provider_user_id;
+    private $cleanup_user_ids;
+    private $created_user_role;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // projects.id is smallint unsigned and not auto-increment — pick free ids in the high range.
+        do {
+            $this->origin_project_id = random_int(60000, 65000);
+        } while (
+            Project::withTrashed()
+                ->where('id', $this->origin_project_id)
+                ->exists()
+        );
+        Project::create([
+            'id' => $this->origin_project_id,
+            'name' => 'Social login test origin project',
+        ]);
+        do {
+            $this->new_project_id = random_int(60000, 65000);
+        } while (
+            $this->new_project_id === $this->origin_project_id ||
+            Project::withTrashed()
+                ->where('id', $this->new_project_id)
+                ->exists()
+        );
+        Project::create([
+            'id' => $this->new_project_id,
+            'name' => 'Social login test new project',
+        ]);
+
+        // login() resolves Role slug 'user' when linking a ProjectMember.
+        $role = Role::where('slug', 'user')->first();
+        $this->created_user_role = !$role;
+        if (!$role) {
+            Role::create([
+                'slug' => 'user',
+                'name' => 'user',
+                'description' => 'User',
+            ]);
+        }
+
+        $this->user = factory(User::class)->create();
+        $this->cleanup_user_ids = [$this->user->id];
+        $this->provider_user_id = 'test-social-' . Str::random(24);
+        Account::create([
+            'user_id' => $this->user->id,
+            'project_id' => $this->origin_project_id,
+            'provider_id' => 'facebook',
+            'provider_user_id' => $this->provider_user_id,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        APIToken::whereIn('user_id', $this->cleanup_user_ids)->delete();
+        // The users FK on user_accounts has no delete cascade — remove accounts first.
+        Account::whereIn('user_id', $this->cleanup_user_ids)->delete();
+        Profile::whereIn('user_id', $this->cleanup_user_ids)->delete();
+        ProjectMember::whereIn('user_id', $this->cleanup_user_ids)->delete();
+        User::withTrashed()
+            ->whereIn('id', $this->cleanup_user_ids)
+            ->forceDelete();
+        // Projects use SoftDeletes — forceDelete fires the FK cascade on any leftover rows.
+        Project::withTrashed()
+            ->whereIn('id', [$this->origin_project_id, $this->new_project_id])
+            ->forceDelete();
+        if ($this->created_user_role) {
+            Role::where('slug', 'user')->delete();
+        }
+        parent::tearDown();
+    }
+
+    private function socialLogin(array $body)
+    {
+        $path = route('v4_internal_user.login', $this->params);
+        echo "\nTesting: $path";
+        return $this->withHeaders($this->params)->post($path, $body);
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function crossProjectSocialLoginWithoutEmailSucceeds()
+    {
+        $response = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $response->assertSuccessful();
+        $this->assertEquals($this->user->id, $response->json('id'));
+        $this->assertEquals(
+            $this->origin_project_id,
+            $response->json('linked_from_project')
+        );
+        $this->assertDatabaseHas(
+            'user_accounts',
+            [
+                'user_id' => $this->user->id,
+                'project_id' => $this->new_project_id,
+                'provider_id' => 'facebook',
+                'provider_user_id' => $this->provider_user_id,
+            ],
+            'dbp_users'
+        );
+        $this->assertDatabaseHas(
+            'project_members',
+            [
+                'user_id' => $this->user->id,
+                'project_id' => $this->new_project_id,
+            ],
+            'dbp_users'
+        );
+
+        // The link is a one-time event: the account row created above resolves the next
+        // login through the project-scoped lookup, so the flag must no longer appear.
+        $second_login = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $second_login->assertSuccessful();
+        $this->assertEquals($this->user->id, $second_login->json('id'));
+        $this->assertNull($second_login->json('linked_from_project'));
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function sameProjectSocialLoginUnaffected()
+    {
+        $response = $this->socialLogin([
+            'project_id' => $this->origin_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $response->assertSuccessful();
+        $this->assertEquals($this->user->id, $response->json('id'));
+        $this->assertNull($response->json('linked_from_project'));
+        // The project-scoped lookup matched — no additional account row was linked.
+        $this->assertEquals(
+            1,
+            Account::where('provider_user_id', $this->provider_user_id)->count()
+        );
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function autocreateFalseSucceedsWithCrossProjectAccount()
+    {
+        $response = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+            'autocreate' => 'false',
+        ]);
+        $response->assertSuccessful();
+        $this->assertEquals($this->user->id, $response->json('id'));
+        $this->assertEquals(
+            $this->origin_project_id,
+            $response->json('linked_from_project')
+        );
+        $this->assertDatabaseHas(
+            'user_accounts',
+            [
+                'user_id' => $this->user->id,
+                'project_id' => $this->new_project_id,
+                'provider_id' => 'facebook',
+                'provider_user_id' => $this->provider_user_id,
+            ],
+            'dbp_users'
+        );
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function autocreateFalseStillReturns401WhenNoAccountAnywhere()
+    {
+        $response = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => 'test-social-' . Str::random(24),
+            'autocreate' => 'false',
+        ]);
+        $response->assertStatus(401);
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function softDeletedUserFallsThroughToAutocreate()
+    {
+        // Re-fetch before soft deleting — the legacy factory instance lacks the
+        // deleted_at attribute and errors inside SoftDeletes::runSoftDelete().
+        $this->user->fresh()->delete();
+
+        $response = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $response->assertSuccessful();
+        $new_user_id = $response->json('id');
+        $this->assertNotNull($new_user_id);
+        // The soft-deleted user's account is skipped; a new user is created instead of a 401.
+        $this->assertNotEquals($this->user->id, $new_user_id);
+        $this->cleanup_user_ids[] = $new_user_id;
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function oldestAccountWinsAcrossProjects()
+    {
+        // user_accounts has no unique constraint — the same social identity can point at
+        // different users. The fallback must deterministically pick the oldest account.
+        $second_user = factory(User::class)->create();
+        $this->cleanup_user_ids[] = $second_user->id;
+        Account::create([
+            'user_id' => $second_user->id,
+            'project_id' => $this->origin_project_id,
+            'provider_id' => 'facebook',
+            'provider_user_id' => $this->provider_user_id,
+        ]);
+
+        $response = $this->socialLogin([
+            'project_id' => $this->new_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $response->assertSuccessful();
+        $this->assertEquals($this->user->id, $response->json('id'));
+    }
+
+    /**
+     * @category V4_API
+     * @category Route Name: v4_internal_user.login
+     * @see      \App\Http\Controllers\User\UsersController::login
+     * @group    V4
+     * @group    travis
+     * @test
+     */
+    public function nonexistentProjectIdReturns404InsteadOf500()
+    {
+        // Before the early project check, an unknown project_id survived until the
+        // user_accounts insert and died on the projects FK with a 500.
+        do {
+            $missing_project_id = random_int(60000, 65000);
+        } while (
+            Project::withTrashed()
+                ->where('id', $missing_project_id)
+                ->exists()
+        );
+
+        $response = $this->socialLogin([
+            'project_id' => $missing_project_id,
+            'social_provider_id' => 'facebook',
+            'social_provider_user_id' => $this->provider_user_id,
+        ]);
+        $response->assertStatus(404);
+        // Rejected before any side effects: no account row was linked anywhere.
+        $this->assertEquals(
+            1,
+            Account::where('provider_user_id', $this->provider_user_id)->count()
+        );
+    }
+}


### PR DESCRIPTION
# Issue Link
[Product Backlog Item 96056](https://dev.azure.com/FCBH/Bible%20Brain/_workitems/edit/96056): Public API request - Social provider login attempts without email - please do a fallback account lookup without project_id

# Description

Hosanna (project 63452) shares the `dbp_users` database with Bible.is (52341). When an existing Bible.is user signs into Hosanna with a social provider that sends **no email** — Facebook accounts without one, or Apple ID on any sign-in after the first — the project-scoped account lookup misses and there is no email to fall back on. The API then either created a duplicate empty user (`autocreate=true`) or returned 401 with registration blocked by the `unique_social_provider` validator (`autocreate=false`). Either way the user could not reach their existing account and history.

This PR adds a cross-project fallback on the social identity itself, parallel to the email fallback that already covers Scenarios A and B.

## What Changed

| File | Change |
|---|---|
| `app/Http/Controllers/User/UsersController.php` (`loginWithSocialProvider`) | When the project-scoped lookup misses, fall back to `(provider_id, provider_user_id)` across all projects. Oldest account wins (`ORDER BY created_at, user_id` — deterministic; duplicates exist in the table). `whereHas('user')` skips soft-deleted users. The fallback only resolves the user; the method's existing tail creates the Account row for the new project, so the link happens once and the next login resolves project-scoped. |
| Same file (`loginWithSocialProvider` return) | One-time `linked_from_project` response field on the login where the link happens (e.g. `"linked_from_project": 52341`), so the app can tell the user their existing account was connected. Absent on every later login. |
| Same file (`login`) | Validates `project_id` exists up front → clean 404 `"Project Not found"`. Previously an unknown project survived to the `user_accounts` insert and died on the projects FK with a 500, after creating an orphan user (seen in dev, where project 63452 was missing). |
| `database/migrations/2026_07_15_000000_add_provider_index_to_user_accounts.php` | New index `(provider_user_id, provider_id)` on `user_accounts`. Both the fallback and the pre-existing lookups were scanning the table (~384k rows) on every social login; with the index they read ~2 rows. Also covers `AccountValidator`. The migration is a local convenience — on deploy the index is applied with plain SQL (see QA section). |
| `tests/Integration/SocialLoginTest.php` | New — 7 tests / 24 assertions: cross-project link without email (+ one-time flag), same-project unaffected, `autocreate=false` with and without a cross-project match, soft-deleted fall-through, oldest-account tie-break, unknown project 404. Creates its own projects/users/accounts and cleans up after itself. |

## How Do I QA This

### 1. Automated

```bash
docker exec -e APP_CONFIG_CACHE=/tmp/no-config-cache.php \
  -e DBP_DATABASE=<local dbp db> -e DBP_USERNAME=root -e DBP_PASSWORD= dbp-php-1 \
  sh -c 'cd /opt/app && vendor/bin/phpunit --do-not-cache-result \
    --filter "/^(?!.*(versionsReturnSuccessful|bucketsReturnSuccessful|statsReturnSuccessful)).*$/" \
    tests/Integration/SocialLoginTest.php'
```

Expect: `OK (7 tests, 24 assertions)`. (Without the filter you also get 3 pre-existing errors inherited from `ApiV4Test` — dead base-class tests for removed routes, unrelated to this PR.)

### 2. Manual curl

Precondition: a user with a `user_accounts` row under project 52341 for `facebook` + some `provider_user_id`, and **no** row under 63452.

```bash
# First Hosanna login — cross-project link happens
curl "$APP_URL/api/login?v=4&key=$KEY" -H 'Content-Type: application/json' \
  -d '{"social_provider_id":"facebook","social_provider_user_id":"<ID>","project_id":"63452"}'
# → 200, "id" = the EXISTING Bible.is user, "linked_from_project": 52341
#   New user_accounts row (user, 63452, facebook) and project_members row created.

# Second login — resolves project-scoped, no flag
# (same curl) → 200, same "id", no "linked_from_project"

# Unknown project — clean error instead of FK 500
# (same curl with "project_id":"59999") → 404 {"error":{"message":"Project Not found"...}}
```

### 3. Database change (index - Optional)

Database changes should be applied directly with SQL. Run this against the `dbp_users` database:

```sql
ALTER TABLE user_accounts
  ADD INDEX user_accounts_provider_user_id_provider_id_index (provider_user_id, provider_id);
```

Rollback, if ever needed:

```sql
ALTER TABLE user_accounts
  DROP INDEX user_accounts_provider_user_id_provider_id_index;
```

Optional (local environments only): `php artisan migrate` runs the included migration, which creates the same index with the same name. Apply one or the other, not both — the second attempt fails with a duplicate key name.